### PR TITLE
Add Codexワークツリー作成コマンド

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help setup setup-check dev build up down logs clean test
 .PHONY: ts-dev ts-build ts-lint ts-test ts-prisma-generate ts-prisma-migrate ts-prisma-check rust-dev rust-build rust-test rust-fmt rust-clippy rust-lint rust-ci py-dev py-test elixir-dev elixir-build
-.PHONY: db-up db-down db-reset db-migrate db-migrate-revert db-migrate-info db-schema db-schema-check worktree-sync-env
+.PHONY: db-up db-down db-reset db-migrate db-migrate-revert db-migrate-info db-schema db-schema-check worktree-sync-env codex-worktree
 
 # 色設定
 GREEN  := \033[0;32m
@@ -35,6 +35,13 @@ setup-check: ## 環境構築状況を確認
 
 worktree-sync-env: ## 現在のworktreeへ.envファイルを自動検出元からコピー
 	@./setup/create-worktree-with-env.sh
+
+codex-worktree: ## 新規worktreeを作成しCodex CLIを起動 (例: make codex-worktree NAME=lin-300 BASE=origin/main)
+	@if [ -z "$(NAME)" ]; then \
+		echo "$(RED)NAME を指定してください。例: make codex-worktree NAME=lin-300$(NC)"; \
+		exit 1; \
+	fi
+	@./setup/create-worktree-and-codex.sh "$(NAME)" $(if $(BASE),--base $(BASE),)
 
 # ============================================
 # Docker コマンド

--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ make dev
 | Python (FastAPI) | http://localhost:8000 | Pythonサービス |
 | Elixir | http://localhost:4000 | Elixirサービス |
 
+## Codex CLI で新規 worktree を開始
+
+```bash
+# codex/lin-300 ブランチを作成し、worktreeで Codex CLI を起動
+make codex-worktree NAME=lin-300
+
+# ベースブランチを明示する場合
+make codex-worktree NAME=lin-300 BASE=origin/main
+```
+
+- 実体スクリプト: `setup/create-worktree-and-codex.sh`
+- 既存の `setup/create-worktree-with-env.sh` を利用して `.env*` も同期します。
+
 ## プロジェクト構成
 
 ```
@@ -224,6 +237,7 @@ make help           # ヘルプを表示
 # セットアップ
 make setup          # 全環境を自動セットアップ
 make setup-check    # 環境構築状況を確認
+make codex-worktree NAME=lin-300 # 新規worktree作成 + Codex CLI起動
 
 # Docker
 make up             # 全サービスを起動

--- a/setup/create-worktree-and-codex.sh
+++ b/setup/create-worktree-and-codex.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./setup/create-worktree-and-codex.sh <task-name> [--base <ref>] [--no-open] [-- <codex-args...>]
+
+Examples:
+  ./setup/create-worktree-and-codex.sh lin-300
+  ./setup/create-worktree-and-codex.sh lin-300 --base origin/main
+  ./setup/create-worktree-and-codex.sh lin-300 -- --profile default --full-auto
+  ./setup/create-worktree-and-codex.sh lin-300 --no-open
+
+Environment:
+  CODEX_WORKTREE_ROOT  Destination root for created worktrees (default: $HOME/.codex/worktrees)
+EOF
+}
+
+require_command() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: required command not found: $cmd" >&2
+        exit 1
+    fi
+}
+
+slugify() {
+    local value="$1"
+    value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+    value="$(printf '%s' "$value" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+    printf '%s' "$value"
+}
+
+resolve_default_base_ref() {
+    local repo_root="$1"
+    local current_branch
+    current_branch="$(git -C "$repo_root" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+    if [[ -n "$current_branch" ]]; then
+        printf '%s\n' "$current_branch"
+        return
+    fi
+
+    local origin_head
+    origin_head="$(git -C "$repo_root" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+    if [[ -n "$origin_head" ]]; then
+        printf '%s\n' "$origin_head"
+        return
+    fi
+
+    if git -C "$repo_root" show-ref --verify --quiet refs/heads/main; then
+        printf 'main\n'
+        return
+    fi
+
+    if git -C "$repo_root" show-ref --verify --quiet refs/heads/master; then
+        printf 'master\n'
+        return
+    fi
+
+    git -C "$repo_root" rev-parse --short HEAD
+}
+
+task_name=""
+base_ref=""
+open_codex=1
+codex_args=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -b|--base)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --base requires a value" >&2
+                usage
+                exit 1
+            fi
+            base_ref="$2"
+            shift 2
+            ;;
+        --no-open)
+            open_codex=0
+            shift
+            ;;
+        --)
+            shift
+            codex_args=("$@")
+            break
+            ;;
+        -*)
+            echo "Error: unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+        *)
+            if [[ -n "$task_name" ]]; then
+                echo "Error: task-name is already specified: $task_name" >&2
+                usage
+                exit 1
+            fi
+            task_name="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$task_name" ]]; then
+    echo "Error: task-name is required" >&2
+    usage
+    exit 1
+fi
+
+require_command git
+if [[ "$open_codex" -eq 1 ]]; then
+    require_command codex
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" ]]; then
+    echo "Error: current directory is not inside a git repository" >&2
+    exit 1
+fi
+
+if [[ -z "$base_ref" ]]; then
+    base_ref="$(resolve_default_base_ref "$repo_root")"
+fi
+
+if ! git -C "$repo_root" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+    echo "Error: base ref not found: $base_ref" >&2
+    exit 1
+fi
+
+branch_suffix="${task_name#codex/}"
+slug="$(slugify "$branch_suffix")"
+if [[ -z "$slug" ]]; then
+    echo "Error: task-name must contain at least one alphanumeric character" >&2
+    exit 1
+fi
+
+branch_name="codex/$slug"
+
+if git -C "$repo_root" worktree list --porcelain | awk '/^branch / {print $2}' | grep -Fxq "refs/heads/$branch_name"; then
+    echo "Error: branch is already checked out in another worktree: $branch_name" >&2
+    exit 1
+fi
+
+worktree_root="${CODEX_WORKTREE_ROOT:-$HOME/.codex/worktrees}"
+mkdir -p "$worktree_root"
+session_dir="$(mktemp -d "${worktree_root%/}/${slug}-XXXXXX")"
+session_dir="$(cd "$session_dir" && pwd -P)"
+repo_name="$(basename "$repo_root")"
+worktree_path="$session_dir/$repo_name"
+
+if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch_name"; then
+    git -C "$repo_root" worktree add "$worktree_path" "$branch_name"
+else
+    git -C "$repo_root" worktree add -b "$branch_name" "$worktree_path" "$base_ref"
+fi
+
+env_sync_script="$repo_root/setup/create-worktree-with-env.sh"
+if [[ -x "$env_sync_script" ]]; then
+    (cd "$worktree_path" && "$env_sync_script")
+fi
+
+echo "Created worktree: $worktree_path"
+echo "Branch: $branch_name"
+echo "Base ref: $base_ref"
+
+if [[ "$open_codex" -eq 0 ]]; then
+    printf 'Run: codex --cd %q' "$worktree_path"
+    if [[ ${#codex_args[@]} -gt 0 ]]; then
+        for arg in "${codex_args[@]}"; do
+            printf ' %q' "$arg"
+        done
+    fi
+    printf '\n'
+    exit 0
+fi
+
+if [[ ${#codex_args[@]} -gt 0 ]]; then
+    exec codex --cd "$worktree_path" "${codex_args[@]}"
+else
+    exec codex --cd "$worktree_path"
+fi


### PR DESCRIPTION
Summary
- `make codex-worktree` を追加し、ブランチ発行や worktree 作成後に `codex` CLI を立ち上げるタスクを `setup/create-worktree-and-codex.sh` で実装
- README に利用例と `.env*` 同期についての説明を追記し、新コマンドの流れを明示
- 新スクリプトはベースリファレンスの解決、既存 branch の検出、`origin` への発行制御、環境同期まで一連の操作を自動化

Testing
- Not run (not requested)