### PR TITLE
LIN-289: message_id冪等保存ルールを契約化

### DIFF
--- a/database/contracts/lin289_idempotent_write_contract.md
+++ b/database/contracts/lin289_idempotent_write_contract.md
@@ -1,0 +1,48 @@
+# LIN-289 `message_id` 冪等保存契約
+
+## 目的
+
+- 同一 `message_id` の二重保存を防止する。
+- 再送 / 再接続時も同じ手順で安全に再実行できる保存規約を定義する。
+- `IF NOT EXISTS` を使った duplicate no-op の期待結果を再現可能にする。
+
+## 対象 / 非対象
+
+- 対象: `chat.messages_by_channel` への新規メッセージ保存（MessageCreated）
+- 非対象: MessageUpdated / MessageDeleted、アプリケーション実装、既存スキーマ変更
+
+## 事前条件
+
+1. `message_id` はメッセージ作成ごとに一意である。
+2. `bucket` 算出は決定的であり、同一 `message_id` から同一 `bucket` が得られる。
+3. 保存時の整合性レベルは `LOCAL_QUORUM`、直列整合は `LOCAL_SERIAL` を推奨する。
+
+## 保存契約（適用順序）
+
+1. 入力から `bucket` を算出する。
+2. `chat.messages_by_channel` に `INSERT ... IF NOT EXISTS` を実行する。
+3. 応答の `[applied]` を評価する。
+4. `[applied] = true` の場合は初回保存成功として扱う。
+5. `[applied] = false` の場合は duplicate として no-op 成功として扱う。
+6. ACK未達・タイムアウトで結果不確定の場合は `SELECT` で存在確認する。
+7. 行が存在すれば成功終了、存在しなければ同じ値で `INSERT ... IF NOT EXISTS` を再実行する。
+
+## duplicate no-op の期待結果
+
+| シナリオ | `INSERT ... IF NOT EXISTS` の結果 | 期待結果 |
+| --- | --- | --- |
+| 初回保存 | `[applied] = true` | 1行作成される |
+| 同一 payload を再送 | `[applied] = false` | 新規行は作成されない（no-op） |
+| 結果不確定後の再試行（既存あり） | `[applied] = false` または事前 `SELECT` で検出 | 新規行は作成されない（no-op） |
+
+## 検証手順
+
+1. `database/scylla/queries/lin289_idempotent_write_strategy.cql` の検証シナリオを `cqlsh` で順に実行する。
+2. 初回保存で `[applied] = true` を確認する。
+3. 同一 `message_id` の再実行で `[applied] = false` を確認する。
+4. `SELECT COUNT(*)` の結果が増加しないことを確認する（重複排除）。
+
+## 判定基準
+
+- 上記手順で duplicate 時に `[applied] = false` となり、行数が増えなければ LIN-289 の DB 契約を満たす。
+- 本契約は「重複作成を防ぐ」ことを保証範囲とし、編集 / 削除イベントは別契約で扱う。

--- a/database/scylla/queries/lin289_idempotent_write_strategy.cql
+++ b/database/scylla/queries/lin289_idempotent_write_strategy.cql
@@ -1,0 +1,76 @@
+-- LIN-289: message_id 冪等保存戦略
+-- 目的: 再送 / 再接続で同一 message_id が再到達しても重複行を作らない。
+-- 前提: bucket 算出は決定的であり、同一 message_id は同一 bucket に解決される。
+-- 非対象: MessageUpdated / MessageDeleted の保存戦略（別Issue）。
+
+-- 推奨整合性設定（アプリ実行時）
+-- CONSISTENCY LOCAL_QUORUM;
+-- SERIAL CONSISTENCY LOCAL_SERIAL;
+
+-- [適用順序 1/3] message_id を含む主キーに対して LWT で保存を試行する。
+INSERT INTO chat.messages_by_channel (
+  channel_id,
+  bucket,
+  message_id,
+  author_id,
+  content,
+  version,
+  edited_at,
+  is_deleted,
+  deleted_at,
+  deleted_by,
+  created_at
+) VALUES (
+  :channel_id,
+  :bucket,
+  :message_id,
+  :author_id,
+  :content,
+  :version,
+  null,
+  false,
+  null,
+  null,
+  :created_at
+) IF NOT EXISTS;
+
+-- [適用順序 2/3] 結果解釈
+-- [applied] = true  -> 初回保存成功
+-- [applied] = false -> 既存行あり。duplicate として no-op 扱いで成功終了
+
+-- [適用順序 3/3] 再送 / 再接続時（ACK未達・タイムアウト時）の read-before-retry
+-- 1) 既存確認
+SELECT message_id
+FROM chat.messages_by_channel
+WHERE channel_id = :channel_id
+  AND bucket = :bucket
+  AND message_id = :message_id;
+-- 2) 行が存在する場合: 既に保存済みとして成功終了（再INSERTしない）
+-- 3) 行が存在しない場合: 同じ値で INSERT ... IF NOT EXISTS を再実行
+
+-- 検証シナリオ（cqlsh 実行例）
+TRUNCATE chat.messages_by_channel;
+
+-- 初回保存: [applied] = true を期待
+INSERT INTO chat.messages_by_channel (
+  channel_id, bucket, message_id, author_id, content, version,
+  edited_at, is_deleted, deleted_at, deleted_by, created_at
+) VALUES (
+  10, 20260221, 10001, 501, 'hello', 1,
+  null, false, null, null, '2026-02-21T01:00:00Z'
+) IF NOT EXISTS;
+
+-- 重複保存: [applied] = false を期待（no-op）
+INSERT INTO chat.messages_by_channel (
+  channel_id, bucket, message_id, author_id, content, version,
+  edited_at, is_deleted, deleted_at, deleted_by, created_at
+) VALUES (
+  10, 20260221, 10001, 501, 'hello', 1,
+  null, false, null, null, '2026-02-21T01:00:00Z'
+) IF NOT EXISTS;
+
+-- 重複行が増えていないことを確認（期待値: 1）
+SELECT COUNT(*) AS row_count
+FROM chat.messages_by_channel
+WHERE channel_id = 10
+  AND bucket = 20260221;


### PR DESCRIPTION
## 概要
- LIN-289 向けに `message_id` 重複排除の保存戦略CQLを追加
- `IF NOT EXISTS` ベースの no-op 規約と read-before-retry 手順を契約文書化
- 既存スキーマは変更せず、契約資産のみ追加

## 追加ファイル
- `database/scylla/queries/lin289_idempotent_write_strategy.cql`
- `database/contracts/lin289_idempotent_write_contract.md`

## 検証
- ファイル内に duplicate no-op の再現手順（`[applied]` / `COUNT(*)`）を記載

Closes #295
