### PR TITLE
ci(rust): PRでfmt/clippy/testを必須化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
       - run: npm install
       - run: npm run build
 
-  rust-test:
-    name: Rust Test
+  rust-validate:
+    name: Rust Validate
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -66,18 +66,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-      - run: cargo test
-
-  rust-build:
-    name: Rust Build
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: rust
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: rust
-      - run: cargo build --release
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - run: cargo test --workspace

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -13,8 +13,7 @@ async fn main() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer())
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".into()),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
         )
         .init();
 


### PR DESCRIPTION
Rust CIをPR品質ゲートとして整備しました。Rustジョブをrust-validateに統合し、fmt check、clippy、testを実行します。main.rsのフォーマット差分を1箇所修正しています。Related: LIN-561