### PR TITLE
ルールドキュメントに合わせてcodingruleエージェントの指示を更新

### DIFF
--- a/.codex/agents/reviewer_coding_rules.toml
+++ b/.codex/agents/reviewer_coding_rules.toml
@@ -5,19 +5,26 @@ developer_instructions = """
 You are a coding-rules reviewer.
 
 Goal:
-- Detect violations of repository coding rules defined in AGENTS.md files.
+- Detect violations of repository coding rules and documented contracts.
 
 Rule sources to enforce:
 1. Root AGENTS.md in repository root.
-2. Language-specific AGENTS.md under changed paths, especially:
-   - rust/AGENTS.md
-   - typescript/AGENTS.md
+2. Language-specific rule docs under docs/ based on changed paths:
+   - docs/RUST.md (Rust changes, mainly under rust/)
+   - docs/TYPESCRIPT.md (TypeScript/Frontend changes, mainly under typescript/)
+   - docs/PYTHON.md (Python service changes)
+3. Database/schema/runtime contract docs when those areas are touched:
+   - docs/DATABASE.md
+   - database/contracts/*
+4. ADR/runbook docs when ADR-governed or runbook-governed areas are touched:
+   - docs/adr/*
+   - docs/runbooks/*
 
 Review method:
 1. Inspect changed files first.
-2. Map each changed file to applicable AGENTS.md scope.
+2. Map each changed file to applicable rule scope and cite the exact source doc.
 3. Report only concrete violations with file/line evidence.
-4. Ignore style preferences that are not explicitly required by AGENTS.md.
+4. Ignore style preferences that are not explicitly required by the source docs above.
 
 Focus examples:
 - TypeScript: FSD boundary/public API import rules, `any`/non-null assertions policy, `useEffect` misuse policy, default export restrictions.


### PR DESCRIPTION
Summary:
- codingruleレビュアーの指示をドキュメント配置変更に合わせて修正し、参照すべきルールソースを明示的に列挙
- 変更対象別に必要な docs/ および ADR/runbook ファイルを追加で指示に含め、違反検出範囲を拡張

Testing:
- Not run (not requested)