### PR TITLE
LIN-288: 履歴カーソル走査クエリ契約を追加

### DIFF
--- a/database/contracts/lin288_history_cursor_contract.md
+++ b/database/contracts/lin288_history_cursor_contract.md
@@ -1,0 +1,85 @@
+# LIN-288 履歴カーソル走査契約（cursor / limit / nextCursor）
+
+## 目的
+
+- 対象 Issue: LIN-288
+- 対象クエリ資産: `database/scylla/queries/lin288_history_cursor_paging.cql`
+- 参照先: LIN-279（履歴取得API）
+
+本契約で定義するもの:
+
+- `cursor` 比較キー
+- `limit + 1` 取得規約
+- `nextCursor` 発行規約
+- 順序と重複排除規約
+
+## 1. カーソル比較キー
+
+履歴ページングの比較キーは次の複合キーで統一する。
+
+- `cursor_key = (timestamp, message_id)`
+- `timestamp` は `created_at` を指す。
+- 同一 `timestamp` の場合は `message_id` でタイブレークする。
+
+比較規則（厳密不等号）:
+
+- older 側へ進む（forward）: `(created_at, message_id) < (cursor_ts, cursor_message_id)`
+- newer 側へ戻る（backward）: `(created_at, message_id) > (cursor_ts, cursor_message_id)`
+
+## 2. limit + 1 規約
+
+呼び出し側は常に `limit + 1` 件を要求する。
+
+- リクエスト入力: `limit`
+- DBクエリ入力: `limit_plus_one = limit + 1`
+
+返却件数:
+
+- 取得結果が `limit_plus_one` 件の場合は先頭 `limit` 件を返却し、余剰1件を `nextCursor` 判定にのみ使用する。
+- 取得結果が `limit` 件以下の場合はそのまま返却する。
+
+## 3. nextCursor 規約
+
+`nextCursor` は「同方向に続きが存在する」場合のみ返す。
+
+- 判定条件: 取得件数が `limit_plus_one` 件
+- 発行値: クライアントへ返却する末尾要素（`limit` 件目）の `(created_at, message_id)`
+- 非発行条件: 取得件数が `limit` 件以下
+
+補足:
+
+- `forward` では「より古い履歴」が残っている場合に `nextCursor` を返す。
+- `backward` では「より新しい履歴」が残っている場合に `nextCursor` を返す。
+
+## 4. 順序規約
+
+返却順序は方向ごとに次を満たす。
+
+- `forward`（older 取得）: 新しい -> 古い（降順）
+- `backward`（newer 取得）: 古い -> 新しい（昇順）
+
+実装上、`backward` クエリ結果が降順で返る場合は、返却前に昇順へ反転して契約順序を満たす。
+
+## 5. 重複排除規約
+
+ページ境界での重複は次の規約で禁止する。
+
+- 比較演算は必ず厳密不等号（`<` / `>`）を使用し、カーソル行自身を再取得しない。
+- アプリケーション側の重複キーは `(message_id)` を正とする。
+- 同一ページ内・ページ跨ぎ双方で、`message_id` が重複した要素は返却集合から除外する。
+
+## 6. LIN-279 での再利用ポイント
+
+LIN-279（履歴取得API）は以下を本契約のまま利用する。
+
+- カーソルのシリアライズ対象を `(created_at, message_id)` とする。
+- DB呼び出し時は必ず `limit + 1` を使用する。
+- `nextCursor` 発行有無を「余剰1件の有無」で判定する。
+- 方向ごとの返却順序を固定し、境界重複を排除する。
+
+## 7. 実施確認（証跡コマンド）
+
+```bash
+rg -n "forward|backward|LIMIT :limit_plus_one" database/scylla/queries/lin288_history_cursor_paging.cql
+rg -n "nextCursor|limit \+ 1|重複排除|timestamp" database/contracts/lin288_history_cursor_contract.md
+```

--- a/database/scylla/queries/lin288_history_cursor_paging.cql
+++ b/database/scylla/queries/lin288_history_cursor_paging.cql
@@ -1,0 +1,81 @@
+-- LIN-288: 履歴カーソル走査クエリ（再利用資産）
+--
+-- 目的:
+-- - cursor 比較キーを `(created_at, message_id)` として統一する
+-- - forward / backward のページングを同一契約で扱う
+-- - `LIMIT :limit_plus_one` で nextCursor 判定を可能にする
+--
+-- 想定入力:
+-- - :channel_id      bigint
+-- - :bucket          int
+-- - :cursor_ts       timestamp
+-- - :cursor_message_id bigint
+-- - :limit_plus_one  int   -- 呼び出し側で `limit + 1` を計算して渡す
+
+-- 1) 初回ページ（最新側から取得）
+--    cursor なし時に使用する。
+SELECT
+  channel_id,
+  bucket,
+  message_id,
+  author_id,
+  content,
+  version,
+  edited_at,
+  is_deleted,
+  deleted_at,
+  deleted_by,
+  created_at
+FROM chat.messages_by_channel
+WHERE channel_id = :channel_id
+  AND bucket = :bucket
+ORDER BY message_id DESC
+LIMIT :limit_plus_one;
+
+-- 2) forward (older) ページ
+--    走査方向: 新しい -> 古い
+--    cursor より「古い」行を取得する。
+--    同一 timestamp は message_id でタイブレークする。
+SELECT
+  channel_id,
+  bucket,
+  message_id,
+  author_id,
+  content,
+  version,
+  edited_at,
+  is_deleted,
+  deleted_at,
+  deleted_by,
+  created_at
+FROM chat.messages_by_channel
+WHERE channel_id = :channel_id
+  AND bucket = :bucket
+  AND (created_at, message_id) < (:cursor_ts, :cursor_message_id)
+ORDER BY message_id DESC
+LIMIT :limit_plus_one
+ALLOW FILTERING;
+
+-- 3) backward (newer) ページ
+--    走査方向: 古い -> 新しい（逆方向移動）
+--    cursor より「新しい」行を取得し、返却前に昇順へ反転する前提。
+--    同一 timestamp は message_id でタイブレークする。
+SELECT
+  channel_id,
+  bucket,
+  message_id,
+  author_id,
+  content,
+  version,
+  edited_at,
+  is_deleted,
+  deleted_at,
+  deleted_by,
+  created_at
+FROM chat.messages_by_channel
+WHERE channel_id = :channel_id
+  AND bucket = :bucket
+  AND (created_at, message_id) > (:cursor_ts, :cursor_message_id)
+ORDER BY message_id ASC
+LIMIT :limit_plus_one
+ALLOW FILTERING;


### PR DESCRIPTION
## 概要
- LIN-288 向けに履歴カーソル走査の再利用CQL資産を追加
- `cursor(timestamp+message_id)` / `limit+1` / `nextCursor` / 重複排除の契約文書を追加
- API/UI/Rust層の変更は行わず、DB契約資産に限定

## 追加ファイル
- `database/scylla/queries/lin288_history_cursor_paging.cql`
- `database/contracts/lin288_history_cursor_contract.md`

## 検証
- `rg -n "forward|backward|LIMIT :limit_plus_one" database/scylla/queries/lin288_history_cursor_paging.cql`
- `rg -n "nextCursor|limit \+ 1|重複排除|timestamp" database/contracts/lin288_history_cursor_contract.md`

## 補足
- 現行スキーマ上、timestamp条件は `ALLOW FILTERING` 前提

Closes #294
