### PR TITLE
feat(db): add users birth_date column

### DIFF
--- a/database/postgres/migrations/0004_lin450_users_birth_date.down.sql
+++ b/database/postgres/migrations/0004_lin450_users_birth_date.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+  DROP COLUMN IF EXISTS birth_date;

--- a/database/postgres/migrations/0004_lin450_users_birth_date.up.sql
+++ b/database/postgres/migrations/0004_lin450_users_birth_date.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+  ADD COLUMN birth_date DATE;

--- a/database/postgres/schema.sql
+++ b/database/postgres/schema.sql
@@ -268,6 +268,7 @@ CREATE TABLE public.users (
     display_name text NOT NULL,
     avatar_key text,
     status_text text,
+    birth_date date,
     theme text DEFAULT 'dark'::text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -568,7 +569,6 @@ ALTER TABLE ONLY public.invites
 
 ALTER TABLE ONLY public.password_reset_tokens
     ADD CONSTRAINT password_reset_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
-
 
 
 

--- a/typescript/prisma/migrations/0002_add_users_birth_date/migration.sql
+++ b/typescript/prisma/migrations/0002_add_users_birth_date/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users"
+ADD COLUMN "birth_date" DATE;

--- a/typescript/prisma/schema.prisma
+++ b/typescript/prisma/schema.prisma
@@ -16,6 +16,7 @@ model User {
   displayName                        String                     @map("display_name")
   avatarKey                          String?                    @map("avatar_key")
   statusText                         String?                    @map("status_text")
+  birthDate                          DateTime?                  @map("birth_date") @db.Date
   theme                              String                     @default("dark")
   createdAt                          DateTime                   @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt                          DateTime                   @default(now()) @map("updated_at") @db.Timestamptz(6)


### PR DESCRIPTION
## Summary
- add birth_date column to users
- add sqlx migration for postgres schema (0004_lin450_users_birth_date)
- update Prisma schema and migration to map users.birth_date
- update database schema snapshot

## Related
- LIN-450
