### PR TITLE
LIN-258 AppShellFrameを3カラム骨格へ拡張

### DIFF
--- a/typescript/src/widgets/app-shell/index.test.tsx
+++ b/typescript/src/widgets/app-shell/index.test.tsx
@@ -1,0 +1,45 @@
+/** @vitest-environment happy-dom */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { AppShellFrame } from "./index";
+
+describe("AppShellFrame", () => {
+  test("デフォルトでは3カラム構造を描画し、右パネルを表示しない", () => {
+    render(
+      <AppShellFrame
+        serverRailSlot={<div>server rail</div>}
+        listSlot={<div>list</div>}
+        mainSlot={<div>main</div>}
+      />,
+    );
+
+    const grid = screen.getByTestId("app-shell-grid");
+
+    expect(grid.className).toContain("grid-cols-[72px_280px_minmax(0,1fr)]");
+    expect(screen.getByRole("navigation", { name: "app-shell-server-rail" })).toBeTruthy();
+    expect(screen.getByLabelText("app-shell-list")).toBeTruthy();
+    expect(screen.getByRole("main", { name: "app-shell-main" })).toBeTruthy();
+    expect(screen.queryByLabelText("app-shell-header")).toBeNull();
+    expect(screen.queryByLabelText("app-shell-right-panel")).toBeNull();
+  });
+
+  test("右パネルを開いたときに4カラム構造と右パネルを描画する", () => {
+    render(
+      <AppShellFrame
+        headerSlot={<div>header</div>}
+        serverRailSlot={<div>server rail</div>}
+        listSlot={<div>list</div>}
+        mainSlot={<div>main</div>}
+        isRightPanelOpen
+        rightPanelSlot={<div>right panel</div>}
+      />,
+    );
+
+    const grid = screen.getByTestId("app-shell-grid");
+
+    expect(grid.className).toContain("grid-cols-[72px_280px_minmax(0,1fr)_320px]");
+    expect(screen.getByLabelText("app-shell-header")).toBeTruthy();
+    expect(screen.getByLabelText("app-shell-right-panel")).toBeTruthy();
+  });
+});

--- a/typescript/src/widgets/app-shell/index.tsx
+++ b/typescript/src/widgets/app-shell/index.tsx
@@ -1,32 +1,129 @@
 import type { ReactNode } from "react";
 
-export type AppShellSlots = {
+type AppShellFrameBaseProps = {
+  headerSlot?: ReactNode;
+  serverRailSlot: ReactNode;
+  listSlot: ReactNode;
+  mainSlot: ReactNode;
+};
+
+type AppShellFrameWithRightPanel = {
+  isRightPanelOpen: true;
+  rightPanelSlot: ReactNode;
+};
+
+type AppShellFrameWithoutRightPanel = {
+  isRightPanelOpen?: false;
+  rightPanelSlot?: never;
+};
+
+type AppShellFrameLegacyProps = {
   headerSlot?: ReactNode;
   sidebarSlot?: ReactNode;
   contentSlot: ReactNode;
+  serverRailSlot?: never;
+  listSlot?: never;
+  mainSlot?: never;
+  isRightPanelOpen?: never;
+  rightPanelSlot?: never;
 };
+
+export type AppShellFrameProps =
+  | (AppShellFrameBaseProps &
+      (AppShellFrameWithRightPanel | AppShellFrameWithoutRightPanel))
+  | AppShellFrameLegacyProps;
+
+export type AppShellSlots = AppShellFrameProps;
+
+type ResolvedAppShellFrameProps = {
+  headerSlot?: ReactNode;
+  serverRailSlot: ReactNode;
+  listSlot: ReactNode;
+  mainSlot: ReactNode;
+  isRightPanelOpen: boolean;
+  rightPanelSlot?: ReactNode;
+};
+
+function isLegacyProps(props: AppShellFrameProps): props is AppShellFrameLegacyProps {
+  return "contentSlot" in props;
+}
+
+function resolveAppShellFrameProps(props: AppShellFrameProps): ResolvedAppShellFrameProps {
+  if (isLegacyProps(props)) {
+    return {
+      headerSlot: props.headerSlot,
+      serverRailSlot: props.sidebarSlot ?? null,
+      listSlot: null,
+      mainSlot: props.contentSlot,
+      isRightPanelOpen: false,
+    };
+  }
+
+  return {
+    headerSlot: props.headerSlot,
+    serverRailSlot: props.serverRailSlot,
+    listSlot: props.listSlot,
+    mainSlot: props.mainSlot,
+    isRightPanelOpen: props.isRightPanelOpen ?? false,
+    rightPanelSlot: props.rightPanelSlot,
+  };
+}
 
 /**
  * Discord系3カラムUIの骨格を提供する。
  *
  * Contract:
- * - `contentSlot` は必須
- * - `headerSlot` / `sidebarSlot` は任意
+ * - `serverRailSlot` / `listSlot` / `mainSlot` は必須
+ * - `headerSlot` は任意
+ * - `isRightPanelOpen=true` のとき `rightPanelSlot` は必須
  */
-export function AppShellFrame({
-  headerSlot,
-  sidebarSlot,
-  contentSlot,
-}: AppShellSlots) {
+export function AppShellFrame(props: AppShellFrameProps) {
+  const {
+    headerSlot,
+    serverRailSlot,
+    listSlot,
+    mainSlot,
+    isRightPanelOpen,
+    rightPanelSlot,
+  } = resolveAppShellFrameProps(props);
+
+  const gridColumnClass = isRightPanelOpen
+    ? "grid-cols-[72px_280px_minmax(0,1fr)_320px]"
+    : "grid-cols-[72px_280px_minmax(0,1fr)]";
+
   return (
-    <main className="grid min-h-screen grid-cols-[240px_1fr] grid-rows-[64px_1fr] bg-discord-darkest text-white">
-      <header className="col-span-2 border-b border-white/10 px-6 py-4">
-        {headerSlot}
-      </header>
-      <aside className="border-r border-white/10 bg-discord-dark px-4 py-6">
-        {sidebarSlot}
-      </aside>
-      <section className="bg-discord-darker px-8 py-6">{contentSlot}</section>
-    </main>
+    <div className="flex min-h-screen flex-col overflow-hidden bg-discord-darkest text-white">
+      {headerSlot ? (
+        <header aria-label="app-shell-header" className="shrink-0 border-b border-white/10 px-6 py-4">
+          {headerSlot}
+        </header>
+      ) : null}
+
+      <div className={`grid min-h-0 flex-1 overflow-hidden ${gridColumnClass}`} data-testid="app-shell-grid">
+        <nav
+          aria-label="app-shell-server-rail"
+          className="min-w-0 overflow-y-auto border-r border-white/10 bg-discord-dark px-3 py-4"
+        >
+          {serverRailSlot}
+        </nav>
+        <aside
+          aria-label="app-shell-list"
+          className="min-w-0 overflow-y-auto border-r border-white/10 bg-discord-dark px-4 py-4"
+        >
+          {listSlot}
+        </aside>
+        <main aria-label="app-shell-main" className="min-w-0 overflow-y-auto bg-discord-darker px-8 py-6">
+          {mainSlot}
+        </main>
+        {isRightPanelOpen ? (
+          <aside
+            aria-label="app-shell-right-panel"
+            className="min-w-0 overflow-y-auto border-l border-white/10 bg-discord-dark px-4 py-4"
+          >
+            {rightPanelSlot}
+          </aside>
+        ) : null}
+      </div>
+    </div>
   );
 }

--- a/typescript/src/widgets/index.ts
+++ b/typescript/src/widgets/index.ts
@@ -1,2 +1,2 @@
 export { AppShellFrame } from "@/widgets/app-shell";
-export type { AppShellSlots } from "@/widgets/app-shell";
+export type { AppShellFrameProps, AppShellSlots } from "@/widgets/app-shell";


### PR DESCRIPTION
## 概要
- AppShellFrame を3カラム（server rail / list / main）+ 任意ヘッダー + 任意右パネル対応に更新
- isRightPanelOpen に応じて右パネル列を切り替え可能にし、minmax(0,1fr)/min-w-0/overflow制御で崩れにくいレイアウトへ調整
- widgets Public API (src/widgets/index.ts) から AppShellFrameProps を公開

## 変更ファイル
- typescript/src/widgets/app-shell/index.tsx
- typescript/src/widgets/app-shell/index.test.tsx
- typescript/src/widgets/index.ts

## テスト
- npm run lint
- npm run test

## Linear
- LIN-258
