### PR TITLE
LIN-554: apply channel_reads monotonic upsert contract

### DIFF
--- a/rust/src/channel_reads.rs
+++ b/rust/src/channel_reads.rs
@@ -1,0 +1,85 @@
+use serde::{Deserialize, Serialize};
+use sqlx::{postgres::PgPool, Executor, Postgres};
+use thiserror::Error;
+
+const CHANNEL_READS_UPSERT_SQL: &str =
+    include_str!("../../database/postgres/channel_reads_upsert.sql");
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ChannelReadUpsertInput {
+    pub channel_id: i64,
+    pub user_id: i64,
+    pub last_read_message_id: Option<i64>,
+    pub last_client_seq: Option<i64>,
+}
+
+#[derive(Debug, Error)]
+pub enum ChannelReadsError {
+    #[error("database connection is not configured")]
+    DbUnavailable,
+    #[error("database query failed: {0}")]
+    Query(#[from] sqlx::Error),
+}
+
+#[derive(Clone)]
+pub struct ChannelReadsRepository {
+    pool: Option<PgPool>,
+}
+
+impl ChannelReadsRepository {
+    pub fn new(pool: Option<PgPool>) -> Self {
+        Self { pool }
+    }
+
+    pub async fn upsert(
+        &self,
+        input: &ChannelReadUpsertInput,
+    ) -> Result<(), ChannelReadsError> {
+        let pool = self.pool.as_ref().ok_or(ChannelReadsError::DbUnavailable)?;
+        self.upsert_with_executor(pool, input).await
+    }
+
+    pub async fn upsert_with_executor<'e, E>(
+        &self,
+        exec: E,
+        input: &ChannelReadUpsertInput,
+    ) -> Result<(), ChannelReadsError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query(CHANNEL_READS_UPSERT_SQL)
+            .bind(input.channel_id)
+            .bind(input.user_id)
+            .bind(input.last_read_message_id)
+            .bind(input.last_client_seq)
+            .execute(exec)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_input_payload() {
+        let payload = r#"{
+          "channel_id": 10,
+          "user_id": 20,
+          "last_read_message_id": 120,
+          "last_client_seq": 8
+        }"#;
+
+        let parsed: ChannelReadUpsertInput = serde_json::from_str(payload).unwrap();
+        assert_eq!(
+            parsed,
+            ChannelReadUpsertInput {
+                channel_id: 10,
+                user_id: 20,
+                last_read_message_id: Some(120),
+                last_client_seq: Some(8),
+            }
+        );
+    }
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,12 +1,27 @@
 use axum::{
+    extract::State,
     extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    http::StatusCode,
+    response::Json,
     response::IntoResponse,
+    routing::post,
     routing::get,
     Router,
 };
+use channel_reads::{ChannelReadUpsertInput, ChannelReadsError, ChannelReadsRepository};
+use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgPoolOptions;
 use std::net::SocketAddr;
+use std::time::Duration;
 use tower_http::cors::{Any, CorsLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+mod channel_reads;
+
+#[derive(Clone)]
+struct AppState {
+    channel_reads_repo: ChannelReadsRepository,
+}
 
 #[tokio::main]
 async fn main() {
@@ -18,7 +33,21 @@ async fn main() {
         )
         .init();
 
-    let app = app();
+    let db_pool = std::env::var("DATABASE_URL")
+        .ok()
+        .and_then(|database_url| {
+            PgPoolOptions::new()
+                .acquire_timeout(Duration::from_secs(3))
+                .max_connections(5)
+                .connect_lazy(&database_url)
+                .ok()
+        });
+
+    let state = AppState {
+        channel_reads_repo: ChannelReadsRepository::new(db_pool),
+    };
+
+    let app = app(state);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
     tracing::info!("Server running on {}", addr);
@@ -35,7 +64,7 @@ async fn health_check() -> &'static str {
     "OK"
 }
 
-fn app() -> Router {
+fn app(state: AppState) -> Router {
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_methods(Any)
@@ -45,7 +74,43 @@ fn app() -> Router {
         .route("/", get(root))
         .route("/health", get(health_check))
         .route("/ws", get(ws_handler))
+        .route("/internal/channel-reads", post(upsert_channel_reads))
+        .with_state(state)
         .layer(cors)
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
+async fn upsert_channel_reads(
+    State(state): State<AppState>,
+    Json(input): Json<ChannelReadUpsertInput>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorBody>)> {
+    state
+        .channel_reads_repo
+        .upsert(&input)
+        .await
+        .map_err(map_channel_reads_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn map_channel_reads_error(err: ChannelReadsError) -> (StatusCode, Json<ErrorBody>) {
+    match err {
+        ChannelReadsError::DbUnavailable => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorBody {
+                error: "database is unavailable".to_string(),
+            }),
+        ),
+        ChannelReadsError::Query(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorBody {
+                error: "database query failed".to_string(),
+            }),
+        ),
+    }
 }
 
 async fn ws_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
@@ -71,18 +136,22 @@ async fn handle_socket(mut socket: WebSocket) {
 
 #[cfg(test)]
 mod tests {
-    use super::app;
+    use super::{app, AppState, ErrorBody};
     use axum::{
         body::{to_bytes, Body},
         http::{Request, StatusCode},
     };
+    use crate::channel_reads::ChannelReadsRepository;
+    use serde_json::json;
     use tower::ServiceExt;
 
     const MAX_RESPONSE_BYTES: usize = 16 * 1024;
 
     #[tokio::test]
     async fn root_returns_server_name() {
-        let app = app();
+        let app = app(AppState {
+            channel_reads_repo: ChannelReadsRepository::new(None),
+        });
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
             .await
@@ -97,7 +166,9 @@ mod tests {
 
     #[tokio::test]
     async fn health_returns_ok() {
-        let app = app();
+        let app = app(AppState {
+            channel_reads_repo: ChannelReadsRepository::new(None),
+        });
         let response = app
             .oneshot(
                 Request::builder()
@@ -113,5 +184,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(body.as_ref(), b"OK");
+    }
+
+    #[tokio::test]
+    async fn channel_reads_requires_database() {
+        let app = app(AppState {
+            channel_reads_repo: ChannelReadsRepository::new(None),
+        });
+        let payload = json!({
+          "channel_id": 10,
+          "user_id": 20,
+          "last_read_message_id": 120,
+          "last_client_seq": 8
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/internal/channel-reads")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let parsed: ErrorBody = serde_json::from_slice(body.as_ref()).unwrap();
+        assert_eq!(parsed.error, "database is unavailable".to_string());
     }
 }


### PR DESCRIPTION
## Summary
- add Rust repository that executes channel_reads_upsert.sql
- expose /internal/channel-reads endpoint to apply monotonic upsert from app code
- return explicit errors when database is unavailable or query fails
- add tests for payload parsing and endpoint behavior

## Verification
- cargo test (rust)