### PR TITLE
文書化する Dragonfly セッション再開 TTL 契約 (LIN-587)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 - For Python service changes, read `docs/PYTHON.md` first.
 - For database/schema/runtime contract changes, read `docs/DATABASE.md` and related files under `database/contracts/`.
 - For ADR-governed changes (event schema compatibility, delivery class boundary, search consistency, AuthZ fail-close, Dragonfly rate-limit failure policy), read relevant files under `docs/adr/` before implementation. Use `docs/adr/README.md` to identify the target ADR.
-- For runbook-governed operational changes (for example search reindex, edge REST/WS routing/drain, and Postgres PITR operations), read relevant files under `docs/runbooks/` before implementation. Use `docs/runbooks/README.md` to identify the target runbook.
+- For runbook-governed operational changes (for example search reindex, edge REST/WS routing/drain, session/resume continuity, and Postgres PITR operations), read relevant files under `docs/runbooks/` before implementation. Use `docs/runbooks/README.md` to identify the target runbook.
 - For Dragonfly/Redis rate-limit outage policy, degraded transition thresholds, recovery resynchronization rules, and Postgres migration/pooling contracts, also read related runtime contract files under `database/contracts/` before implementation.
 - Event schema changes must be additive and backward-compatible only. Breaking changes are prohibited unless approved via a separate ADR.
 - Event Class A/B classification and outage behavior decisions must follow ADR-002 as the single source of truth.
@@ -37,3 +37,4 @@
   - `docs/PYTHON.md`: Python/FastAPI rules (typing, naming, exception handling, function docs, lint/format/test).
   - `docs/adr/`: ADR directory summary and per-file descriptions are documented in `docs/adr/README.md`.
   - `docs/runbooks/`: Runbook directory summary and per-file descriptions are documented in `docs/runbooks/README.md`.
+    - `docs/runbooks/session-resume-dragonfly-operations-runbook.md`: Session/resume/TTL baseline, Dragonfly outage degraded behavior, and TTL rollout/rollback procedure.

--- a/database/contracts/lin139_runtime_contracts.md
+++ b/database/contracts/lin139_runtime_contracts.md
@@ -130,3 +130,21 @@ LIN-139 のスコープに含め、スキーマ実装とセットで適用しま
 - 重要操作の判定時
 - ノード再起動 / リバランス直後
 - L1 状態キャッシュミス時
+
+## 4. Session/Resume（Dragonfly）実行時契約（LIN-587）
+
+- session/resume 契約のSSOTは `database/contracts/lin587_session_resume_runtime_contract.md` を参照する。
+- Dragonfly の session 状態は揮発ストアとして扱い、永続SoRとしては扱わない。
+- 固定基準:
+  - `session TTL = 180s`
+  - `heartbeat interval = 30s`
+  - `liveness timeout = 90s`
+- state model:
+  - `active`
+  - `resumable`
+  - `expired`
+- Dragonflyキー:
+  - `sess:v0:{session_id}`
+  - 必須保持項目: `principal_id`, `issued_at`, `expires_at`, `last_heartbeat_at`, `last_disconnect_at`, `resume_nonce`
+- resume 失敗時は `full re-auth + History API再取得誘導` を固定フォールバックとする。
+- Dragonfly障害時は ADR-005 の `Read/session continuity` に従い `degraded fail-open`（継続性優先、品質低下許容）を適用する。

--- a/database/contracts/lin587_session_resume_runtime_contract.md
+++ b/database/contracts/lin587_session_resume_runtime_contract.md
@@ -1,0 +1,151 @@
+# LIN-587 Session/Resume Runtime Contract (Dragonfly)
+
+## 目的
+
+- 対象Issue: LIN-587
+- v0 Gatewayの session/resume 継続性契約を固定し、LIN-593 以降の前提を明確化する。
+- Dragonfly を揮発状態ストアとして使う範囲と制約を固定する。
+
+## スコープ
+
+In scope:
+
+- Session状態モデル（`active` / `resumable` / `expired`）
+- Dragonfly sessionキー命名、保持項目、TTL契約
+- Resume成立条件と失敗時フォールバック
+- Dragonfly障害時の劣化方針（ADR-005整合）
+- 運用メトリクスと目標値
+
+Out of scope:
+
+- Rustランタイム実装変更
+- Dragonfly永続化や永続SoR化
+- v1向け高度セッション配布/再送制御
+
+## 参照
+
+- `docs/adr/ADR-005-dragonfly-ratelimit-failure-policy.md`
+- `docs/runbooks/edge-rest-ws-routing-drain-runbook.md`
+- `docs/runbooks/auth-firebase-principal-operations-runbook.md`
+- `docs/runbooks/session-resume-dragonfly-operations-runbook.md`
+
+## 1. Session状態モデル
+
+| 状態 | 定義 | 継続条件 | 終了条件 |
+| --- | --- | --- | --- |
+| `active` | WS接続が生存し、heartbeatが liveness timeout 内で継続している状態 | `heartbeat interval = 30s` を満たし、`liveness timeout = 90s` を超えない | 明示切断、liveness timeout超過、認証失効、障害切断 |
+| `resumable` | 接続は切れているが、resume条件を満たせる再開猶予状態 | sessionキーが存在し、`session TTL = 180s` 内 | TTL失効、principal不一致、認証失効 |
+| `expired` | session再開不能状態 | なし | 新規セッション作成のみ可能 |
+
+補足:
+
+- Dragonflyは session の揮発状態ストアであり、永続SoRではない。
+- sessionキー消失は `expired` 扱いとし、推測補完は行わない。
+
+## 2. Dragonflyキー契約
+
+### 2.1 キー形式
+
+- 主キー: `sess:v0:{session_id}`
+- TTL: `180` 秒（固定基準）
+
+### 2.2 値スキーマ（必須項目）
+
+| フィールド | 型 | 必須 | 説明 |
+| --- | --- | --- | --- |
+| `principal_id` | integer | required | セッション主体の内部ID |
+| `issued_at` | unix epoch seconds | required | セッション発行時刻 |
+| `expires_at` | unix epoch seconds | required | `issued_at + 180` を基準にした有効期限 |
+| `last_heartbeat_at` | unix epoch seconds | required | 最終heartbeat受信時刻 |
+| `last_disconnect_at` | unix epoch seconds or null | required | 切断検知時刻（未切断時は null 可） |
+| `resume_nonce` | opaque string | required | resume試行の再利用防止トークン |
+
+### 2.3 更新ルール
+
+1. 接続確立時:
+- 新規 `session_id` を採番し、必須項目を保存する。
+2. heartbeat受信時:
+- `last_heartbeat_at` を更新し、TTLを `180s` に延長する。
+3. 切断検知時:
+- `last_disconnect_at` を更新し、キーはTTL満了まで保持する。
+4. resume成功時:
+- `resume_nonce` をローテーションし、`last_disconnect_at` を `null` に戻し、TTLを `180s` に再設定する。
+
+## 3. Resume成立条件
+
+Resumeは以下をすべて満たす場合のみ成立する:
+
+1. `sess:v0:{session_id}` が存在する。
+2. `expires_at` が現在時刻より後（TTL内）である。
+3. 再接続主体の `principal_id` が保存値と一致する。
+4. 認証状態が有効（LIN-586契約の fail-close 条件に反しない）。
+
+判定順序（固定）:
+
+1. sessionキー存在確認
+2. TTL/期限確認
+3. principal一致確認
+4. 認証有効確認
+
+## 4. Resume失敗時フォールバック契約
+
+Resume不成立時は、理由に関わらず次を実行する:
+
+1. full re-auth（新規接続時と同等の認証）
+2. クライアントへ履歴再取得誘導
+3. History API経由で欠落イベントを補償
+
+代表的な失敗理由:
+
+- `session_not_found`
+- `session_expired`
+- `principal_mismatch`
+- `auth_unavailable_or_invalid`
+- `dragonfly_unavailable`
+
+## 5. Dragonfly障害時の劣化方針（ADR-005整合）
+
+- session/resume/heartbeat は ADR-005 の `Read/session continuity` クラスとして扱う。
+- Dragonfly障害時は `degraded fail-open` を適用する。
+
+固定動作:
+
+1. 新規接続は継続する（認証成功前提）。
+2. resumeはベストエフォートとし、失敗時は即フォールバック（full re-auth + 履歴再取得）へ遷移する。
+3. presence/session品質低下（再開成功率低下、再購読増加）は許容し、可用性を優先する。
+
+## 6. メトリクス契約と目標値
+
+必須メトリクス:
+
+- `session_resume_attempt_total`
+- `session_resume_success_total`
+- `session_resume_fallback_total{reason}`
+- `session_heartbeat_timeout_total`
+- `session_dragonfly_unavailable_total`
+
+指標:
+
+- `resume_success_rate = session_resume_success_total / session_resume_attempt_total`
+
+目標値:
+
+- Dragonfly健全時・短時間切断シナリオで `resume_success_rate >= 95%`
+
+## 7. TTL変更の運用契約
+
+TTL変更は直接本番反映せず、次の順序で実施する:
+
+1. staging
+2. canary
+3. full rollout
+
+詳細手順とロールバック条件は
+`docs/runbooks/session-resume-dragonfly-operations-runbook.md` をSSOTとする。
+
+## 8. 検証観点
+
+1. 短時間切断からの再接続で resume 成立手順を再現できる。
+2. TTL満了時に resume不成立となり、再認証 + 履歴再取得に遷移する。
+3. Dragonfly停止時に degraded fail-open と fallback方針が矛盾なく適用される。
+4. 下流Issue（LIN-593）が追加仮定なしで本契約を参照できる。

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -101,6 +101,13 @@ The source of truth for Postgres operations (forward-only migration, pool exhaus
 - `database/contracts/lin588_postgres_operations_baseline.md`
 - `docs/runbooks/postgres-pitr-runbook.md`
 
+### 2.7 Session/Resume Runtime Baseline (LIN-587)
+
+The source of truth for Dragonfly-backed session continuity (`session TTL`, `resume`, `heartbeat`, `degraded behavior`) is:
+
+- `database/contracts/lin587_session_resume_runtime_contract.md`
+- `docs/runbooks/session-resume-dragonfly-operations-runbook.md`
+
 ## 3. ScyllaDB の現在状態
 
 基準: `database/scylla/001_lin139_messages.cql`
@@ -145,3 +152,6 @@ The source of truth for Postgres operations (forward-only migration, pool exhaus
 - LIN-588 Postgres operations baseline:
   - `database/contracts/lin588_postgres_operations_baseline.md`
   - `docs/runbooks/postgres-pitr-runbook.md`
+- LIN-587 Session/resume operations baseline:
+  - `database/contracts/lin587_session_resume_runtime_contract.md`
+  - `docs/runbooks/session-resume-dragonfly-operations-runbook.md`

--- a/docs/agent_runs/LIN-587/Documentation.md
+++ b/docs/agent_runs/LIN-587/Documentation.md
@@ -1,0 +1,41 @@
+# LIN-587 Documentation Log
+
+## Status
+- Initialized LIN-587 run memory files.
+- Completed documentation pass for LIN-587 scoped artifacts (runtime contract + runbook + index updates).
+
+## Decisions
+- Scope: documentation-only (no runtime code change).
+- Session TTL baseline: `180s`.
+- Heartbeat/liveness baseline: `30s` / `90s` (from edge WS runbook).
+- Outage posture: ADR-005 aligned degraded fail-open for read/session continuity paths.
+
+## Implemented artifacts
+- `docs/agent_runs/LIN-587/Prompt.md`
+- `docs/agent_runs/LIN-587/Plan.md`
+- `docs/agent_runs/LIN-587/Implement.md`
+- `docs/agent_runs/LIN-587/Documentation.md`
+- `database/contracts/lin587_session_resume_runtime_contract.md`
+- `database/contracts/lin139_runtime_contracts.md` (LIN-587 reference section)
+- `docs/runbooks/session-resume-dragonfly-operations-runbook.md`
+- `docs/runbooks/README.md` (runbook index update)
+- `docs/DATABASE.md` (LIN-587 baseline reference)
+- `AGENTS.md` (runbook-governed changes guidance update)
+
+## Validation results
+- `make validate`: failed due to missing TypeScript formatting dependency.
+  - failing step: `cd typescript && make format`
+  - root cause: `pnpm run format` -> `prettier: command not found`
+  - note: failure is environment dependency related (`node_modules` missing), not caused by LIN-587 document changes.
+
+## Pending
+- None in current LIN-587 documentation scope.
+
+## PR notes (acceptance mapping)
+
+| LIN-587 acceptance criterion | Coverage |
+| --- | --- |
+| 機能: session/resume/TTL/heartbeat仕様が文書化される | `database/contracts/lin587_session_resume_runtime_contract.md` sections 1-4 |
+| 性能: resume成功率の目標と計測観点が定義される | `database/contracts/lin587_session_resume_runtime_contract.md` section 6, `docs/runbooks/session-resume-dragonfly-operations-runbook.md` sections 2/6 |
+| 障害時: Dragonfly障害時の劣化挙動（presence/session低下）が定義される | `database/contracts/lin587_session_resume_runtime_contract.md` section 5, `docs/runbooks/session-resume-dragonfly-operations-runbook.md` section 5 |
+| 運用: TTL変更時のロールアウト手順が記載される | `docs/runbooks/session-resume-dragonfly-operations-runbook.md` section 7 |

--- a/docs/agent_runs/LIN-587/Implement.md
+++ b/docs/agent_runs/LIN-587/Implement.md
@@ -1,0 +1,8 @@
+# LIN-587 Implement Rules
+
+- Keep scope limited to LIN-587 documentation contracts and runbooks.
+- Do not modify Rust runtime code in this issue.
+- Reuse existing baseline values unless LIN-587 explicitly overrides them.
+- Keep Dragonfly role as volatile cache/state only, never persistent SoR.
+- Keep degraded behavior wording aligned with ADR-005 hybrid policy.
+- Ensure downstream issue LIN-593 can consume this contract without additional assumptions.

--- a/docs/agent_runs/LIN-587/Plan.md
+++ b/docs/agent_runs/LIN-587/Plan.md
@@ -1,0 +1,17 @@
+# LIN-587 Plan
+
+## Milestones
+1. Add LIN-587 runtime contract under `database/contracts/`.
+2. Link LIN-587 contract from `database/contracts/lin139_runtime_contracts.md`.
+3. Add session/resume operations runbook under `docs/runbooks/`.
+4. Update documentation indexes (`docs/runbooks/README.md`, `docs/DATABASE.md`, `AGENTS.md`).
+5. Record run memory and validation outcomes under `docs/agent_runs/LIN-587/`.
+
+## Validation commands
+- make validate
+
+## Acceptance checks
+- Session/resume/TTL/heartbeat behavior is documented with fixed numeric baseline.
+- Resume success target and metrics viewpoints are explicitly listed.
+- Dragonfly outage degraded behavior is unambiguous and ADR-005 consistent.
+- TTL rollout procedure includes `staging -> canary -> full rollout` and rollback trigger.

--- a/docs/agent_runs/LIN-587/Prompt.md
+++ b/docs/agent_runs/LIN-587/Prompt.md
@@ -1,0 +1,17 @@
+# LIN-587 Prompt
+
+## Goal
+- Fix the v0 session/resume contract for Dragonfly-backed gateway continuity.
+- Keep this issue documentation-only and avoid runtime code changes.
+
+## Non-goals
+- Implement full gateway resume runtime behavior in Rust.
+- Introduce Dragonfly as a persistent source of record.
+- Design v1 advanced session distribution.
+
+## Done conditions
+- Session state model (`active` / `resumable` / `expired`) is documented.
+- Dragonfly key/TTL contract is fixed with `session TTL = 180s`.
+- Resume success/failure conditions and fallback behavior are documented.
+- Dragonfly outage degraded behavior is aligned with ADR-005.
+- TTL rollout and rollback procedure is documented in runbook form.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -5,3 +5,4 @@
 - `search-reindex-runbook.md`: Search reindex operational flow (pre-check, start, execute, verify, and close) for the v0 baseline.
 - `edge-rest-ws-routing-drain-runbook.md`: Edge REST/WS routing contract, health checks, rolling WS drain policy, and rollback procedure baseline.
 - `auth-firebase-principal-operations-runbook.md`: Firebase Auth and `uid -> principal_id` operations baseline (REST/WS error policy, logs/metrics, and outage triage).
+- `session-resume-dragonfly-operations-runbook.md`: Session/resume/TTL continuity baseline on Dragonfly, including degraded behavior and TTL rollout/rollback procedure.

--- a/docs/runbooks/session-resume-dragonfly-operations-runbook.md
+++ b/docs/runbooks/session-resume-dragonfly-operations-runbook.md
@@ -1,0 +1,191 @@
+# Session/Resume Dragonfly Operations Runbook (Draft)
+
+- Status: Draft
+- Last updated: 2026-02-27
+- Owner scope: v0 session continuity baseline for WS reconnect/resume
+- References:
+  - `database/contracts/lin587_session_resume_runtime_contract.md`
+  - `database/contracts/lin139_runtime_contracts.md`
+  - [ADR-005 Dragonfly Outage RateLimit Failure Policy (Hybrid)](../adr/ADR-005-dragonfly-ratelimit-failure-policy.md)
+  - [Edge REST/WS Routing and WS Drain Runbook](./edge-rest-ws-routing-drain-runbook.md)
+  - [Firebase Auth / principal_id Operations Runbook](./auth-firebase-principal-operations-runbook.md)
+  - `LIN-587`
+
+## 1. Purpose and scope
+
+This runbook fixes one operational baseline for v0 session continuity using Dragonfly-backed volatile session state.
+
+In scope:
+
+- Session/resume/TTL operational baseline
+- Verification steps for short-disconnect resume success
+- Behavior for TTL expiry fallback
+- Dragonfly outage degraded behavior for continuity class
+- TTL rollout and rollback procedure
+
+Out of scope:
+
+- Runtime implementation details in Rust code
+- v1 advanced session routing/distribution
+- Dragonfly persistence guarantees
+
+## 2. Fixed baseline values
+
+| item | baseline |
+| --- | --- |
+| Session TTL | `180s` |
+| Heartbeat interval | `30s` |
+| Liveness timeout | `90s` |
+| Resume success target | `>= 95%` (Dragonfly healthy, short disconnect scenario) |
+
+## 3. Session and resume contract summary
+
+- Session state model: `active` / `resumable` / `expired`
+- Dragonfly key: `sess:v0:{session_id}`
+- Mandatory fields: `principal_id`, `issued_at`, `expires_at`, `last_heartbeat_at`, `last_disconnect_at`, `resume_nonce`
+- Resume success requires:
+1. session key exists
+2. TTL not expired
+3. same principal
+4. valid authentication context
+
+On resume failure, execute:
+
+1. full re-auth
+2. history re-fetch guidance
+
+## 4. Verification procedures
+
+### 4.1 Scenario A: short disconnect -> resume success
+
+Preconditions:
+
+1. Dragonfly is healthy.
+2. Test user can establish authenticated WS connection.
+
+Procedure:
+
+1. Connect WS and complete auth handshake.
+2. Confirm session key creation for `sess:v0:{session_id}`.
+3. Disconnect client for less than `180s`.
+4. Reconnect with same principal and resume token/session_id.
+5. Confirm resume succeeds and fallback metric does not increment.
+
+Pass criteria:
+
+- `session_resume_success_total` increments.
+- `session_resume_fallback_total` does not increment for the same attempt.
+
+### 4.2 Scenario B: TTL expiry -> fallback
+
+Preconditions:
+
+1. Dragonfly is healthy.
+2. Existing resumable session is created.
+
+Procedure:
+
+1. Wait until session key TTL expires (> `180s` without successful resume).
+2. Attempt resume using expired session_id.
+3. Verify resume rejection reason is `session_expired` or `session_not_found`.
+4. Verify flow transitions to full re-auth.
+5. Verify client receives history re-fetch guidance.
+
+Pass criteria:
+
+- `session_resume_fallback_total{reason="session_expired"}` or `session_not_found` increments.
+- New authenticated session can be established after fallback.
+
+### 4.3 Scenario C: Dragonfly outage -> degraded continuity
+
+Preconditions:
+
+1. Staging environment with controllable Dragonfly stop/start.
+2. Session/resume metrics dashboard is available.
+
+Procedure:
+
+1. Simulate Dragonfly outage.
+2. Verify new authenticated connections continue where possible.
+3. Attempt resume during outage and observe best-effort failures.
+4. Verify failures route to fallback path (full re-auth + history re-fetch).
+5. Restore Dragonfly and confirm recovery trend in resume metrics.
+
+Pass criteria:
+
+- Service continuity remains available for new sessions.
+- Resume quality degrades without ambiguous behavior.
+- Outage and fallback metrics provide clear diagnosis signals.
+
+## 5. Degraded behavior policy (ADR-005 alignment)
+
+Session continuity is treated as `Read/session continuity` class from ADR-005.
+
+Operational behavior during Dragonfly outage:
+
+1. Apply degraded fail-open for continuity-sensitive path.
+2. Do not hard-fail all reconnect attempts solely due to Dragonfly unavailability.
+3. Permit resume failure and immediately route to fallback.
+4. Accept temporary quality degradation in presence/session continuity.
+
+## 6. Metrics and alert viewpoints
+
+Required metrics:
+
+- `session_resume_attempt_total`
+- `session_resume_success_total`
+- `session_resume_fallback_total{reason}`
+- `session_heartbeat_timeout_total`
+- `session_dragonfly_unavailable_total`
+
+Operational targets:
+
+- `resume_success_rate >= 95%` (Dragonfly healthy)
+
+Suggested alerts:
+
+1. `resume_success_rate < 95%` for 10 consecutive minutes in healthy state.
+2. `session_dragonfly_unavailable_total` continues increasing for 5 minutes.
+3. `session_heartbeat_timeout_total` spikes above recent baseline.
+
+## 7. TTL change rollout procedure
+
+Use staged rollout only:
+
+1. Staging:
+- Apply TTL change.
+- Run scenario A/B verification.
+2. Canary:
+- Apply to limited production slice.
+- Observe metrics for at least 30 minutes.
+3. Full rollout:
+- Expand only if canary meets thresholds.
+
+Rollback triggers:
+
+1. `resume_success_rate` drops below `95%` and does not recover within 10 minutes.
+2. `session_resume_fallback_total` shows sustained abnormal increase after TTL change.
+3. `session_heartbeat_timeout_total` rises sharply compared to pre-change baseline.
+
+Rollback action:
+
+1. Revert TTL to previous value.
+2. Keep fallback path active.
+3. Record incident and open follow-up issue if needed.
+
+## 8. Operational record template
+
+```markdown
+### Session/Resume TTL Change Record
+
+- Date:
+- Environment:
+- Previous TTL:
+- New TTL:
+- Staging verification result:
+- Canary window:
+- Resume success rate:
+- Fallback reason distribution:
+- Rollback executed: yes/no
+- Follow-up issues:
+```


### PR DESCRIPTION
## Summary
- LIN-587 のセッション再開/TTL 契約を `database/contracts/lin587_session_resume_runtime_contract.md` で定義し、既存契約やドキュメントへの参照を更新。
- 新しい runbook `docs/runbooks/session-resume-dragonfly-operations-runbook.md` を追加して検証手順・障害時行動・TTL 変更手順を記述し、README・AGENTS・DATABASE に説明とリンクを追加。
- Agent Run ファイルを生成し、ゴール・非ゴール・検証方針・進捗記録を先行させて LIN-587 実装計画を固定。

### LIN-587 Acceptance Criteria 対応
- 合意済み状態モデルと Dragonfly キー/TTL/保持項目、resume 成立・失敗フォールバック、メトリクス/目標値を `lin587_session_resume_runtime_contract.md` と runbook に明文化。
- Dragonfly 障害時の degraded fail-open 挙動を ADR-005 に沿って runbook に記載し、運用メトリクスと品質目標を補強。
- TTL ロールアウト/ロールバック手順を runbook に含め、README/AGENTS/DATABASE のリンク整合性も保証。
- Agent run の Prompt/Plan/Implement/Documentation を作成し、進行記録と文書固定の根拠を保持。

## Testing
- Not run (not requested)