### PR TITLE
feat: LIN-239 channels配下にアプリシェル統合を追加

### DIFF
--- a/typescript/src/app/channels/@me/page.tsx
+++ b/typescript/src/app/channels/@me/page.tsx
@@ -1,0 +1,8 @@
+export default function ChannelsMePage() {
+  return (
+    <section aria-label="channels-me-placeholder" className="space-y-2">
+      <h1 className="text-lg font-semibold text-white">ダイレクトメッセージ</h1>
+      <p className="text-sm text-white/70">LIN-239: /channels/@me プレースホルダー</p>
+    </section>
+  );
+}

--- a/typescript/src/app/channels/layout.test.tsx
+++ b/typescript/src/app/channels/layout.test.tsx
@@ -1,0 +1,28 @@
+/** @vitest-environment happy-dom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import ChannelsMePage from "./@me/page";
+import ChannelsLayout from "./layout";
+
+describe("Channels layout", () => {
+  test("アプリシェル統合と右パネル開閉を描画できる", () => {
+    render(
+      <ChannelsLayout me={<ChannelsMePage />}>
+        <p>fallback child content</p>
+      </ChannelsLayout>
+    );
+
+    expect(screen.getByRole("navigation", { name: "app-shell-server-rail" })).toBeTruthy();
+    expect(screen.getByLabelText("app-shell-list")).toBeTruthy();
+    expect(screen.getByLabelText("chat-header")).toBeTruthy();
+    expect(screen.getByText("LIN-239: /channels/@me プレースホルダー")).toBeTruthy();
+    expect(screen.getByLabelText("member-panel")).toBeTruthy();
+
+    const toggleButton = screen.getByRole("button", { name: "メンバーパネルを開閉" });
+    fireEvent.click(toggleButton);
+
+    expect(toggleButton.getAttribute("aria-pressed")).toBe("false");
+    expect(screen.queryByLabelText("member-panel")).toBeNull();
+  });
+});

--- a/typescript/src/app/channels/layout.tsx
+++ b/typescript/src/app/channels/layout.tsx
@@ -1,0 +1,10 @@
+import { ChannelsShell } from "@/widgets/channels-shell";
+
+type ChannelsLayoutProps = Readonly<{
+  children: React.ReactNode;
+  me: React.ReactNode;
+}>;
+
+export default function ChannelsLayout({ children, me }: ChannelsLayoutProps) {
+  return <ChannelsShell>{me ?? children}</ChannelsShell>;
+}

--- a/typescript/src/widgets/channels-shell/index.tsx
+++ b/typescript/src/widgets/channels-shell/index.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import type { MemberSummary } from "@/entities";
+import { AppShellFrame } from "@/widgets/app-shell";
+import { ChannelList, type ChannelListItem } from "@/widgets/channel-list";
+import { ChatHeader } from "@/widgets/chat-header";
+import { MemberPanel } from "@/widgets/member-panel";
+import { ServerRail, type ServerRailItem } from "@/widgets/server-rail";
+
+type ChannelsShellProps = {
+  children: ReactNode;
+};
+
+const serverRailItems: ServerRailItem[] = [
+  {
+    id: "home",
+    label: "Home",
+    iconLabel: "LL",
+    isSelected: true,
+  },
+  {
+    id: "design",
+    label: "Design",
+    iconLabel: "DS",
+    hasUnread: true,
+    mentionCount: 2,
+  },
+  {
+    id: "product",
+    label: "Product",
+    iconLabel: "PD",
+  },
+];
+
+const channelListItems: ChannelListItem[] = [
+  {
+    id: "general",
+    label: "general",
+    isSelected: true,
+  },
+  {
+    id: "design-review",
+    label: "design-review",
+    hasUnread: true,
+    mentionCount: 1,
+  },
+  {
+    id: "bot-updates",
+    label: "bot-updates",
+  },
+];
+
+const memberPanelItems: MemberSummary[] = [
+  {
+    id: "member-1",
+    displayName: "LinkLynx Bot",
+    statusLabel: "Online",
+    avatarLabel: "LB",
+  },
+  {
+    id: "member-2",
+    displayName: "Design Reviewer",
+    statusLabel: "Away",
+    avatarLabel: "DR",
+  },
+];
+
+/**
+ * channels配下で利用するアプリシェル骨格を描画する。
+ *
+ * Contract:
+ * - 右サイドパネルの開閉状態は本コンポーネントで管理する
+ * - 会話本文は `children` として注入する
+ */
+export function ChannelsShell({ children }: ChannelsShellProps) {
+  const [isMemberPanelOpen, setIsMemberPanelOpen] = useState(true);
+
+  const rightPanelProps = isMemberPanelOpen
+    ? {
+        isRightPanelOpen: true as const,
+        rightPanelSlot: <MemberPanel members={memberPanelItems} title="Members" />,
+      }
+    : {
+        isRightPanelOpen: false as const,
+      };
+
+  return (
+    <AppShellFrame
+      serverRailSlot={<ServerRail ariaLabel="Servers" items={serverRailItems} />}
+      listSlot={<ChannelList ariaLabel="Channel list" items={channelListItems} title="Channels" />}
+      mainSlot={
+        <section className="flex min-h-0 flex-1 flex-col gap-4" data-testid="channels-shell-main">
+          <ChatHeader
+            isMemberPanelOpen={isMemberPanelOpen}
+            onToggleMemberPanel={() => setIsMemberPanelOpen((current) => !current)}
+            subtitle="DM"
+            title="Direct Messages"
+          />
+          <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-white/10 bg-discord-dark/30 p-4">
+            {children}
+          </div>
+        </section>
+      }
+      {...rightPanelProps}
+    />
+  );
+}


### PR DESCRIPTION
## 概要
- `channels` 配下にアプリシェル統合用の `ChannelsShell` を追加し、Wave 1で実装済みの widgets を接続しました。
- `app/channels/layout.tsx` を追加し、`@me` スロットを優先して描画するレイアウトを実装しました。
- `app/channels/@me/page.tsx` に最小プレースホルダを追加しました。
- `app/channels/layout.test.tsx` でシェル描画とメンバーパネルトグル（`aria-pressed`）を検証しました。

## 変更ファイル
- `typescript/src/widgets/channels-shell/index.tsx`
- `typescript/src/app/channels/layout.tsx`
- `typescript/src/app/channels/@me/page.tsx`
- `typescript/src/app/channels/layout.test.tsx`

## テスト
- `cd typescript && npm run lint`
- `cd typescript && npm run test`
- `cd typescript && npm run build`

## 関連Issue
- LIN-239
