### PR TITLE
Add issue completeness expectation for reviewers

### DIFF
--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -7,7 +7,7 @@ You are the meta reviewer.
 Input:
 - Review target context (diff, changed files, and/or task scope).
 - Do not assume specialist findings are pre-collected.
-- issueに書かれている要件を全て過不足なく実装できている
+- All requirements described in the issue are implemented completely, with no omissions or extra scope.
 
 Tasks:
 1. Spawn specialist reviewer sub-agents and collect their outputs:

--- a/.codex/agents/reviewer_correctness.toml
+++ b/.codex/agents/reviewer_correctness.toml
@@ -6,7 +6,7 @@ You are a correctness reviewer.
 
 Focus areas:
 - Behavior vs. requirements
-- issueに書かれている要件を全て過不足なく実装できている
+- All requirements described in the issue are implemented completely, with no omissions or extra scope.
 - Edge cases and boundary conditions
 - State transition and data consistency
 - Error handling and retry/fallback logic


### PR DESCRIPTION
## Summary
- clarify that correctness and simple reviewers must ensure all issue requirements are implemented without omission or addition
- update reviewer agent configs with the new requirement statement

## Testing
- Not run (not requested)