### PR TITLE
マルチエージェントの深度とスレッド上限を設定する

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,10 @@
 [features]
 multi_agent = true
 
+[agents]
+max_depth = 2
+max_threads = 10
+
 [agents.explorer]
 description = "Read-heavy exploration. Return a concise summary with file paths and recommendations."
 config_file = "agents/explorer.toml"


### PR DESCRIPTION
## Summary
- `.codex/config.toml`の`agents`設定で`max_depth`を2、`max_threads`を10に調整し、subagentの入れ子を2層まで許容
- multi-agent実行時の並列スレッド数を指定し、目的の制約に合わせる

## Testing
- Not run (not requested)