### PR TITLE
LIN-131: DB-only runtime helper migrations for reads/outbox

### DIFF
--- a/database/contracts/lin292_db_runtime_helpers_contract.md
+++ b/database/contracts/lin292_db_runtime_helpers_contract.md
@@ -1,0 +1,45 @@
+# LIN-292 DB Runtime Helpers Contract
+
+## 目的
+
+アプリ実装差分に依存せず、DB側で以下の実行契約を固定する。
+
+- `channel_reads` の単調増加更新（逆行更新の防止）
+- `outbox_events` の claim / sent / failed の状態遷移
+
+## 追加関数
+
+### `upsert_channel_reads_monotonic(...)`
+
+- 対象: `channel_reads`
+- 仕様:
+  - `ON CONFLICT (channel_id, user_id)` で upsert
+  - `last_read_message_id` / `last_client_seq` は `GREATEST` による単調増加
+  - `NULL` 入力時は既存値を保持
+
+### `claim_outbox_events(p_limit, p_lease_seconds)`
+
+- 対象: `outbox_events`
+- 仕様:
+  - claim対象:
+    - `status='PENDING'` かつ `next_retry_at IS NULL OR <= now()`
+    - `status='FAILED'` かつ `next_retry_at <= now()`
+  - `FOR UPDATE SKIP LOCKED` で競合回避
+  - claim時に `next_retry_at = now() + lease` を設定
+
+### `mark_outbox_event_sent(p_id)`
+
+- 対象イベントを `SENT` へ遷移
+- `next_retry_at = NULL`
+
+### `mark_outbox_event_failed(p_id, p_retry_seconds)`
+
+- 対象イベントを `FAILED` へ遷移
+- `attempts = attempts + 1`
+- `next_retry_at = now() + retry_seconds`
+
+## 関連ファイル
+
+- migration up: `database/postgres/migrations/0004_lin131_db_runtime_helpers.up.sql`
+- migration down: `database/postgres/migrations/0004_lin131_db_runtime_helpers.down.sql`
+- schema snapshot: `database/postgres/schema.sql`

--- a/database/postgres/migrations/0004_lin131_db_runtime_helpers.down.sql
+++ b/database/postgres/migrations/0004_lin131_db_runtime_helpers.down.sql
@@ -1,0 +1,4 @@
+DROP FUNCTION IF EXISTS mark_outbox_event_failed(BIGINT, INTEGER);
+DROP FUNCTION IF EXISTS mark_outbox_event_sent(BIGINT);
+DROP FUNCTION IF EXISTS claim_outbox_events(INTEGER, INTEGER);
+DROP FUNCTION IF EXISTS upsert_channel_reads_monotonic(BIGINT, BIGINT, BIGINT, BIGINT);

--- a/database/postgres/migrations/0004_lin131_db_runtime_helpers.up.sql
+++ b/database/postgres/migrations/0004_lin131_db_runtime_helpers.up.sql
@@ -1,0 +1,104 @@
+CREATE OR REPLACE FUNCTION upsert_channel_reads_monotonic(
+  p_channel_id BIGINT,
+  p_user_id BIGINT,
+  p_last_read_message_id BIGINT,
+  p_last_client_seq BIGINT
+)
+RETURNS VOID
+LANGUAGE sql
+AS $$
+INSERT INTO channel_reads (
+  channel_id,
+  user_id,
+  last_read_message_id,
+  last_client_seq,
+  updated_at
+)
+VALUES (
+  p_channel_id,
+  p_user_id,
+  p_last_read_message_id,
+  p_last_client_seq,
+  now()
+)
+ON CONFLICT (channel_id, user_id)
+DO UPDATE
+SET
+  last_read_message_id = CASE
+    WHEN channel_reads.last_read_message_id IS NULL THEN EXCLUDED.last_read_message_id
+    WHEN EXCLUDED.last_read_message_id IS NULL THEN channel_reads.last_read_message_id
+    ELSE GREATEST(channel_reads.last_read_message_id, EXCLUDED.last_read_message_id)
+  END,
+  last_client_seq = CASE
+    WHEN channel_reads.last_client_seq IS NULL THEN EXCLUDED.last_client_seq
+    WHEN EXCLUDED.last_client_seq IS NULL THEN channel_reads.last_client_seq
+    ELSE GREATEST(channel_reads.last_client_seq, EXCLUDED.last_client_seq)
+  END,
+  updated_at = now();
+$$;
+
+CREATE OR REPLACE FUNCTION claim_outbox_events(
+  p_limit INTEGER DEFAULT 50,
+  p_lease_seconds INTEGER DEFAULT 30
+)
+RETURNS TABLE (
+  id BIGINT,
+  event_type TEXT,
+  aggregate_id TEXT,
+  payload JSONB
+)
+LANGUAGE sql
+AS $$
+WITH pending AS (
+  SELECT outbox_events.id
+  FROM outbox_events
+  WHERE (
+    status = 'PENDING'
+    AND (next_retry_at IS NULL OR next_retry_at <= now())
+  ) OR (
+    status = 'FAILED'
+    AND next_retry_at IS NOT NULL
+    AND next_retry_at <= now()
+  )
+  ORDER BY created_at
+  LIMIT p_limit
+  FOR UPDATE SKIP LOCKED
+)
+UPDATE outbox_events o
+SET
+  next_retry_at = now() + make_interval(secs => p_lease_seconds),
+  updated_at = now()
+FROM pending
+WHERE o.id = pending.id
+RETURNING o.id, o.event_type, o.aggregate_id, o.payload;
+$$;
+
+CREATE OR REPLACE FUNCTION mark_outbox_event_sent(
+  p_id BIGINT
+)
+RETURNS VOID
+LANGUAGE sql
+AS $$
+UPDATE outbox_events
+SET
+  status = 'SENT',
+  next_retry_at = NULL,
+  updated_at = now()
+WHERE id = p_id;
+$$;
+
+CREATE OR REPLACE FUNCTION mark_outbox_event_failed(
+  p_id BIGINT,
+  p_retry_seconds INTEGER DEFAULT 15
+)
+RETURNS VOID
+LANGUAGE sql
+AS $$
+UPDATE outbox_events
+SET
+  status = 'FAILED',
+  attempts = attempts + 1,
+  next_retry_at = now() + make_interval(secs => p_retry_seconds),
+  updated_at = now()
+WHERE id = p_id;
+$$;

--- a/database/postgres/schema.sql
+++ b/database/postgres/schema.sql
@@ -82,6 +82,93 @@ END;
 $$;
 
 
+CREATE FUNCTION public.upsert_channel_reads_monotonic(p_channel_id bigint, p_user_id bigint, p_last_read_message_id bigint, p_last_client_seq bigint) RETURNS void
+    LANGUAGE sql
+    AS $$
+INSERT INTO channel_reads (
+  channel_id,
+  user_id,
+  last_read_message_id,
+  last_client_seq,
+  updated_at
+)
+VALUES (
+  p_channel_id,
+  p_user_id,
+  p_last_read_message_id,
+  p_last_client_seq,
+  now()
+)
+ON CONFLICT (channel_id, user_id)
+DO UPDATE
+SET
+  last_read_message_id = CASE
+    WHEN channel_reads.last_read_message_id IS NULL THEN EXCLUDED.last_read_message_id
+    WHEN EXCLUDED.last_read_message_id IS NULL THEN channel_reads.last_read_message_id
+    ELSE GREATEST(channel_reads.last_read_message_id, EXCLUDED.last_read_message_id)
+  END,
+  last_client_seq = CASE
+    WHEN channel_reads.last_client_seq IS NULL THEN EXCLUDED.last_client_seq
+    WHEN EXCLUDED.last_client_seq IS NULL THEN channel_reads.last_client_seq
+    ELSE GREATEST(channel_reads.last_client_seq, EXCLUDED.last_client_seq)
+  END,
+  updated_at = now();
+$$;
+
+
+CREATE FUNCTION public.claim_outbox_events(p_limit integer DEFAULT 50, p_lease_seconds integer DEFAULT 30) RETURNS TABLE(id bigint, event_type text, aggregate_id text, payload jsonb)
+    LANGUAGE sql
+    AS $$
+WITH pending AS (
+  SELECT outbox_events.id
+  FROM outbox_events
+  WHERE (
+    status = 'PENDING'
+    AND (next_retry_at IS NULL OR next_retry_at <= now())
+  ) OR (
+    status = 'FAILED'
+    AND next_retry_at IS NOT NULL
+    AND next_retry_at <= now()
+  )
+  ORDER BY created_at
+  LIMIT p_limit
+  FOR UPDATE SKIP LOCKED
+)
+UPDATE outbox_events o
+SET
+  next_retry_at = now() + make_interval(secs => p_lease_seconds),
+  updated_at = now()
+FROM pending
+WHERE o.id = pending.id
+RETURNING o.id, o.event_type, o.aggregate_id, o.payload;
+$$;
+
+
+CREATE FUNCTION public.mark_outbox_event_sent(p_id bigint) RETURNS void
+    LANGUAGE sql
+    AS $$
+UPDATE outbox_events
+SET
+  status = 'SENT',
+  next_retry_at = NULL,
+  updated_at = now()
+WHERE id = p_id;
+$$;
+
+
+CREATE FUNCTION public.mark_outbox_event_failed(p_id bigint, p_retry_seconds integer DEFAULT 15) RETURNS void
+    LANGUAGE sql
+    AS $$
+UPDATE outbox_events
+SET
+  status = 'FAILED',
+  attempts = attempts + 1,
+  next_retry_at = now() + make_interval(secs => p_retry_seconds),
+  updated_at = now()
+WHERE id = p_id;
+$$;
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -568,7 +655,6 @@ ALTER TABLE ONLY public.invites
 
 ALTER TABLE ONLY public.password_reset_tokens
     ADD CONSTRAINT password_reset_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
-
 
 
 


### PR DESCRIPTION
## Summary
DB-only remake PR.

- add migration 0004_lin131_db_runtime_helpers (up/down)
  - upsert_channel_reads_monotonic(...)
  - claim_outbox_events(...)
  - mark_outbox_event_sent(...)
  - mark_outbox_event_failed(...)
- sync database/postgres/schema.sql snapshot with new function definitions
- add contract doc database/contracts/lin292_db_runtime_helpers_contract.md

## Notes
- This PR intentionally excludes Rust/API implementation changes.
- Migration apply command could not be executed in this environment because Docker daemon is not running.

## Validation attempted
- make db-up && make db-migrate && make db-migrate-info (failed: Docker daemon unavailable)
