### PR TITLE
LIN-589 Scylla SoR境界と運用Runbookを整備

### DIFF
--- a/database/contracts/lin589_scylla_sor_partition_baseline.md
+++ b/database/contracts/lin589_scylla_sor_partition_baseline.md
@@ -1,0 +1,146 @@
+# LIN-589 Scylla SoR / Partition Design Baseline
+
+## Purpose
+
+- Target issue: LIN-589
+- Fix a documentation-only operational baseline for Scylla as the message data source of record (SoR).
+- Provide stable prerequisites for LIN-592 (History API), LIN-593 (Message path), LIN-594 (Search ingest), and LIN-597 (DR v0).
+
+In scope:
+
+- SoR boundary for `messages`, `message_edits`, and `read_state_hotpath`
+- Partition design review criteria for history-first access patterns
+- Measurement perspective for latest-N retrieval target (`P95 <= 500ms`)
+- Node-loss continuity policy and minimum backup/restore policy
+
+Out of scope:
+
+- CQL schema changes and table additions
+- Application/API implementation changes
+- Postgres schema or migration changes
+
+## References
+
+- `docs/DATABASE.md`
+- `database/scylla/001_lin139_messages.cql`
+- `database/contracts/lin287_scylla_primary_key_validation.md`
+- `database/contracts/lin288_history_cursor_contract.md`
+- `database/contracts/lin289_idempotent_write_contract.md`
+- `docs/adr/ADR-002-class-ab-event-classification-and-delivery-boundary.md`
+- `docs/runbooks/scylla-node-loss-backup-runbook.md`
+
+## 1. SoR boundary
+
+### 1.1 Responsibility matrix
+
+| Domain | SoR | Primary storage / contract | Notes |
+| --- | --- | --- | --- |
+| messages body | Scylla | `chat.messages_by_channel` (`database/scylla/001_lin139_messages.cql`) | Main store for channel history retrieval |
+| message_edits state | Scylla | `version`, `edited_at`, `is_deleted`, `deleted_at`, `deleted_by` on `chat.messages_by_channel` | v0 manages latest edit/delete state in the same row family |
+| read_state_hotpath | Scylla | Scylla-side hotpath read pointer contract for reconnect/history catch-up | Low-latency read path responsibility only |
+| read_state durable record (`channel_reads`) | Postgres | `channel_reads`, `upsert_channel_reads_monotonic(...)` | Keep existing Postgres contract; separate from Scylla hotpath responsibility |
+
+### 1.2 Explicit prohibitions
+
+- Do not allow single-partition concentration designs for message history.
+- Do not duplicate-write message body to Postgres.
+- Do not expand Scylla hotpath responsibilities into full durable account state ownership in LIN-589.
+
+### 1.3 ADR-002 alignment
+
+- Follow ADR-002 as the SSOT for Class A/B outage behavior.
+- For Class A message paths, treat fanout uncertainty as possible loss and require history re-fetch/state resync as compensation.
+
+## 2. Partition design review criteria (history-first)
+
+### 2.1 Required key principle
+
+The baseline key design for history retrieval is:
+
+- `PRIMARY KEY ((channel_id, bucket), message_id)`
+- `CLUSTERING ORDER BY (message_id DESC)`
+
+Review must reject proposals that break this baseline without providing an approved compatibility path.
+
+### 2.2 Fail conditions (must reject)
+
+Reject design in review when any condition is true:
+
+1. A single partition can grow unbounded for hot channels without bucket split strategy.
+2. Latest-N retrieval requires full-scan or ambiguous filtering across uncontrolled partitions.
+3. Cursor paging cannot preserve deterministic ordering and duplicate exclusion defined by LIN-288.
+4. Idempotent create path cannot preserve duplicate no-op behavior defined by LIN-289.
+
+### 2.3 Required pre-estimation items
+
+Before approving partition design, document all items below:
+
+1. Estimated rows per bucket (`messages / bucket`)
+2. Estimated partition size per bucket (bytes)
+3. Hot-channel skew estimate (top channel concentration)
+4. Cross-bucket read frequency for history pagination
+
+If any item is missing, review is not complete.
+
+### 2.4 Latest-N measurement perspective
+
+Baseline measurement setup:
+
+- Default `N = 50`
+- Measure `P50 / P95 / P99` latency for latest-N retrieval
+- Measure on hot-channel assumed load scenario (same input profile used in partition review)
+- Use fixed windows and record sample count per window
+
+Target and recording rule:
+
+- Target: `P95 <= 500ms`
+- Record pass/fail decision with window, sample count, and query path used
+
+This is a review target for LIN-589 baseline, not a guarantee of all future workloads.
+
+## 3. Node-loss continuity baseline
+
+### 3.1 Continuation rule
+
+Continue service when all are true:
+
+1. One node loss is detected, but quorum for required consistency remains available.
+2. History read path remains healthy enough for compensation re-fetch.
+3. No data divergence signal is detected in critical message paths.
+
+### 3.2 Non-continuation rule
+
+If quorum is not maintained or cluster state is uncertain:
+
+- Treat write paths as fail-close and prioritize recovery.
+- Keep only safe read paths if they do not violate consistency expectations.
+- Resume writes only after recovery gates are satisfied.
+
+Detailed operation steps are defined in:
+
+- `docs/runbooks/scylla-node-loss-backup-runbook.md`
+
+## 4. Minimum backup / restore policy
+
+Minimum required artifacts:
+
+1. Snapshot data for `chat` keyspace
+2. Keyspace/table schema snapshot
+3. Backup execution record (time window, scope, owner)
+
+Minimum restore policy:
+
+1. Prepare restore target and schema first.
+2. Restore snapshot data.
+3. Validate data and query health.
+4. Resume read-first, then write paths.
+
+Detailed operational steps and close conditions are defined in the Scylla runbook.
+
+## 5. Verification points (review procedure)
+
+1. SoR boundary and table responsibilities are explicitly documented.
+2. Prohibited patterns (single partition concentration, Postgres message dual-write) are explicitly documented.
+3. Latest-N measurement method and `P95 <= 500ms` target are documented.
+4. Node-loss continuation/non-continuation gates are unambiguous.
+5. Minimum backup/restore procedure is reproducible from docs only.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -13,7 +13,7 @@
 ## 1. 全体構成
 
 - PostgreSQL: ユーザー、ギルド、権限、招待、監査、既読、Outbox などの正データ
-- ScyllaDB: メッセージ本文ストア（チャネル履歴、冪等保存、ページング）
+- ScyllaDB: メッセージ SoR（本文、編集状態、履歴ページング、read_state_hotpath）
 
 ## 2. PostgreSQL の現在状態
 
@@ -122,7 +122,7 @@ The source of truth for Dragonfly-backed session continuity (`session TTL`, `res
 - `chat.messages_by_channel`
   - 主キー: `((channel_id, bucket), message_id)`
   - クラスタ順: `message_id DESC`
-  - 用途: チャネル履歴の主ストア
+  - 用途: チャネル履歴の主ストア（`version` / `edited_at` / `is_deleted` による編集・削除の最新状態を保持）
 - `chat.messages_by_id`（任意）
   - 主キー: `(message_id)`
   - 用途: message_id 直参照
@@ -134,6 +134,13 @@ The source of truth for Dragonfly-backed session continuity (`session TTL`, `res
 - 冪等保存: `database/scylla/queries/lin289_idempotent_write_strategy.cql`
   - `INSERT ... IF NOT EXISTS` による重複防止
   - 再送時の read-before-retry を規定
+
+### 3.4 Scylla Operations Baseline (LIN-589)
+
+The source of truth for Scylla operations (SoR boundary, partition review criteria, latest-N measurement perspective, node-loss continuity policy, and minimum backup/restore procedure) is:
+
+- `database/contracts/lin589_scylla_sor_partition_baseline.md`
+- `docs/runbooks/scylla-node-loss-backup-runbook.md`
 
 ## 4. 変更時の運用ルール
 
@@ -155,3 +162,6 @@ The source of truth for Dragonfly-backed session continuity (`session TTL`, `res
 - LIN-587 Session/resume operations baseline:
   - `database/contracts/lin587_session_resume_runtime_contract.md`
   - `docs/runbooks/session-resume-dragonfly-operations-runbook.md`
+- LIN-589 Scylla operations baseline:
+  - `database/contracts/lin589_scylla_sor_partition_baseline.md`
+  - `docs/runbooks/scylla-node-loss-backup-runbook.md`

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -6,3 +6,4 @@
 - `edge-rest-ws-routing-drain-runbook.md`: Edge REST/WS routing contract, health checks, rolling WS drain policy, and rollback procedure baseline.
 - `auth-firebase-principal-operations-runbook.md`: Firebase Auth and `uid -> principal_id` operations baseline (REST/WS error policy, logs/metrics, and outage triage).
 - `session-resume-dragonfly-operations-runbook.md`: Session/resume/TTL continuity baseline on Dragonfly, including degraded behavior and TTL rollout/rollback procedure.
+- `scylla-node-loss-backup-runbook.md`: Scylla node-loss continuity decisions and minimum backup/restore execution baseline for v0.

--- a/docs/runbooks/scylla-node-loss-backup-runbook.md
+++ b/docs/runbooks/scylla-node-loss-backup-runbook.md
@@ -1,0 +1,177 @@
+# Scylla Node Loss and Backup/Restore Runbook (Draft)
+
+- Status: Draft
+- Last updated: 2026-02-27
+- Owner scope: Scylla operations baseline (v0)
+- References:
+  - `database/contracts/lin589_scylla_sor_partition_baseline.md`
+  - `docs/DATABASE.md`
+  - `docs/adr/ADR-002-class-ab-event-classification-and-delivery-boundary.md`
+  - `LIN-589`
+  - `LIN-597`
+
+## 1. Purpose and scope
+
+This runbook defines start/stop decision gates and minimum execution steps for Scylla node-loss continuity and backup/restore operations.
+
+In scope:
+
+- Node-loss start and close decisions
+- Continuation vs fail-close decision gates
+- Minimum backup procedure (snapshot + schema preservation)
+- Minimum restore procedure and staged resume
+- Tabletop checklist and drill record template
+
+Out of scope:
+
+- Vendor-managed automation details
+- Multi-region DR architecture design
+- CQL schema redesign or application implementation changes
+
+## 2. Baseline assumptions
+
+1. Production keyspace replication is configured so one-node loss can still keep quorum.
+2. Message persistence path uses quorum-level consistency compatible with the LIN-589 baseline.
+3. ADR-002 remains the SSOT for Class A/B outage and compensation behavior.
+4. Message body dual-write to Postgres is prohibited.
+
+## 3. Node-loss start conditions
+
+Treat node-loss operation as active when all are true:
+
+1. At least one Scylla node is confirmed unavailable (`DN`) beyond transient restart windows.
+2. Message read/write path shows sustained degradation or elevated error rate.
+3. Incident owner and decision owner are assigned.
+
+Do not start emergency operations when:
+
+- Node state is flapping and converges to healthy within the observation window.
+- Observed failures are isolated to non-Scylla dependencies.
+
+## 4. Continuation decision
+
+### 4.1 Continue in degraded mode
+
+Continue service when both are true:
+
+1. Required quorum is still achievable after one-node loss.
+2. No critical divergence signal exists for message persistence/history retrieval.
+
+Actions:
+
+1. Keep read and write paths active.
+2. Apply temporary backpressure to reduce burst load.
+3. Increase monitoring for latest-N latency and write timeout trends.
+
+### 4.2 Switch to recovery-first mode (fail-close writes)
+
+Switch when any is true:
+
+1. Quorum cannot be maintained.
+2. Cluster state is uncertain and consistency cannot be asserted.
+3. Critical write errors persist beyond mitigation window.
+
+Actions:
+
+1. Fail-close write paths.
+2. Keep only safe read paths where consistency expectations are satisfied.
+3. Prioritize cluster recovery, then staged traffic resume.
+
+## 5. Minimum backup procedure
+
+### 5.1 Pre-check
+
+1. Record incident/ticket link, operator, and execution start time.
+2. Confirm target keyspace and table scope (`chat`).
+3. Confirm available disk/storage capacity for snapshot artifacts.
+
+### 5.2 Execute backup
+
+1. Create snapshot on each healthy node.
+2. Export keyspace/table schema snapshot.
+3. Collect snapshot artifacts and schema artifacts to backup storage.
+4. Record artifact manifest (node, path, timestamp, checksum if available).
+
+Reference command pattern (adjust to environment):
+
+```bash
+nodetool snapshot --tag <tag> chat
+cqlsh -e "DESCRIBE KEYSPACE chat" > chat_keyspace_<tag>.cql
+```
+
+### 5.3 Backup completion criteria
+
+Declare backup complete only when all are true:
+
+1. Snapshot artifacts from required nodes are present.
+2. Schema snapshot is archived with the same backup tag.
+3. Artifact manifest is recorded and reviewable.
+
+## 6. Minimum restore procedure
+
+### 6.1 Start conditions
+
+Start restore only when:
+
+1. Continuity mode cannot satisfy service objectives, or
+2. Explicit restore decision is made by incident owner.
+
+### 6.2 Execute restore
+
+1. Prepare restore target cluster/node.
+2. Apply keyspace/table schema snapshot.
+3. Restore snapshot SSTable data to target.
+4. Refresh and recover node/table state.
+5. Run health and data validation checks.
+
+### 6.3 Validation checklist
+
+1. Target keyspace/table metadata is consistent with baseline schema.
+2. Latest-N retrieval path succeeds with expected ordering semantics.
+3. No critical read/write error bursts after restore.
+4. Compensation re-fetch path (ADR-002 Class A expectation) is available.
+
+### 6.4 Staged resume
+
+1. Resume read paths first.
+2. Resume write paths after read stability is confirmed.
+3. Keep heightened monitoring until close criteria are satisfied.
+
+## 7. Close conditions
+
+Close node-loss operation only when all are true:
+
+1. Cluster/node health is stable.
+2. Required quorum is healthy.
+3. Read and write paths are resumed according to staged plan.
+4. Incident timeline, impact scope, and follow-up actions are recorded.
+
+## 8. Tabletop checklist
+
+1. Confirm start conditions can be judged without undocumented assumptions.
+2. Verify continuation vs fail-close decision is deterministic.
+3. Walk through backup and restore steps end-to-end from this runbook only.
+4. Confirm close conditions are objective and measurable.
+5. Record LIN-597 follow-up tasks if gaps are found.
+
+## 9. Drill record template
+
+```markdown
+### Scylla Node-Loss Drill Record
+
+- Date:
+- Environment:
+- Scenario:
+- Detected at:
+- Decision (continue/fail-close) at:
+- Backup started at:
+- Backup completed at:
+- Restore started at:
+- Restore completed at:
+- Read resume at:
+- Write resume at:
+- Validation summary:
+- Data-loss summary:
+- Open risks:
+- Follow-up issues (incl. LIN-597 linkage):
+```


### PR DESCRIPTION
概要
- `database/contracts/lin589_scylla_sor_partition_baseline.md` に LIN-589 の Scylla SoR 境界、パーティション見直し基準、latest-N 計測観点を明文化
- `docs/runbooks/scylla-node-loss-backup-runbook.md` を追加し、ノード障害時の継続方針と最小バックアップ/リストア手順を定義
- `docs/runbooks/README.md` と `docs/DATABASE.md` に LIN-589 基準文書への参照を追加

テスト
- 未実行（ドキュメント変更のみのため、CI結果で確認）