### PR TITLE
LIN-253 メール確認待ち/再送/完了UIを実装

### DIFF
--- a/typescript/src/app/(auth)/verify-email/complete/page.test.tsx
+++ b/typescript/src/app/(auth)/verify-email/complete/page.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import VerifyEmailCompletePage from "./page";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+async function renderVerifyEmailCompletePage(searchParams: SearchParams = {}): Promise<string> {
+  const page = await VerifyEmailCompletePage({ searchParams: Promise.resolve(searchParams) });
+  return renderToStaticMarkup(page);
+}
+
+describe("Verify email complete page", () => {
+  test("デフォルトで確認完了とログイン導線を表示する", async () => {
+    const html = await renderVerifyEmailCompletePage();
+
+    expect(html).toContain("確認完了");
+    expect(html).toContain("メール確認が完了しました");
+    expect(html).toContain("href=\"/login\"");
+    expect(html).toContain("href=\"/verify-email\"");
+  });
+
+  test("state=already-verified で確認済み表示を出す", async () => {
+    const html = await renderVerifyEmailCompletePage({ state: "already-verified" });
+
+    expect(html).toContain("確認済み");
+    expect(html).toContain("このメールはすでに確認済みです");
+  });
+
+  test("未知のstateは success にフォールバックする", async () => {
+    const html = await renderVerifyEmailCompletePage({ state: "unexpected" });
+
+    expect(html).toContain("確認完了");
+    expect(html).not.toContain("このメールはすでに確認済みです");
+  });
+});

--- a/typescript/src/app/(auth)/verify-email/complete/page.tsx
+++ b/typescript/src/app/(auth)/verify-email/complete/page.tsx
@@ -1,0 +1,12 @@
+import { VerifyEmailCompleteScreen, parseVerifyEmailCompleteState } from "@/features/auth-verify";
+
+type VerifyEmailCompletePageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function VerifyEmailCompletePage({ searchParams }: VerifyEmailCompletePageProps) {
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const state = parseVerifyEmailCompleteState(resolvedSearchParams);
+
+  return <VerifyEmailCompleteScreen state={state} />;
+}

--- a/typescript/src/app/(auth)/verify-email/page.test.tsx
+++ b/typescript/src/app/(auth)/verify-email/page.test.tsx
@@ -1,0 +1,52 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import VerifyEmailPage from "./page";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+async function renderVerifyEmailPage(searchParams: SearchParams = {}): Promise<string> {
+  const page = await VerifyEmailPage({ searchParams: Promise.resolve(searchParams) });
+  return renderToStaticMarkup(page);
+}
+
+describe("Verify email page", () => {
+  test("デフォルトで確認待ちと次アクション導線を表示する", async () => {
+    const html = await renderVerifyEmailPage();
+
+    expect(html).toContain("確認待ち");
+    expect(html).toContain("確認メールを送信しました");
+    expect(html).toContain("href=\"/verify-email?state=resent\"");
+    expect(html).toContain("href=\"/login\"");
+  });
+
+  test("state=resent で再送完了表示を出す", async () => {
+    const html = await renderVerifyEmailPage({ state: "resent" });
+
+    expect(html).toContain("再送完了");
+    expect(html).toContain("data-testid=\"verify-email-notice-resent\"");
+    expect(html).toContain("確認メールを再送しました。");
+  });
+
+  test("state=resend-error で再送失敗表示を出す", async () => {
+    const html = await renderVerifyEmailPage({ state: "resend-error" });
+
+    expect(html).toContain("再送失敗");
+    expect(html).toContain("data-testid=\"verify-email-notice-resend-error\"");
+    expect(html).toContain("確認メールの再送に失敗しました。");
+  });
+
+  test("state=expired で期限切れ表示を出す", async () => {
+    const html = await renderVerifyEmailPage({ state: "expired" });
+
+    expect(html).toContain("リンク期限切れ");
+    expect(html).toContain("確認リンクの有効期限が切れています");
+    expect(html).toContain("data-testid=\"verify-email-notice-expired\"");
+  });
+
+  test("未知のstateは waiting にフォールバックする", async () => {
+    const html = await renderVerifyEmailPage({ state: "unexpected" });
+
+    expect(html).toContain("確認待ち");
+    expect(html).not.toContain("再送失敗");
+  });
+});

--- a/typescript/src/app/(auth)/verify-email/page.tsx
+++ b/typescript/src/app/(auth)/verify-email/page.tsx
@@ -1,0 +1,12 @@
+import { VerifyEmailScreen, parseVerifyEmailState } from "@/features/auth-verify";
+
+type VerifyEmailPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function VerifyEmailPage({ searchParams }: VerifyEmailPageProps) {
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const state = parseVerifyEmailState(resolvedSearchParams);
+
+  return <VerifyEmailScreen state={state} />;
+}

--- a/typescript/src/features/auth-verify/index.tsx
+++ b/typescript/src/features/auth-verify/index.tsx
@@ -1,0 +1,265 @@
+import { z } from "zod";
+import { classNames } from "@/shared";
+
+export type AuthSearchParams = Record<string, string | string[] | undefined>;
+
+const verifyEmailStateSchema = z.enum(["waiting", "resent", "resend-error", "expired"]);
+const verifyEmailCompleteStateSchema = z.enum(["success", "already-verified"]);
+
+type StatusTone = "neutral" | "success" | "error" | "warning";
+type NoticeTone = "success" | "error" | "warning";
+
+type ActionLinkView = {
+  href: string;
+  label: string;
+};
+
+type StatusNoticeView = {
+  testId: string;
+  message: string;
+  tone: NoticeTone;
+};
+
+type AuthStatusView = {
+  eyebrow: string;
+  statusLabel: string;
+  statusTone: StatusTone;
+  title: string;
+  description: string;
+  primaryAction: ActionLinkView;
+  secondaryAction: ActionLinkView;
+  footnote: string;
+  notice?: StatusNoticeView;
+};
+
+export type VerifyEmailState = z.infer<typeof verifyEmailStateSchema>;
+export type VerifyEmailCompleteState = z.infer<typeof verifyEmailCompleteStateSchema>;
+
+function readStateParam(searchParams: AuthSearchParams): string | undefined {
+  const { state } = searchParams;
+  if (Array.isArray(state)) {
+    return state[0];
+  }
+  return state;
+}
+
+function resolveStatusToneClassName(tone: StatusTone): string {
+  switch (tone) {
+    case "success":
+      return "border-emerald-300/35 bg-emerald-400/10 text-emerald-100";
+    case "error":
+      return "border-discord-red/60 bg-discord-red/10 text-discord-red";
+    case "warning":
+      return "border-amber-300/40 bg-amber-400/10 text-amber-100";
+    case "neutral":
+      return "border-white/20 bg-white/10 text-white/85";
+  }
+}
+
+function resolveNoticeToneClassName(tone: NoticeTone): string {
+  switch (tone) {
+    case "success":
+      return "border-emerald-300/40 bg-emerald-400/10 text-emerald-100";
+    case "error":
+      return "border-discord-red/70 bg-discord-red/10 text-discord-red";
+    case "warning":
+      return "border-amber-300/40 bg-amber-400/10 text-amber-100";
+  }
+}
+
+function createVerifyEmailView(state: VerifyEmailState): AuthStatusView {
+  const baseView: AuthStatusView = {
+    eyebrow: "Email Verification",
+    statusLabel: "確認待ち",
+    statusTone: "neutral",
+    title: "確認メールを送信しました",
+    description:
+      "登録したメールアドレスに確認リンクを送信しました。メール内のリンクを開いて認証を完了してください。",
+    primaryAction: {
+      href: "/verify-email?state=resent",
+      label: "確認メールを再送する",
+    },
+    secondaryAction: {
+      href: "/login",
+      label: "ログインへ戻る",
+    },
+    footnote: "メールが見つからない場合は迷惑メールフォルダも確認してください。",
+  };
+
+  switch (state) {
+    case "waiting":
+      return baseView;
+    case "resent":
+      return {
+        ...baseView,
+        statusLabel: "再送完了",
+        statusTone: "success",
+        primaryAction: {
+          href: "/verify-email?state=resent",
+          label: "確認メールをもう一度再送する",
+        },
+        notice: {
+          testId: "verify-email-notice-resent",
+          message: "確認メールを再送しました。受信トレイをご確認ください。",
+          tone: "success",
+        },
+      };
+    case "resend-error":
+      return {
+        ...baseView,
+        statusLabel: "再送失敗",
+        statusTone: "error",
+        title: "確認メールを再送できませんでした",
+        description: "ネットワーク状況を確認して、時間をおいてもう一度再送してください。",
+        notice: {
+          testId: "verify-email-notice-resend-error",
+          message: "確認メールの再送に失敗しました。再試行してください。",
+          tone: "error",
+        },
+      };
+    case "expired":
+      return {
+        ...baseView,
+        statusLabel: "リンク期限切れ",
+        statusTone: "warning",
+        title: "確認リンクの有効期限が切れています",
+        description: "新しい確認メールを再送して、届いた最新リンクから再度アクセスしてください。",
+        primaryAction: {
+          href: "/verify-email?state=resent",
+          label: "新しい確認メールを再送する",
+        },
+        notice: {
+          testId: "verify-email-notice-expired",
+          message: "以前の確認リンクは利用できません。新しいリンクを発行してください。",
+          tone: "warning",
+        },
+      };
+  }
+}
+
+function createVerifyEmailCompleteView(state: VerifyEmailCompleteState): AuthStatusView {
+  const baseView: AuthStatusView = {
+    eyebrow: "Verification Complete",
+    statusLabel: "確認完了",
+    statusTone: "success",
+    title: "メール確認が完了しました",
+    description: "アカウントの有効化が完了しました。ログインして LinkLynx を利用開始できます。",
+    primaryAction: {
+      href: "/login",
+      label: "ログインへ進む",
+    },
+    secondaryAction: {
+      href: "/verify-email",
+      label: "確認メール画面に戻る",
+    },
+    footnote: "ログイン後は通常どおりワークスペースへ参加できます。",
+  };
+
+  if (state === "already-verified") {
+    return {
+      ...baseView,
+      statusLabel: "確認済み",
+      title: "このメールはすでに確認済みです",
+      description: "同じメールアドレスでそのままログインできます。",
+      footnote: "ログインに失敗する場合は、パスワード再設定をお試しください。",
+    };
+  }
+
+  return baseView;
+}
+
+function AuthStatusCard({ view }: { view: AuthStatusView }) {
+  return (
+    <section className="w-full rounded-2xl border border-white/10 bg-discord-darker/95 p-6 shadow-2xl sm:p-8">
+      <header className="space-y-3 text-center">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-white/55">{view.eyebrow}</p>
+        <p
+          className={classNames(
+            "mx-auto inline-flex rounded-full border px-3 py-1 text-xs font-semibold",
+            resolveStatusToneClassName(view.statusTone)
+          )}
+        >
+          {view.statusLabel}
+        </p>
+        <h1 className="text-2xl font-bold text-white">{view.title}</h1>
+        <p className="text-sm text-white/70">{view.description}</p>
+      </header>
+
+      {view.notice ? (
+        <p
+          data-testid={view.notice.testId}
+          role="alert"
+          className={classNames(
+            "mt-5 rounded-md border px-3 py-2 text-sm",
+            resolveNoticeToneClassName(view.notice.tone)
+          )}
+        >
+          {view.notice.message}
+        </p>
+      ) : null}
+
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+        <a
+          href={view.primaryAction.href}
+          className="inline-flex items-center justify-center rounded-md bg-discord-primary px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-[#4752c4]"
+        >
+          {view.primaryAction.label}
+        </a>
+        <a
+          href={view.secondaryAction.href}
+          className="inline-flex items-center justify-center rounded-md border border-white/20 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-white/10"
+        >
+          {view.secondaryAction.label}
+        </a>
+      </div>
+
+      <p className="mt-4 text-xs text-white/60">{view.footnote}</p>
+    </section>
+  );
+}
+
+/**
+ * `/verify-email` の state クエリを解釈する。
+ *
+ * Contract:
+ * - 許可値は `waiting|resent|resend-error|expired`
+ * - 未知の値は `waiting` にフォールバックする
+ */
+export function parseVerifyEmailState(searchParams: AuthSearchParams): VerifyEmailState {
+  return verifyEmailStateSchema.catch("waiting").parse(readStateParam(searchParams));
+}
+
+/**
+ * `/verify-email/complete` の state クエリを解釈する。
+ *
+ * Contract:
+ * - 許可値は `success|already-verified`
+ * - 未知の値は `success` にフォールバックする
+ */
+export function parseVerifyEmailCompleteState(
+  searchParams: AuthSearchParams
+): VerifyEmailCompleteState {
+  return verifyEmailCompleteStateSchema.catch("success").parse(readStateParam(searchParams));
+}
+
+/**
+ * メール確認待ち・再送関連のUIを描画する。
+ *
+ * Contract:
+ * - stateに応じて waiting/resend/error/expired の表示のみを担当する
+ * - メール再送処理や検証処理は実行しない
+ */
+export function VerifyEmailScreen({ state }: { state: VerifyEmailState }) {
+  return <AuthStatusCard view={createVerifyEmailView(state)} />;
+}
+
+/**
+ * メール確認完了画面のUIを描画する。
+ *
+ * Contract:
+ * - stateに応じて success/already-verified を表示する
+ * - 画面内で次アクション導線を提供する
+ */
+export function VerifyEmailCompleteScreen({ state }: { state: VerifyEmailCompleteState }) {
+  return <AuthStatusCard view={createVerifyEmailCompleteView(state)} />;
+}


### PR DESCRIPTION
## 概要
- `/verify-email` と `/verify-email/complete` のUIを追加
- `state` クエリ（waiting/resent/resend-error/expired, success/already-verified）で表示切替
- 再送・ログイン戻りなど次アクション導線を画面内に明示

## 変更内容
- `src/features/auth-verify/index.tsx` を新規作成し、stateパースと表示コンポーネントを実装
- `src/app/(auth)/verify-email/page.tsx` を追加
- `src/app/(auth)/verify-email/complete/page.tsx` を追加
- `src/app/(auth)/verify-email/page.test.tsx` を追加
- `src/app/(auth)/verify-email/complete/page.test.tsx` を追加

## 非対象
- メール送信・トークン検証などのAPI/バックエンド処理
- LIN-238系のガード処理

## テスト
- `npm run lint`
- `npm run typecheck`
- `npm run test`
