### PR TITLE
ci: Claude自動レビュー指示を現行言語構成に合わせて修正

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,12 +35,14 @@ jobs:
             - Security implications
             - Test coverage requirements
             - Documentation updates if needed
-            - Architecture compliance (Clean Architecture for Go, FSD for TypeScript-v2)
+            - Architecture compliance based on the target service conventions
 
             For multi-service projects, check these CLAUDE.md files as applicable:
             - /CLAUDE.md (root project guidelines)
-            - /go/CLAUDE.md (Go backend guidelines)
-            - /typescript-v2/CLAUDE.md (TypeScript-v2 frontend guidelines)
+            - /rust/CLAUDE.md (Rust service guidelines)
+            - /typescript/CLAUDE.md (TypeScript service guidelines)
+            - /python/CLAUDE.md (Python service guidelines)
+            - /elixir/CLAUDE.md (Elixir service guidelines)
 
             Additionally, review the QA items listed at the end of the pull request description (dev環境でのQA項目):
             - Verify that the QA checklist is comprehensive and covers all necessary testing scenarios


### PR DESCRIPTION
## 概要\n- Claude Auto Review の direct_prompt から存在しない言語/構成前提の記述を削除\n- Architecture compliance の指示を Go/TypeScript-v2 固定から汎用表現に変更\n- multi-service 向け参照先を現行ディレクトリ構成（rust/typescript/python/elixir）に更新\n\n## 背景\n- 現在のワークフローには go / typescript-v2 前提の記載があり、実際のリポジトリ構成と不一致だったため\n\n## 変更ファイル\n- .github/workflows/claude-review.yml