### PR TITLE
Add ファイル責務の分割指針

### DIFF
--- a/docs/RUST.md
+++ b/docs/RUST.md
@@ -33,6 +33,7 @@ pub trait UserRepository: Send + Sync {
 Rules:
 - Do not use `mod.rs`; use `foo.rs` + `foo/` structure.
 - Split files before they exceed roughly 300-500 lines.
+- Keep one primary responsibility per file; when concerns start to mix, split by module/type before the file becomes hard to reason about.
 - Expose crate public API through `pub use` in `lib.rs`.
 - Keep `prelude` limited to frequent and stable exports.
 

--- a/docs/TYPESCRIPT.md
+++ b/docs/TYPESCRIPT.md
@@ -68,6 +68,7 @@
 
 ## 5.1 Implementation and Testing Policy
 - Split functions by responsibility to keep them testable.
+- Keep one primary responsibility per file; split before a file starts mixing multiple concerns (UI/state/API/helpers).
 - Implement tests whenever practical, prioritizing regression prevention.
 - Separate pure functions from external interactions (I/O, HTTP, browser APIs, state mutation).
 


### PR DESCRIPTION
Summary
- docs/RUST.mdとdocs/TYPESCRIPT.mdに、それぞれファイルが複数責務を持ち始めたらモジュールや型で分割する旨を追記しました

Testing
- Not run (not requested)