### PR TITLE
[LIN-304] protocol-wsのFrame/Op契約型を追加

### DIFF
--- a/rust/src/contracts/mod.rs
+++ b/rust/src/contracts/mod.rs
@@ -1,0 +1,5 @@
+pub mod protocol_ws;
+
+pub use protocol_ws::{
+    AckPayload, AckStatus, AuthPayload, EventPayload, Frame, HelloPayload, Op, SendMessagePayload,
+};

--- a/rust/src/contracts/protocol_ws.rs
+++ b/rust/src/contracts/protocol_ws.rs
@@ -1,0 +1,156 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Op {
+    Hello,
+    Auth,
+    SendMessage,
+    Ack,
+    Event,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", content = "d", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Frame {
+    Hello(HelloPayload),
+    Auth(AuthPayload),
+    SendMessage(SendMessagePayload),
+    Ack(AckPayload),
+    Event(EventPayload),
+}
+
+impl Frame {
+    pub const fn op(&self) -> Op {
+        match self {
+            Self::Hello(_) => Op::Hello,
+            Self::Auth(_) => Op::Auth,
+            Self::SendMessage(_) => Op::SendMessage,
+            Self::Ack(_) => Op::Ack,
+            Self::Event(_) => Op::Event,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HelloPayload {
+    pub connection_id: String,
+    pub heartbeat_interval_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthPayload {
+    pub token: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SendMessagePayload {
+    pub correlation_id: String,
+    pub channel_id: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AckStatus {
+    Accepted,
+    Persisted,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AckPayload {
+    pub correlation_id: String,
+    pub status: AckStatus,
+    pub code: Option<String>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EventPayload {
+    pub event_type: String,
+    pub event: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AckPayload, AckStatus, AuthPayload, EventPayload, Frame, HelloPayload, Op,
+        SendMessagePayload,
+    };
+
+    fn assert_round_trip(frame: Frame) {
+        let serialized = serde_json::to_string(&frame).unwrap();
+        let deserialized: Frame = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, frame);
+    }
+
+    #[test]
+    fn hello_frame_round_trip() {
+        let frame = Frame::Hello(HelloPayload {
+            connection_id: "conn-1".to_string(),
+            heartbeat_interval_ms: 30_000,
+        });
+        assert_eq!(frame.op(), Op::Hello);
+        assert_round_trip(frame);
+    }
+
+    #[test]
+    fn auth_frame_round_trip() {
+        let frame = Frame::Auth(AuthPayload {
+            token: "token-1".to_string(),
+        });
+        assert_eq!(frame.op(), Op::Auth);
+        assert_round_trip(frame);
+    }
+
+    #[test]
+    fn send_message_frame_round_trip() {
+        let frame = Frame::SendMessage(SendMessagePayload {
+            correlation_id: "corr-1".to_string(),
+            channel_id: "channel-1".to_string(),
+            content: "hello".to_string(),
+        });
+        assert_eq!(frame.op(), Op::SendMessage);
+        assert_round_trip(frame);
+    }
+
+    #[test]
+    fn ack_frame_round_trip() {
+        let frame = Frame::Ack(AckPayload {
+            correlation_id: "corr-1".to_string(),
+            status: AckStatus::Persisted,
+            code: None,
+            reason: None,
+        });
+        assert_eq!(frame.op(), Op::Ack);
+        assert_round_trip(frame);
+    }
+
+    #[test]
+    fn event_frame_round_trip() {
+        let frame = Frame::Event(EventPayload {
+            event_type: "MESSAGE_CREATED".to_string(),
+            event: serde_json::json!({
+                "id": "msg-1",
+                "channel_id": "channel-1"
+            }),
+        });
+        assert_eq!(frame.op(), Op::Event);
+        assert_round_trip(frame);
+    }
+
+    #[test]
+    fn missing_required_field_fails_deserialization() {
+        let invalid = serde_json::json!({
+            "op": "SEND_MESSAGE",
+            "d": {
+                "correlation_id": "corr-1",
+                "content": "hello"
+            }
+        });
+
+        let result: Result<Frame, _> = serde_json::from_value(invalid);
+        assert!(result.is_err());
+    }
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,3 +1,5 @@
+pub mod contracts;
+
 use axum::{
     extract::ws::{Message, WebSocket, WebSocketUpgrade},
     response::IntoResponse,
@@ -13,8 +15,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer())
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .init();
 


### PR DESCRIPTION
## 概要

- Linear Issue: LIN-304
- Linear URL: https://linear.app/linklynx-ai/issue/LIN-304/backend-protocol-wsにframeop契約接続送信ackを定義
- 対応内容サマリ: protocol-ws の Frame/Op 契約を Rust 型として追加し、gateway/API から `crate::contracts` 経由で参照できるようにしました。

## 実装内容（詳細）

- `rust/src/contracts/protocol_ws.rs` を新規追加し、`Frame`/`Op` と `HELLO/AUTH/SEND_MESSAGE/ACK/EVENT` の payload 型を定義
- `Frame` は `#[serde(tag = "op", content = "d", rename_all = "SCREAMING_SNAKE_CASE")]` で JSON 契約を固定
- `ACK` の必須項目として `correlation_id` と `status`（`accepted/persisted/failed`）を定義し、失敗詳細は任意項目に分離
- `rust/src/contracts/mod.rs` を追加して `protocol_ws` と主要型を re-export
- `rust/src/main.rs` に `pub mod contracts;` を追加して公開導線を有効化
- round-trip（serialize -> deserialize）テストと必須フィールド欠落時の失敗テストを追加

## 初心者向け説明（2-3行）

この変更は、WebSocket でやり取りするデータ形式を Rust の型として先に固定し、実装側の解釈ズレを防ぐためのものです。
`op` と `d` の形を enum/struct で表現したので、gateway や API で同じ契約を安全に使えます。
今回は契約定義だけを追加しており、WS ハンドラの業務ロジックは変更していません。

## テスト内容

- [x] `protocol_ws` の frame round-trip テストを追加（HELLO/AUTH/SEND_MESSAGE/ACK/EVENT）
- [x] 必須フィールド欠落時に deserialize が失敗するテストを追加
- [ ] `make rust-lint`（実行したが crates.io へ到達できず依存取得に失敗）
- [ ] `make rust-test`（同上。ネットワーク制約により未完了）

## レビュー観点

- `Frame` のタグ付け（`op`/`d`）が想定する運用契約と一致しているか
- payload の必須項目（特に `SEND_MESSAGE` と `ACK`）が後続 Issue（LIN-444/445/446）の前提を満たすか
