### PR TITLE
追加 schema スナップショット管理コマンド

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help setup setup-check dev build up down logs clean test
 .PHONY: ts-dev ts-build ts-lint ts-test rust-dev rust-build rust-test rust-fmt rust-clippy rust-lint rust-ci py-dev py-test elixir-dev elixir-build
-.PHONY: db-up db-down db-reset db-migrate db-migrate-revert db-migrate-info worktree-sync-env
+.PHONY: db-up db-down db-reset db-migrate db-migrate-revert db-migrate-info db-schema db-schema-check worktree-sync-env
 
 # 色設定
 GREEN  := \033[0;32m
@@ -11,6 +11,8 @@ NC     := \033[0m
 
 DATABASE_URL ?= postgres://postgres:password@localhost:5432/linklynx
 SQLX_MIGRATIONS_DIR ?= ../database/postgres/migrations
+SCHEMA_SNAPSHOT_PATH ?= database/postgres/schema.sql
+POSTGRES_DUMP_CMD ?= docker compose exec -T postgres pg_dump -U postgres -d linklynx --schema-only --no-owner --no-privileges --exclude-table=_sqlx_migrations
 
 help: ## ヘルプを表示
 	@echo "$(BLUE)LinkLynx-AI$(NC) - Discord Clone 開発コマンド"
@@ -164,6 +166,51 @@ db-migrate-revert: ## sqlx migration を1件ロールバック
 
 db-migrate-info: ## sqlx migration の適用状態を表示
 	cd rust && DATABASE_URL=$(DATABASE_URL) sqlx migrate info --source $(SQLX_MIGRATIONS_DIR)
+
+db-schema: ## 現在のDBから schema.sql スナップショットを生成
+	@mkdir -p "$(dir $(SCHEMA_SNAPSHOT_PATH))"
+	@raw_file="$$(mktemp)"; \
+	tmp_file="$$(mktemp)"; \
+	if ! $(POSTGRES_DUMP_CMD) > "$$raw_file"; then \
+		rm -f "$$raw_file" "$$tmp_file"; \
+		echo "$(RED)pg_dump の実行に失敗しました$(NC)"; \
+		exit 1; \
+	fi; \
+	sed -e '/^--/d' -e '/^[\\]restrict /d' -e '/^[\\]unrestrict /d' "$$raw_file" > "$$tmp_file"; \
+	if [ ! -s "$$tmp_file" ]; then \
+		rm -f "$$raw_file" "$$tmp_file"; \
+		echo "$(RED)schema.sql の生成結果が空です。DB接続を確認してください$(NC)"; \
+		exit 1; \
+	fi; \
+	mv "$$tmp_file" "$(SCHEMA_SNAPSHOT_PATH)"; \
+	rm -f "$$raw_file"; \
+	echo "$(GREEN)$(SCHEMA_SNAPSHOT_PATH) を更新しました$(NC)"
+
+db-schema-check: ## schema.sql と現在DBスキーマの差分を検証
+	@if [ ! -f "$(SCHEMA_SNAPSHOT_PATH)" ]; then \
+		echo "$(RED)$(SCHEMA_SNAPSHOT_PATH) がありません。make db-schema を実行してください$(NC)"; \
+		exit 1; \
+	fi
+	@raw_file="$$(mktemp)"; \
+	tmp_file="$$(mktemp)"; \
+	if ! $(POSTGRES_DUMP_CMD) > "$$raw_file"; then \
+		rm -f "$$raw_file" "$$tmp_file"; \
+		echo "$(RED)pg_dump の実行に失敗しました$(NC)"; \
+		exit 1; \
+	fi; \
+	sed -e '/^--/d' -e '/^[\\]restrict /d' -e '/^[\\]unrestrict /d' "$$raw_file" > "$$tmp_file"; \
+	if [ ! -s "$$tmp_file" ]; then \
+		rm -f "$$raw_file" "$$tmp_file"; \
+		echo "$(RED)schema比較用の生成結果が空です。DB接続を確認してください$(NC)"; \
+		exit 1; \
+	fi; \
+	if ! diff -u "$(SCHEMA_SNAPSHOT_PATH)" "$$tmp_file"; then \
+		echo "$(RED)schema.sql が最新ではありません。make db-schema を実行してください$(NC)"; \
+		rm -f "$$raw_file" "$$tmp_file"; \
+		exit 1; \
+	fi; \
+	rm -f "$$raw_file" "$$tmp_file"; \
+	echo "$(GREEN)schema snapshot は最新です$(NC)"
 
 # ============================================
 # 開発ワークフロー

--- a/README.md
+++ b/README.md
@@ -253,11 +253,14 @@ make db-reset       # DBをリセット（※データ全削除）
 make db-migrate     # sqlx migration適用
 make db-migrate-revert # sqlx migrationを1件ロールバック
 make db-migrate-info   # sqlx migrationの適用状態を確認
+make db-schema      # 現在DBから schema.sql を生成
+make db-schema-check # schema.sql と現在DBの差分を検証
 ```
 
 ## DBスキーマ運用（LIN-135）
 
-PostgreSQLスキーマは `database/postgres/migrations` を正として管理します。
+PostgreSQLスキーマは `database/postgres/migrations` を正として管理します。  
+`database/postgres/schema.sql` は、レビューしやすいスナップショット（派生物）として扱います。
 
 ```bash
 # 事前準備（未インストール時）
@@ -271,6 +274,12 @@ make db-migrate
 
 # 適用状態を確認
 make db-migrate-info
+
+# schema snapshot を更新
+make db-schema
+
+# schema snapshot のドリフト検証
+make db-schema-check
 
 # rollback確認（逆順で1件戻す）
 make db-migrate-revert

--- a/database/postgres/schema.sql
+++ b/database/postgres/schema.sql
@@ -1,0 +1,574 @@
+
+
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+
+CREATE TYPE public.audit_action AS ENUM (
+    'INVITE_CREATE',
+    'INVITE_DISABLE',
+    'GUILD_MEMBER_JOIN',
+    'GUILD_MEMBER_LEAVE',
+    'ROLE_ASSIGN',
+    'ROLE_REVOKE',
+    'CHANNEL_CREATE',
+    'CHANNEL_UPDATE',
+    'CHANNEL_DELETE',
+    'MESSAGE_DELETE_MOD',
+    'USER_BAN',
+    'USER_UNBAN'
+);
+
+
+
+CREATE TYPE public.channel_type AS ENUM (
+    'guild_text',
+    'dm'
+);
+
+
+
+CREATE TYPE public.outbox_status AS ENUM (
+    'PENDING',
+    'SENT',
+    'FAILED'
+);
+
+
+
+CREATE TYPE public.role_level AS ENUM (
+    'owner',
+    'admin',
+    'member'
+);
+
+
+
+CREATE FUNCTION public.enforce_dm_pairs_channel_type() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM channels c
+    WHERE c.id = NEW.channel_id
+      AND c.type = 'dm'
+  ) THEN
+    RAISE EXCEPTION 'dm_pairs.channel_id must reference channels.type=dm';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+
+
+CREATE FUNCTION public.set_users_updated_at() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+
+CREATE TABLE public.audit_logs (
+    id bigint NOT NULL,
+    guild_id bigint,
+    actor_id bigint,
+    action public.audit_action NOT NULL,
+    target_type text,
+    target_id bigint,
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+CREATE TABLE public.channel_last_message (
+    channel_id bigint NOT NULL,
+    last_message_id bigint NOT NULL,
+    last_message_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+CREATE TABLE public.channel_permission_overrides (
+    channel_id bigint NOT NULL,
+    level public.role_level NOT NULL,
+    can_view boolean,
+    can_post boolean
+);
+
+
+
+COMMENT ON COLUMN public.channel_permission_overrides.can_view IS 'NULL はロール既定値を継承、TRUE/FALSE は明示上書き。';
+
+
+
+COMMENT ON COLUMN public.channel_permission_overrides.can_post IS 'NULL はロール既定値を継承、TRUE/FALSE は明示上書き。';
+
+
+
+CREATE TABLE public.channel_reads (
+    channel_id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    last_read_message_id bigint,
+    last_client_seq bigint,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+CREATE TABLE public.channels (
+    id bigint NOT NULL,
+    type public.channel_type NOT NULL,
+    guild_id bigint,
+    name text,
+    created_by bigint,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT chk_channels_shape_dm CHECK (((type <> 'dm'::public.channel_type) OR (guild_id IS NULL))),
+    CONSTRAINT chk_channels_shape_guild_text CHECK (((type <> 'guild_text'::public.channel_type) OR ((guild_id IS NOT NULL) AND (name IS NOT NULL))))
+);
+
+
+
+CREATE TABLE public.dm_pairs (
+    user_low bigint NOT NULL,
+    user_high bigint NOT NULL,
+    channel_id bigint NOT NULL,
+    CONSTRAINT chk_dm_pairs_order CHECK ((user_low < user_high))
+);
+
+
+
+CREATE TABLE public.dm_participants (
+    channel_id bigint NOT NULL,
+    user_id bigint NOT NULL
+);
+
+
+
+CREATE TABLE public.email_verification_tokens (
+    user_id bigint NOT NULL,
+    token_hash text NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+CREATE TABLE public.guild_member_roles (
+    guild_id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    level public.role_level NOT NULL
+);
+
+
+
+CREATE TABLE public.guild_members (
+    guild_id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    joined_at timestamp with time zone DEFAULT now() NOT NULL,
+    nickname text
+);
+
+
+
+CREATE TABLE public.guild_roles (
+    guild_id bigint NOT NULL,
+    level public.role_level NOT NULL,
+    name text NOT NULL
+);
+
+
+
+CREATE TABLE public.guilds (
+    id bigint NOT NULL,
+    name text NOT NULL,
+    owner_id bigint NOT NULL,
+    icon_key text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+CREATE TABLE public.invite_uses (
+    invite_id bigint NOT NULL,
+    used_by bigint NOT NULL,
+    used_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+CREATE TABLE public.invites (
+    id bigint NOT NULL,
+    guild_id bigint NOT NULL,
+    created_by bigint,
+    code text NOT NULL,
+    expires_at timestamp with time zone,
+    max_uses integer,
+    uses integer DEFAULT 0 NOT NULL,
+    is_disabled boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT chk_invites_max_uses_positive CHECK (((max_uses IS NULL) OR (max_uses > 0))),
+    CONSTRAINT chk_invites_uses_lte_max CHECK (((max_uses IS NULL) OR (uses <= max_uses))),
+    CONSTRAINT chk_invites_uses_non_negative CHECK ((uses >= 0))
+);
+
+
+
+CREATE TABLE public.outbox_events (
+    id bigint NOT NULL,
+    event_type text NOT NULL,
+    aggregate_id text NOT NULL,
+    payload jsonb NOT NULL,
+    status public.outbox_status DEFAULT 'PENDING'::public.outbox_status NOT NULL,
+    attempts integer DEFAULT 0 NOT NULL,
+    next_retry_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT chk_outbox_attempts_non_negative CHECK ((attempts >= 0))
+);
+
+
+
+CREATE TABLE public.password_reset_tokens (
+    user_id bigint NOT NULL,
+    token_hash text NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+
+CREATE TABLE public.users (
+    id bigint NOT NULL,
+    email text NOT NULL,
+    email_verified boolean DEFAULT false NOT NULL,
+    password_hash text NOT NULL,
+    display_name text NOT NULL,
+    avatar_key text,
+    status_text text,
+    theme text DEFAULT 'dark'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT chk_users_password_hash_argon2id CHECK ((password_hash ~~ '$argon2id$%'::text)),
+    CONSTRAINT chk_users_theme CHECK ((theme = ANY (ARRAY['dark'::text, 'light'::text])))
+);
+
+
+
+COMMENT ON COLUMN public.users.password_hash IS 'Argon2id の PHC 文字列（例: $argon2id$v=19$...）を保存する。';
+
+
+
+ALTER TABLE ONLY public.audit_logs
+    ADD CONSTRAINT audit_logs_pkey PRIMARY KEY (id);
+
+
+
+ALTER TABLE ONLY public.channel_last_message
+    ADD CONSTRAINT channel_last_message_pkey PRIMARY KEY (channel_id);
+
+
+
+ALTER TABLE ONLY public.channel_permission_overrides
+    ADD CONSTRAINT channel_permission_overrides_pkey PRIMARY KEY (channel_id, level);
+
+
+
+ALTER TABLE ONLY public.channel_reads
+    ADD CONSTRAINT channel_reads_pkey PRIMARY KEY (channel_id, user_id);
+
+
+
+ALTER TABLE ONLY public.channels
+    ADD CONSTRAINT channels_pkey PRIMARY KEY (id);
+
+
+
+ALTER TABLE ONLY public.dm_pairs
+    ADD CONSTRAINT dm_pairs_pkey PRIMARY KEY (user_low, user_high);
+
+
+
+ALTER TABLE ONLY public.dm_participants
+    ADD CONSTRAINT dm_participants_pkey PRIMARY KEY (channel_id, user_id);
+
+
+
+ALTER TABLE ONLY public.email_verification_tokens
+    ADD CONSTRAINT email_verification_tokens_pkey PRIMARY KEY (user_id);
+
+
+
+ALTER TABLE ONLY public.email_verification_tokens
+    ADD CONSTRAINT email_verification_tokens_token_hash_key UNIQUE (token_hash);
+
+
+
+ALTER TABLE ONLY public.guild_member_roles
+    ADD CONSTRAINT guild_member_roles_pkey PRIMARY KEY (guild_id, user_id);
+
+
+
+ALTER TABLE ONLY public.guild_members
+    ADD CONSTRAINT guild_members_pkey PRIMARY KEY (guild_id, user_id);
+
+
+
+ALTER TABLE ONLY public.guild_roles
+    ADD CONSTRAINT guild_roles_pkey PRIMARY KEY (guild_id, level);
+
+
+
+ALTER TABLE ONLY public.guilds
+    ADD CONSTRAINT guilds_pkey PRIMARY KEY (id);
+
+
+
+ALTER TABLE ONLY public.invite_uses
+    ADD CONSTRAINT invite_uses_pkey PRIMARY KEY (invite_id, used_by);
+
+
+
+ALTER TABLE ONLY public.invites
+    ADD CONSTRAINT invites_code_key UNIQUE (code);
+
+
+
+ALTER TABLE ONLY public.invites
+    ADD CONSTRAINT invites_pkey PRIMARY KEY (id);
+
+
+
+ALTER TABLE ONLY public.outbox_events
+    ADD CONSTRAINT outbox_events_pkey PRIMARY KEY (id);
+
+
+
+ALTER TABLE ONLY public.password_reset_tokens
+    ADD CONSTRAINT password_reset_tokens_pkey PRIMARY KEY (user_id);
+
+
+
+ALTER TABLE ONLY public.password_reset_tokens
+    ADD CONSTRAINT password_reset_tokens_token_hash_key UNIQUE (token_hash);
+
+
+
+ALTER TABLE ONLY public.dm_pairs
+    ADD CONSTRAINT uq_dm_pairs_channel UNIQUE (channel_id);
+
+
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+
+CREATE INDEX idx_audit_guild_time ON public.audit_logs USING btree (guild_id, created_at DESC) WHERE (guild_id IS NOT NULL);
+
+
+
+CREATE INDEX idx_channel_last_message_time ON public.channel_last_message USING btree (last_message_at DESC);
+
+
+
+CREATE INDEX idx_channel_reads_user ON public.channel_reads USING btree (user_id);
+
+
+
+CREATE INDEX idx_channels_guild ON public.channels USING btree (guild_id) WHERE (type = 'guild_text'::public.channel_type);
+
+
+
+CREATE INDEX idx_dm_participants_user ON public.dm_participants USING btree (user_id);
+
+
+
+CREATE INDEX idx_email_verification_expires ON public.email_verification_tokens USING btree (expires_at);
+
+
+
+CREATE INDEX idx_guild_members_user ON public.guild_members USING btree (user_id);
+
+
+
+CREATE INDEX idx_invites_expires ON public.invites USING btree (expires_at) WHERE (expires_at IS NOT NULL);
+
+
+
+CREATE INDEX idx_invites_guild ON public.invites USING btree (guild_id);
+
+
+
+CREATE INDEX idx_outbox_failed ON public.outbox_events USING btree (status, created_at DESC) WHERE (status = 'FAILED'::public.outbox_status);
+
+
+
+CREATE INDEX idx_outbox_pending ON public.outbox_events USING btree (status, next_retry_at, created_at);
+
+
+
+CREATE INDEX idx_password_reset_expires ON public.password_reset_tokens USING btree (expires_at);
+
+
+
+CREATE UNIQUE INDEX uq_users_email_lower ON public.users USING btree (lower(email));
+
+
+
+CREATE TRIGGER trg_enforce_dm_pairs_channel_type BEFORE INSERT OR UPDATE ON public.dm_pairs FOR EACH ROW EXECUTE FUNCTION public.enforce_dm_pairs_channel_type();
+
+
+
+CREATE TRIGGER trg_users_set_updated_at BEFORE UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION public.set_users_updated_at();
+
+
+
+ALTER TABLE ONLY public.audit_logs
+    ADD CONSTRAINT audit_logs_actor_id_fkey FOREIGN KEY (actor_id) REFERENCES public.users(id) ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY public.audit_logs
+    ADD CONSTRAINT audit_logs_guild_id_fkey FOREIGN KEY (guild_id) REFERENCES public.guilds(id) ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY public.channel_last_message
+    ADD CONSTRAINT channel_last_message_channel_id_fkey FOREIGN KEY (channel_id) REFERENCES public.channels(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.channel_permission_overrides
+    ADD CONSTRAINT channel_permission_overrides_channel_id_fkey FOREIGN KEY (channel_id) REFERENCES public.channels(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.channel_reads
+    ADD CONSTRAINT channel_reads_channel_id_fkey FOREIGN KEY (channel_id) REFERENCES public.channels(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.channel_reads
+    ADD CONSTRAINT channel_reads_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.channels
+    ADD CONSTRAINT channels_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY public.channels
+    ADD CONSTRAINT channels_guild_id_fkey FOREIGN KEY (guild_id) REFERENCES public.guilds(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.dm_pairs
+    ADD CONSTRAINT dm_pairs_channel_id_fkey FOREIGN KEY (channel_id) REFERENCES public.channels(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.dm_pairs
+    ADD CONSTRAINT dm_pairs_user_high_fkey FOREIGN KEY (user_high) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.dm_pairs
+    ADD CONSTRAINT dm_pairs_user_low_fkey FOREIGN KEY (user_low) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.dm_participants
+    ADD CONSTRAINT dm_participants_channel_id_fkey FOREIGN KEY (channel_id) REFERENCES public.channels(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.dm_participants
+    ADD CONSTRAINT dm_participants_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.email_verification_tokens
+    ADD CONSTRAINT email_verification_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.guild_member_roles
+    ADD CONSTRAINT guild_member_roles_guild_id_level_fkey FOREIGN KEY (guild_id, level) REFERENCES public.guild_roles(guild_id, level) ON DELETE RESTRICT;
+
+
+
+ALTER TABLE ONLY public.guild_member_roles
+    ADD CONSTRAINT guild_member_roles_guild_id_user_id_fkey FOREIGN KEY (guild_id, user_id) REFERENCES public.guild_members(guild_id, user_id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.guild_members
+    ADD CONSTRAINT guild_members_guild_id_fkey FOREIGN KEY (guild_id) REFERENCES public.guilds(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.guild_members
+    ADD CONSTRAINT guild_members_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.guild_roles
+    ADD CONSTRAINT guild_roles_guild_id_fkey FOREIGN KEY (guild_id) REFERENCES public.guilds(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.guilds
+    ADD CONSTRAINT guilds_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES public.users(id) ON DELETE RESTRICT;
+
+
+
+ALTER TABLE ONLY public.invite_uses
+    ADD CONSTRAINT invite_uses_invite_id_fkey FOREIGN KEY (invite_id) REFERENCES public.invites(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.invite_uses
+    ADD CONSTRAINT invite_uses_used_by_fkey FOREIGN KEY (used_by) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.invites
+    ADD CONSTRAINT invites_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY public.invites
+    ADD CONSTRAINT invites_guild_id_fkey FOREIGN KEY (guild_id) REFERENCES public.guilds(id) ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY public.password_reset_tokens
+    ADD CONSTRAINT password_reset_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+
+


### PR DESCRIPTION
## Summary
- `Makefile` に `db-schema` / `db-schema-check` を追加し、`pg_dump` でスナップショット作成・検証ができるように
- スナップショットを `database/postgres/schema.sql` に保存し、`README.md` の説明と手順を更新
- 現在のデータベース構造を反映した `schema.sql` の初版を追加

## Testing
- Not run (not requested)