### PR TITLE
[LIN-291] 履歴境界ケースの再現用データと検証手順を追加

### DIFF
--- a/database/contracts/lin291_history_edge_case_verification.md
+++ b/database/contracts/lin291_history_edge_case_verification.md
@@ -1,0 +1,97 @@
+# LIN-291 履歴境界ケース検証手順
+
+## 目的
+
+- 対象 Issue: LIN-291
+- `chat.messages_by_channel` で履歴境界ケースを再現し、DB層での検証手順を固定化する。
+- LIN-288（カーソル/limit規約）と LIN-289（重複試行 no-op 規約）に矛盾しないことを確認する。
+
+## 対象ファイル
+
+- テストデータ: `database/scylla/testdata/lin291_history_edge_cases.cql`
+
+## 参照規約
+
+- `database/scylla/queries/lin288_history_cursor_paging.cql`
+- `database/contracts/lin288_history_cursor_contract.md`
+- `database/scylla/queries/lin289_idempotent_write_strategy.cql`
+- `database/contracts/lin289_idempotent_write_contract.md`
+
+## 対象 / 非対象
+
+対象:
+- 同一 `timestamp` 境界（タイブレーク）
+- `message_id` 欠番を含む履歴列
+- 重複試行（`INSERT ... IF NOT EXISTS`）
+- `limit + 1` 境界
+
+非対象:
+- 本番データ投入
+- UI/API 実装変更
+
+## 事前条件
+
+1. `database/scylla/001_lin139_messages.cql` が適用済みであること。
+2. 検証先は開発/検証用 Scylla であること（本番環境では実行しない）。
+3. `cqlsh` から対象クラスタに接続できること。
+
+## 実行手順
+
+1. `cqlsh` でテストデータ CQL を実行する。
+
+```bash
+cqlsh -f database/scylla/testdata/lin291_history_edge_cases.cql
+```
+
+2. 実行ログで以下の確認ポイントを順に確認する。
+- 重複試行時の `[applied] = false`
+- `row_count = 7`
+- 基準ページの `LIMIT 4` 取得（`limit=3` の `limit + 1` を想定）
+- 同一 `timestamp` 境界での forward/backward の取得結果
+- 最終ページで余剰1件がない（`nextCursor` 非発行条件）
+
+## 期待結果（ケース別）
+
+1. 同一 `timestamp` 境界
+- cursor: `('2026-02-21T10:00:05Z', 120107)`
+- forward（`<`）: `120105, 120102, 120100, 120099`
+- backward（`>`）: `120108, 120110`
+- 判定: 同一 `timestamp` の `120108` が forward 側に混入しないこと。
+
+2. 欠番ケース
+- 取得列: `120110, 120108, 120107, 120105, 120102, 120100, 120099`
+- 判定: 欠番（`120109` など）があってもページング順序が崩れないこと。
+
+3. 重複試行ケース
+- 同一 `message_id=120107` の再実行で `[applied] = false`
+- `COUNT(*)` が `7` で据え置き
+- 判定: duplicate no-op が成立していること。
+
+4. limit 境界ケース
+- 初回 `LIMIT 4` で4行取得（`limit=3` を想定した余剰1件あり）
+- cursor=`('2026-02-21T10:00:02Z', 120100)` では1行のみ
+- 判定: 余剰1件あり/なしの両方を再現できること。
+
+## LIN-288/289 整合チェック
+
+LIN-288 整合:
+- 比較演算が厳密不等号（`<` / `>`）であること
+- `limit + 1` 取得の境界（余剰1件あり/なし）を再現していること
+
+LIN-289 整合:
+- `INSERT ... IF NOT EXISTS` の duplicate で `[applied] = false` を確認できること
+- 重複試行後に行数が増えないこと
+
+## 判定基準
+
+- 上記4ケースがすべて再現できれば LIN-291 の完了条件を満たす。
+- LIN-288/289 の規約と矛盾する結果が出た場合は、実装を進めずに確認・切り分けを行う。
+
+## 証跡コマンド（static）
+
+```bash
+rg -n "120107|LIMIT 4|IF NOT EXISTS|ALLOW FILTERING|row_count" \
+  database/scylla/testdata/lin291_history_edge_cases.cql
+rg -n '同一 `timestamp`|欠番|重複試行|limit 境界|LIN-288|LIN-289' \
+  database/contracts/lin291_history_edge_case_verification.md
+```

--- a/database/scylla/testdata/lin291_history_edge_cases.cql
+++ b/database/scylla/testdata/lin291_history_edge_cases.cql
@@ -1,0 +1,146 @@
+-- LIN-291: 履歴境界ケース再現データ
+-- 目的:
+-- - 同一 timestamp 境界
+-- - message_id 欠番
+-- - 重複試行（IF NOT EXISTS）
+-- - limit + 1 境界
+-- を同一パーティションで再現し、LIN-288/289 の契約検証に再利用する。
+--
+-- 注意:
+-- - 検証専用データ。実運用データへの投入は非対象。
+-- - 既存スキーマ `database/scylla/001_lin139_messages.cql` 適用済み前提。
+
+-- [0] 検証パーティション初期化（ローカル検証専用）
+DELETE FROM chat.messages_by_channel
+WHERE channel_id = 910001
+  AND bucket = 20260221;
+
+-- [1] ベースデータ投入（欠番を含む）
+-- message_id: 120110, 120108, 120107, 120105, 120102, 120100, 120099
+-- 欠番:      120109, 120106, 120104, 120103, 120101
+INSERT INTO chat.messages_by_channel (
+  channel_id, bucket, message_id, author_id, content, version,
+  edited_at, is_deleted, deleted_at, deleted_by, created_at
+) VALUES (
+  910001, 20260221, 120110, 5001, 'lin291-m120110', 1,
+  null, false, null, null, '2026-02-21T10:00:06Z'
+) IF NOT EXISTS;
+
+INSERT INTO chat.messages_by_channel (
+  channel_id, bucket, message_id, author_id, content, version,
+  edited_at, is_deleted, deleted_at, deleted_by, created_at
+) VALUES (
+  910001, 20260221, 120108, 5002, 'lin291-m120108', 1,
+  null, false, null, null, '2026-02-21T10:00:05Z'
+) IF NOT EXISTS;
+
+INSERT INTO chat.messages_by_channel (
+  channel_id, bucket, message_id, author_id, content, version,
+  edited_at, is_deleted, deleted_at, deleted_by, created_at
+) VALUES (
+  910001, 20260221, 120107, 5003, 'lin291-m120107', 1,
+  null, false, null, null, '2026-02-21T10:00:05Z'
+) IF NOT EXISTS;
+
+INSERT INTO chat.messages_by_channel (
+  channel_id, bucket, message_id, author_id, content, version,
+  edited_at, is_deleted, deleted_at, deleted_by, created_at
+) VALUES (
+  910001, 20260221, 120105, 5004, 'lin291-m120105', 1,
+  null, false, null, null, '2026-02-21T10:00:04Z'
+) IF NOT EXISTS;
+
+INSERT INTO chat.messages_by_channel (
+  channel_id, bucket, message_id, author_id, content, version,
+  edited_at, is_deleted, deleted_at, deleted_by, created_at
+) VALUES (
+  910001, 20260221, 120102, 5005, 'lin291-m120102', 1,
+  null, false, null, null, '2026-02-21T10:00:02Z'
+) IF NOT EXISTS;
+
+INSERT INTO chat.messages_by_channel (
+  channel_id, bucket, message_id, author_id, content, version,
+  edited_at, is_deleted, deleted_at, deleted_by, created_at
+) VALUES (
+  910001, 20260221, 120100, 5006, 'lin291-m120100', 1,
+  null, false, null, null, '2026-02-21T10:00:02Z'
+) IF NOT EXISTS;
+
+INSERT INTO chat.messages_by_channel (
+  channel_id, bucket, message_id, author_id, content, version,
+  edited_at, is_deleted, deleted_at, deleted_by, created_at
+) VALUES (
+  910001, 20260221, 120099, 5007, 'lin291-m120099', 1,
+  null, false, null, null, '2026-02-21T10:00:01Z'
+) IF NOT EXISTS;
+
+-- [2] 重複試行（LIN-289 整合）
+-- 期待: [applied] = false（duplicate no-op）
+INSERT INTO chat.messages_by_channel (
+  channel_id, bucket, message_id, author_id, content, version,
+  edited_at, is_deleted, deleted_at, deleted_by, created_at
+) VALUES (
+  910001, 20260221, 120107, 5003, 'lin291-m120107', 1,
+  null, false, null, null, '2026-02-21T10:00:05Z'
+) IF NOT EXISTS;
+
+-- 期待: row_count = 7（重複で増えない）
+SELECT COUNT(*) AS row_count
+FROM chat.messages_by_channel
+WHERE channel_id = 910001
+  AND bucket = 20260221;
+
+-- [3] 欠番/並び確認
+-- 期待順: 120110,120108,120107,120105,120102,120100,120099
+SELECT message_id, created_at
+FROM chat.messages_by_channel
+WHERE channel_id = 910001
+  AND bucket = 20260221
+ORDER BY message_id DESC;
+
+-- [4] limit + 1 境界（LIN-288 整合）
+-- 想定クライアント limit=3 -> DB は limit_plus_one=4
+-- 期待: 4行取得（先頭3行を返却、4行目は nextCursor 判定用）
+SELECT message_id, created_at
+FROM chat.messages_by_channel
+WHERE channel_id = 910001
+  AND bucket = 20260221
+ORDER BY message_id DESC
+LIMIT 4;
+
+-- [5] 同一 timestamp 境界（forward / older）
+-- cursor=(2026-02-21T10:00:05Z, 120107)
+-- 同一 timestamp の 120108 は除外されることを確認する。
+-- 期待順: 120105,120102,120100,120099
+SELECT message_id, created_at
+FROM chat.messages_by_channel
+WHERE channel_id = 910001
+  AND bucket = 20260221
+  AND (created_at, message_id) < ('2026-02-21T10:00:05Z', 120107)
+ORDER BY message_id DESC
+LIMIT 4
+ALLOW FILTERING;
+
+-- [6] 同一 timestamp 境界（backward / newer）
+-- cursor=(2026-02-21T10:00:05Z, 120107)
+-- 期待順: 120108,120110（ASC）
+SELECT message_id, created_at
+FROM chat.messages_by_channel
+WHERE channel_id = 910001
+  AND bucket = 20260221
+  AND (created_at, message_id) > ('2026-02-21T10:00:05Z', 120107)
+ORDER BY message_id ASC
+LIMIT 4
+ALLOW FILTERING;
+
+-- [7] 最終ページ境界（余剰1件なし）
+-- cursor=(2026-02-21T10:00:02Z, 120100), limit_plus_one=4
+-- 期待: 120099 の1行のみ（nextCursor 非発行）
+SELECT message_id, created_at
+FROM chat.messages_by_channel
+WHERE channel_id = 910001
+  AND bucket = 20260221
+  AND (created_at, message_id) < ('2026-02-21T10:00:02Z', 120100)
+ORDER BY message_id DESC
+LIMIT 4
+ALLOW FILTERING;


### PR DESCRIPTION
## 概要

- Linear Issue: LIN-291
- Linear URL: https://linear.app/linklynx-ai/issue/LIN-291/db-%E5%B1%A5%E6%AD%B4%E5%A2%83%E7%95%8C%E3%82%B1%E3%83%BC%E3%82%B9%E5%90%91%E3%81%91db%E3%83%86%E3%82%B9%E3%83%88%E3%83%87%E3%83%BC%E3%82%BF%E6%95%B4%E5%82%99
- 同一timestamp・欠番・重複試行・limit境界を再現するDB検証資産を追加

## 実装内容（詳細）

- `database/scylla/testdata/lin291_history_edge_cases.cql` を追加
- `database/contracts/lin291_history_edge_case_verification.md` を追加
- LIN-288/LIN-289 契約との整合チェック手順を明文化

## テスト内容

- [x] static確認
  - `rg -n "120107|LIMIT 4|IF NOT EXISTS|ALLOW FILTERING|row_count" database/scylla/testdata/lin291_history_edge_cases.cql`
  - `rg -n '同一 `timestamp`|欠番|重複試行|limit 境界|LIN-288|LIN-289' database/contracts/lin291_history_edge_case_verification.md`
- [ ] `cqlsh -f database/scylla/testdata/lin291_history_edge_cases.cql`（ローカルに `cqlsh` がなく未実施）

## 懸念点

- `cqlsh` 実行可能環境での最終確認が未実施
