### PR TITLE
Update reviewer orchestrator to spawn specialist sub-agents

### DIFF
--- a/.agents/skills/linear_implementation/SKILL.md
+++ b/.agents/skills/linear_implementation/SKILL.md
@@ -32,7 +32,7 @@ Fallback procedure when MCP is unavailable:
 - Use separate agents for exploration, implementation, validation, and review to reduce context drift.
 - Run read-heavy and check-heavy work in parallel when safe.
 - Avoid parallel writes to the same code area; default to a single worker for edits.
-- Run specialist reviewers in parallel, then run one meta reviewer to consolidate and decide gate status.
+- Run one meta reviewer (`reviewer`) as review entrypoint; it must orchestrate specialist reviewers in parallel and then consolidate gate status.
 
 ## 3. Parent Issue Handling with Sequential Child Execution
 When given a parent issue:
@@ -59,13 +59,12 @@ For each child issue execute the same loop.
 1. Create branch
 2. Implement scoped changes
 3. Run validation commands
-4. Run specialist review pass in parallel
-5. Run meta review consolidation and gate decision
-6. Run `reviewer_ui_guard` to detect whether UI-related files changed
-7. If UI changes are detected, run `reviewer_ui`; if not, skip UI checks
-8. Open PR
-9. Merge according to merge policy
-10. Move to next issue
+4. Run `reviewer` for consolidated review and gate decision (the reviewer internally runs specialist reviewers)
+5. Run `reviewer_ui_guard` to detect whether UI-related files changed
+6. If UI changes are detected, run `reviewer_ui`; if not, skip UI checks
+7. Open PR
+8. Merge according to merge policy
+9. Move to next issue
 
 ## 6. Role Contracts
 ### Explorer
@@ -89,7 +88,7 @@ For each child issue execute the same loop.
 
 ### Meta Reviewer
 - Role key is `reviewer` for backward compatibility.
-- Consolidate specialist outputs, deduplicate overlaps, normalize severity, and make final gate decision.
+- Spawn and collect specialist reviewer outputs, deduplicate overlaps, normalize severity, and make final gate decision.
 - Gate rule: block when at least one `P1` or higher finding has confidence `>= 0.65`.
 
 ### Conditional UI Review

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -5,20 +5,30 @@ developer_instructions = """
 You are the meta reviewer.
 
 Input:
-- Findings from specialist reviewers: reviewer_security, reviewer_correctness, reviewer_performance, reviewer_test_quality, reviewer_coding_rules.
+- Review target context (diff, changed files, and/or task scope).
+- Do not assume specialist findings are pre-collected.
 
 Tasks:
-1. Deduplicate overlapping findings.
-2. Normalize severity to P0/P1/P2/P3.
-3. Keep only actionable findings with concrete evidence.
-4. Decide final gate:
+1. Spawn specialist reviewer sub-agents and collect their outputs:
+   - reviewer_security
+   - reviewer_correctness
+   - reviewer_performance
+   - reviewer_test_quality
+   - reviewer_coding_rules
+2. Use sub-agent orchestration tools (`spawn_agent`, `send_input`, `wait`) to run specialist reviewers in parallel whenever possible.
+3. If a specialist fails or times out, continue with available reports and record the failure.
+4. Deduplicate overlapping findings.
+5. Normalize severity to P0/P1/P2/P3.
+6. Keep only actionable findings with concrete evidence.
+7. Decide final gate:
    - block: at least one finding is P1 or higher with confidence >= 0.65
    - pass: otherwise
-5. Return a concise final summary and prioritized fixes.
+8. Return a concise final summary and prioritized fixes.
 
 Output format:
 - gate: pass|block
 - block_reasons: list
+- reviewer_runs: list of {agent,status,summary_or_error}
 - consolidated_findings: list of {id,severity,confidence,file,line_start,line_end,risk,evidence,fix,test}
 - dropped_as_duplicate: list
 - dropped_as_low_confidence: list

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -10,7 +10,7 @@ description = "Implementation agent. Keep diffs scoped and follow Plan.md."
 config_file = "agents/worker.toml"
 
 [agents.reviewer]
-description = "Meta reviewer. Consolidate specialist reviewer outputs, deduplicate findings, and make final gate decisions."
+description = "Meta reviewer orchestrator. Spawn specialist reviewers, consolidate outputs, deduplicate findings, and make final gate decisions."
 config_file = "agents/reviewer.toml"
 
 [agents.reviewer_security]


### PR DESCRIPTION
Summary
- document that the meta reviewer (`reviewer`) now spawns specialist reviewer sub-agents and consolidates their reports
- align the linear implementation instructions so `reviewer` is the only entry point for orchestrating specialist reviewers
- expand reviewer configuration to collect sub-agent metadata and failures for better gate signal transparency

Testing
- Not run (not requested)