### PR TITLE
[LIN-310] backend: cursor/limit/nextCursorとエラーコード規約を定義

### DIFF
--- a/rust/src/contracts/mod.rs
+++ b/rust/src/contracts/mod.rs
@@ -12,3 +12,9 @@ pub use protocol_events::{
     MessageCreatedPayload, MessageDeletedPayload, MessageEventType, MessagePayload,
     MessagePayloadBase, MessageUpdatedPayload, ProtocolEventEnvelope,
 };
+
+pub mod pagination_error;
+
+pub use pagination_error::{
+    ErrorCode, ErrorResponse, PaginationMeta, PaginationParams, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT,
+};

--- a/rust/src/contracts/pagination_error.rs
+++ b/rust/src/contracts/pagination_error.rs
@@ -1,0 +1,120 @@
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_PAGE_LIMIT: u32 = 50;
+pub const MAX_PAGE_LIMIT: u32 = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaginationParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(default = "default_page_limit")]
+    pub limit: u32,
+}
+
+impl Default for PaginationParams {
+    fn default() -> Self {
+        Self {
+            cursor: None,
+            limit: DEFAULT_PAGE_LIMIT,
+        }
+    }
+}
+
+impl PaginationParams {
+    pub fn validate_limit(&self) -> Result<(), ErrorCode> {
+        if (1..=MAX_PAGE_LIMIT).contains(&self.limit) {
+            Ok(())
+        } else {
+            Err(ErrorCode::ValidationFailed)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PaginationMeta {
+    #[serde(
+        default,
+        rename = "nextCursor",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    ValidationFailed,
+    AuthorizationFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    pub code: ErrorCode,
+}
+
+const fn default_page_limit() -> u32 {
+    DEFAULT_PAGE_LIMIT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ErrorCode, ErrorResponse, PaginationMeta, PaginationParams, DEFAULT_PAGE_LIMIT,
+        MAX_PAGE_LIMIT,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn pagination_params_default_limit_is_applied() {
+        let params: PaginationParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(params.cursor, None);
+        assert_eq!(params.limit, DEFAULT_PAGE_LIMIT);
+    }
+
+    #[test]
+    fn pagination_params_limit_validation_has_bounds() {
+        let valid = PaginationParams {
+            cursor: None,
+            limit: MAX_PAGE_LIMIT,
+        };
+        assert_eq!(valid.validate_limit(), Ok(()));
+
+        let zero = PaginationParams {
+            cursor: None,
+            limit: 0,
+        };
+        assert_eq!(zero.validate_limit(), Err(ErrorCode::ValidationFailed));
+
+        let too_large = PaginationParams {
+            cursor: None,
+            limit: MAX_PAGE_LIMIT + 1,
+        };
+        assert_eq!(too_large.validate_limit(), Err(ErrorCode::ValidationFailed));
+    }
+
+    #[test]
+    fn pagination_meta_uses_next_cursor_wire_name() {
+        let meta = PaginationMeta {
+            next_cursor: Some("cursor-2".to_string()),
+        };
+
+        let value = serde_json::to_value(meta).unwrap();
+        assert_eq!(value, json!({ "nextCursor": "cursor-2" }));
+    }
+
+    #[test]
+    fn error_code_and_response_round_trip() {
+        let response = ErrorResponse {
+            code: ErrorCode::AuthorizationFailed,
+        };
+
+        let serialized = serde_json::to_value(&response).unwrap();
+        assert_eq!(serialized, json!({ "code": "authorization_failed" }));
+
+        let parsed: ErrorResponse = serde_json::from_value(json!({
+            "code": "validation_failed"
+        }))
+        .unwrap();
+        assert_eq!(parsed.code, ErrorCode::ValidationFailed);
+    }
+}


### PR DESCRIPTION
## 概要

- Linear Issue: LIN-310
- Linear URL: https://linear.app/linklynx-ai/issue/LIN-310/backend-cursorlimitnextcursorとエラーコード規約を定義
- 対応内容サマリ: cursor/limit/nextCursor のページング契約と、validation/authz failure のエラーコード契約を Rust 側に追加し、API 層から参照可能にしました。

## 実装内容（詳細）

- `rust/src/contracts/pagination_error.rs` を新規追加し、以下を定義
  - `PaginationParams`（`cursor` / `limit`）
  - `PaginationMeta`（`nextCursor`）
  - `ErrorCode`（`validation_failed` / `authorization_failed`）
  - `ErrorResponse`
  - `limit` 境界検証メソッド `validate_limit`
- 同ファイル内に契約テストを追加
  - デフォルト limit 適用
  - limit 境界バリデーション
  - `nextCursor` のワイヤー名シリアライズ
  - エラーコード/レスポンスのシリアライズ往復
- `rust/src/contracts/mod.rs` を新規追加し、契約型を公開 re-export
- `rust/src/main.rs` に `pub mod contracts;` を追加して参照導線を公開

## 初心者向け説明（2-3行）

この変更は、ページング情報と API エラーコードの「共通の型」を 1 箇所にまとめるためのものです。
`nextCursor` や `validation_failed` などの表現ゆれを防ぎ、Backend と Frontend が同じ意味でデータを扱えるようにしています。
今回の範囲は契約定義のみで、実際のページングクエリ実装や認可判定ロジックは含みません。

## テスト内容

- [x] 契約テスト追加（`pagination_error.rs`）
- [x] `make rust-lint` 実行
  - 失敗: `index.crates.io` 名前解決不可（依存取得不可）
- [x] `make rust-test` 実行
  - 失敗: `index.crates.io` 名前解決不可（依存取得不可）

## レビュー観点

- `ErrorCode` の命名（`validation_failed` / `authorization_failed`）が API/Frontend 共通契約として妥当か
- `PaginationMeta` の `nextCursor` シリアライズキーが期待契約と一致しているか
