### PR TITLE
Add commit cadence guidance to linear implementation skill

### DIFF
--- a/.agents/skills/linear_implementation/SKILL.md
+++ b/.agents/skills/linear_implementation/SKILL.md
@@ -17,6 +17,11 @@ description: Implement linklinx-AI Linear issues with one issue equals one PR de
 - Any operation on the `main` branch requires explicit user approval in advance.
 - Examples of `main` branch operations that require approval: `checkout/switch main`, merge/rebase/cherry-pick targeting `main`, push to `main`, or direct commits on `main`.
 
+## 0.2 Commit Cadence
+- Commit frequently in small, logical units during implementation.
+- Keep one clear purpose per commit; do not mix unrelated changes.
+- At minimum, create a commit at each meaningful milestone before moving to the next major task.
+
 ## 1. Linear Connection
 Prefer Linear MCP for reading and updating issues.
 - `codex mcp add linear --url https://mcp.linear.app/mcp`
@@ -64,14 +69,15 @@ Use one of these locations according to repository convention.
 For each child issue execute the same loop.
 1. Create branch
 2. Implement scoped changes
-3. Run validation commands
-4. Run `reviewer` for consolidated review and gate decision (the reviewer internally runs specialist reviewers)
-5. Run `reviewer_ui_guard` to detect whether UI-related files changed
-6. If UI changes are detected, run `reviewer_ui`; if not, skip UI checks
-7. If self-review gate is not passed (validation failure, blocking review finding, or failed required UI checks), fix issues and return to step 2.
-8. Open PR
-9. Merge according to merge policy
-10. Move to next issue
+3. Commit progress frequently in small logical units
+4. Run validation commands
+5. Run `reviewer` for consolidated review and gate decision (the reviewer internally runs specialist reviewers)
+6. Run `reviewer_ui_guard` to detect whether UI-related files changed
+7. If UI changes are detected, run `reviewer_ui`; if not, skip UI checks
+8. If self-review gate is not passed (validation failure, blocking review finding, or failed required UI checks), fix issues and return to step 2.
+9. Open PR
+10. Merge according to merge policy
+11. Move to next issue
 
 ## 6. Role Contracts
 ### Explorer


### PR DESCRIPTION
## Summary
- document the new rule to commit frequently in `.agents/skills/linear_implementation/SKILL.md`
- list the step in the child-issue workflow to commit progress before validation

## Testing
- Not run (not requested)