### PR TITLE
LIN-260 チャットヘッダーと右サイドパネル表示切替UIを実装

### DIFF
--- a/typescript/src/widgets/chat-header/index.test.tsx
+++ b/typescript/src/widgets/chat-header/index.test.tsx
@@ -1,0 +1,57 @@
+/** @vitest-environment happy-dom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { ChatHeader } from "./index";
+
+describe("ChatHeader", () => {
+  test("メンバーパネル切替状態を aria-pressed に反映する", () => {
+    render(
+      <ChatHeader
+        isMemberPanelOpen
+        onToggleMemberPanel={() => {}}
+        subtitle="Channel"
+        title="# design-review"
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "メンバーパネルを開閉" });
+
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByText("# design-review")).toBeTruthy();
+    expect(screen.getByText("Channel")).toBeTruthy();
+  });
+
+  test("メンバーパネル切替ボタン押下でコールバックを呼ぶ", () => {
+    const handleToggleMemberPanel = vi.fn();
+
+    render(
+      <ChatHeader
+        isMemberPanelOpen={false}
+        onToggleMemberPanel={handleToggleMemberPanel}
+        title="DM with Design Reviewer"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "メンバーパネルを開閉" }));
+
+    expect(handleToggleMemberPanel).toHaveBeenCalledTimes(1);
+  });
+
+  test("右パネル開閉を阻害しないレイアウトクラスを維持する", () => {
+    render(
+      <ChatHeader
+        isMemberPanelOpen={false}
+        onToggleMemberPanel={() => {}}
+        title="General"
+      />
+    );
+
+    const header = screen.getByTestId("chat-header");
+    const button = screen.getByRole("button", { name: "メンバーパネルを開閉" });
+
+    expect(header.className).toContain("min-w-0");
+    expect(button.className).toContain("shrink-0");
+    expect(button.className).toContain("transition-colors");
+  });
+});

--- a/typescript/src/widgets/chat-header/index.tsx
+++ b/typescript/src/widgets/chat-header/index.tsx
@@ -1,0 +1,51 @@
+import { classNames } from "@/shared";
+
+export type ChatHeaderProps = {
+  title: string;
+  subtitle?: string;
+  isMemberPanelOpen: boolean;
+  onToggleMemberPanel: () => void;
+};
+
+/**
+ * 会話ヘッダーとメンバーパネル切替トリガーを表示する。
+ *
+ * Contract:
+ * - `isMemberPanelOpen` を `aria-pressed` に反映する
+ * - 右パネル開閉時のレイアウト遷移を阻害しないよう `min-w-0` を維持する
+ */
+export function ChatHeader({
+  title,
+  subtitle,
+  isMemberPanelOpen,
+  onToggleMemberPanel,
+}: ChatHeaderProps) {
+  return (
+    <header
+      aria-label="chat-header"
+      className="flex w-full min-w-0 items-center justify-between gap-3"
+      data-testid="chat-header"
+    >
+      <div className="min-w-0 flex-1">
+        {subtitle ? (
+          <p className="truncate text-xs font-medium uppercase tracking-wide text-white/60">{subtitle}</p>
+        ) : null}
+        <h2 className="truncate text-lg font-semibold text-white">{title}</h2>
+      </div>
+      <button
+        aria-label="メンバーパネルを開閉"
+        aria-pressed={isMemberPanelOpen}
+        className={classNames(
+          "shrink-0 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors",
+          isMemberPanelOpen
+            ? "border-discord-primary bg-discord-primary/15 text-discord-primary"
+            : "border-white/20 bg-transparent text-white/80 hover:bg-white/10"
+        )}
+        onClick={onToggleMemberPanel}
+        type="button"
+      >
+        メンバー
+      </button>
+    </header>
+  );
+}

--- a/typescript/src/widgets/index.ts
+++ b/typescript/src/widgets/index.ts
@@ -1,6 +1,10 @@
 export { AppShellFrame } from "@/widgets/app-shell";
 export type { AppShellFrameProps, AppShellSlots } from "@/widgets/app-shell";
+export { ChatHeader } from "@/widgets/chat-header";
+export type { ChatHeaderProps } from "@/widgets/chat-header";
 export { MessageTimeline } from "@/widgets/message-timeline";
+export { MemberPanel } from "@/widgets/member-panel";
+export type { MemberPanelProps } from "@/widgets/member-panel";
 export { ChannelList } from "@/widgets/channel-list";
 export type {
   ChannelListItem,

--- a/typescript/src/widgets/member-panel/index.test.tsx
+++ b/typescript/src/widgets/member-panel/index.test.tsx
@@ -1,0 +1,51 @@
+/** @vitest-environment happy-dom */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import type { MemberSummary } from "@/entities";
+import { MemberPanel } from "./index";
+
+const demoMembers: MemberSummary[] = [
+  {
+    id: "member-1",
+    displayName: "LinkLynx Bot",
+    statusLabel: "Online",
+    avatarLabel: "LB",
+  },
+  {
+    id: "member-2",
+    displayName: "Design Reviewer",
+    statusLabel: "Away",
+    avatarLabel: "DR",
+  },
+];
+
+describe("MemberPanel", () => {
+  test("メンバー一覧を MemberAvatar で描画する", () => {
+    render(<MemberPanel members={demoMembers} title="Channel members" />);
+
+    expect(screen.getByRole("heading", { name: "Channel members" })).toBeTruthy();
+    expect(screen.getByText("LinkLynx Bot")).toBeTruthy();
+    expect(screen.getByText("Design Reviewer")).toBeTruthy();
+    expect(screen.getByText("LB")).toBeTruthy();
+    expect(screen.getByText("DR")).toBeTruthy();
+  });
+
+  test("メンバー未存在時は空状態メッセージを表示する", () => {
+    render(<MemberPanel members={[]} />);
+
+    expect(screen.getByText("表示できるメンバーはいません。")).toBeTruthy();
+  });
+
+  test("右パネル開閉を阻害しないレイアウトクラスを維持する", () => {
+    render(<MemberPanel members={demoMembers} />);
+
+    const panel = screen.getByLabelText("member-panel");
+    const list = screen.getByLabelText("member-panel-list");
+
+    expect(panel.className).toContain("min-w-0");
+    expect(panel.className).toContain("overflow-hidden");
+    expect(list.className).toContain("min-h-0");
+    expect(list.className).toContain("overflow-y-auto");
+  });
+});

--- a/typescript/src/widgets/member-panel/index.tsx
+++ b/typescript/src/widgets/member-panel/index.tsx
@@ -1,0 +1,36 @@
+import { MemberAvatar, type MemberSummary } from "@/entities";
+
+export type MemberPanelProps = {
+  members: MemberSummary[];
+  title?: string;
+};
+
+/**
+ * 右サイドのメンバー一覧パネルを表示する。
+ *
+ * Contract:
+ * - メンバー表示は `MemberAvatar` を再利用する
+ * - パネル開閉時のレイアウト遷移を阻害しないよう `min-w-0` と `overflow` を調整する
+ */
+export function MemberPanel({ members, title = "Members" }: MemberPanelProps) {
+  return (
+    <section aria-label="member-panel" className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
+      <header className="shrink-0 border-b border-white/10 pb-3">
+        <h2 className="truncate text-sm font-semibold uppercase tracking-wide text-white/70">{title}</h2>
+        <p className="mt-1 text-xs text-white/50">{members.length} members</p>
+      </header>
+
+      {members.length > 0 ? (
+        <ul aria-label="member-panel-list" className="mt-3 min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
+          {members.map((member) => (
+            <li className="rounded-md px-2 py-1 transition-colors hover:bg-white/5" key={member.id}>
+              <MemberAvatar member={member} size="sm" />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-3 text-sm text-white/60">表示できるメンバーはいません。</p>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## 概要
- Linear Issue: LIN-260
- チャットヘッダーとメンバーパネルの再利用可能なwidgetsを追加
- 右パネル開閉を想定したレイアウトクラスとアクセシビリティ属性（aria-pressed）を実装

## 実装内容
- `ChatHeader` を新規追加し、`ChatHeaderProps` に `isMemberPanelOpen` / `onToggleMemberPanel` を定義
- `MemberPanel` を新規追加し、`MemberAvatar` を再利用してメンバー一覧を表示
- `widgets/index.ts` に `ChatHeader` / `MemberPanel` と各Propsを公開

## テスト
- `npm run lint`
- `npm run test`

## Linear
- LIN-260
