### PR TITLE
LIN-590 GCS署名URLと保持運用基準を文書化

### DIFF
--- a/database/contracts/lin590_gcs_signed_url_and_retention_baseline.md
+++ b/database/contracts/lin590_gcs_signed_url_and_retention_baseline.md
@@ -1,0 +1,133 @@
+# LIN-590 GCS Signed URL / Object Key / Retention Baseline
+
+## Purpose
+
+- Target issue: LIN-590
+- Fix one v0 operational baseline for attachment binary storage on GCS.
+- Provide a stable prerequisite for LIN-597 DR runbook work.
+
+In scope:
+
+- Attachment binary source-of-record boundary for GCS
+- Object key naming convention
+- Signed URL operation policy (TTL, reissue, failure behavior)
+- Versioning, retention, and accidental deletion recovery baseline
+- SLO/SLI viewpoints for signed URL issuance
+
+Out of scope:
+
+- Attachment UI implementation
+- CDN optimization implementation details
+- Runtime API code changes, DB schema changes, or Terraform changes
+
+## References
+
+- `docs/adr/ADR-002-class-ab-event-classification-and-delivery-boundary.md`
+- `docs/adr/ADR-001-event-schema-compatibility.md`
+- `docs/DATABASE.md`
+- `docs/runbooks/gcs-signed-url-retention-operations-runbook.md`
+- `LIN-590`
+- `LIN-597`
+
+## 1. Source-of-record boundary
+
+- GCS is the source of record for attachment binary objects.
+- Postgres/Scylla remain source of record for metadata and message state; they must not duplicate binary payloads.
+- This baseline does not redefine event class assignments. Any event behavior decision must follow ADR-002.
+
+## 2. Object key convention
+
+### 2.1 Fixed key pattern
+
+```text
+v0/tenant/{tenant_id}/guild/{guild_id}/channel/{channel_id}/message/{message_id}/asset/{asset_id}/{filename}
+```
+
+### 2.2 Naming rules
+
+1. Path segments must appear in the fixed order above.
+2. `tenant_id`, `guild_id`, `channel_id`, `message_id`, and `asset_id` are required and immutable after issuance.
+3. `asset_id` must be unique per attachment object and treated as opaque.
+4. `filename` is original-name metadata only; do not use it as identity.
+5. Runtime callers must not upload to keys outside this prefix.
+
+### 2.3 Scope note
+
+- v0 baseline fixes this format for current attachment paths.
+- Future scope expansion (for example alternate channel domains) requires a new contract update.
+
+## 3. Signed URL policy
+
+### 3.1 TTL (fixed values)
+
+- Upload signed URL TTL: `5 minutes`
+- Download signed URL TTL: `5 minutes`
+
+### 3.2 Issuance and usage rules
+
+1. Signed URLs are short-lived and must be generated on demand.
+2. Expired URLs are never reused.
+3. On expiration, clients must request a newly issued URL.
+4. Issuance failures due to dependency outage are treated as unavailable; do not fall back to public object access.
+
+### 3.3 Security baseline
+
+- Objects are private by default.
+- Anonymous/public-read exposure is out of scope for v0.
+- Signed URL leakage is treated as credential leakage; rotate by reissuing and invalidating stale client state.
+
+## 4. Versioning and retention policy
+
+### 4.1 Bucket safety baseline
+
+- Bucket object versioning must be enabled.
+- Deletion operations must be recoverable within the defined protection window.
+
+### 4.2 Retention values
+
+- Accidental deletion recovery protection window: `7 days`
+- Physical deletion is allowed only after the window elapses.
+
+### 4.3 Deletion policy
+
+1. Logical/object deletion requests must preserve recoverability during the protection window.
+2. Direct hard-delete bypass of the protected window is prohibited in normal operations.
+3. Recovery procedures must follow `docs/runbooks/gcs-signed-url-retention-operations-runbook.md`.
+
+## 5. Signed URL SLO/SLI viewpoints
+
+Minimum required viewpoints:
+
+1. Issuance latency: `p95` and `p99`
+2. Issuance success rate
+3. Reissue rate after expiration
+4. Expired URL request ratio
+
+Initial v0 target values:
+
+- Issuance latency target: `p95 <= 200ms`, `p99 <= 400ms`
+- Issuance success target: `>= 99.9%` (rolling 30 days)
+
+Operational note:
+
+- Threshold tuning is allowed only with explicit runbook and contract updates.
+
+## 6. Failure and recovery baseline
+
+1. Expired URL:
+- Return deterministic expiration error.
+- Reissue a new URL and retry upload/download.
+
+2. Accidental deletion within 7-day window:
+- Restore object version and reissue download URL.
+- Record incident and recovery timestamps.
+
+3. Deletion beyond 7-day window:
+- Treat as unrecoverable in-place.
+- Escalate with impact scope and remediation plan.
+
+## 7. Change management and compatibility notes
+
+- Retention/TTL policy changes must follow the runbook change procedure.
+- This issue does not change event schemas; ADR-001 compatibility checklist is `N/A` for schema diffs.
+- Any future event-contract changes for attachment lifecycle must remain additive and follow ADR-001.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -14,6 +14,7 @@
 
 - PostgreSQL: ユーザー、ギルド、権限、招待、監査、既読、Outbox などの正データ
 - ScyllaDB: メッセージ SoR（本文、編集状態、履歴ページング、read_state_hotpath）
+- GCS: 添付バイナリオブジェクトの SoR（署名URL運用 + 保持/復旧基準）
 
 ## 2. PostgreSQL の現在状態
 
@@ -108,6 +109,13 @@ The source of truth for Dragonfly-backed session continuity (`session TTL`, `res
 - `database/contracts/lin587_session_resume_runtime_contract.md`
 - `docs/runbooks/session-resume-dragonfly-operations-runbook.md`
 
+### 2.8 GCS Attachment Operations Baseline (LIN-590)
+
+The source of truth for attachment binary operations on GCS (signed URL policy, object key naming, versioning/retention, and accidental deletion recovery baseline) is:
+
+- `database/contracts/lin590_gcs_signed_url_and_retention_baseline.md`
+- `docs/runbooks/gcs-signed-url-retention-operations-runbook.md`
+
 ## 3. ScyllaDB の現在状態
 
 基準: `database/scylla/001_lin139_messages.cql`
@@ -165,3 +173,6 @@ The source of truth for Scylla operations (SoR boundary, partition review criter
 - LIN-589 Scylla operations baseline:
   - `database/contracts/lin589_scylla_sor_partition_baseline.md`
   - `docs/runbooks/scylla-node-loss-backup-runbook.md`
+- LIN-590 GCS attachment operations baseline:
+  - `database/contracts/lin590_gcs_signed_url_and_retention_baseline.md`
+  - `docs/runbooks/gcs-signed-url-retention-operations-runbook.md`

--- a/docs/agent_runs/LIN-590/Documentation.md
+++ b/docs/agent_runs/LIN-590/Documentation.md
@@ -1,0 +1,46 @@
+# LIN-590 Documentation Log
+
+## Status
+- Completed documentation implementation for LIN-590 scoped baseline updates.
+- Added new contract and runbook for GCS signed URL / naming / retention policy.
+- Updated DB and runbook index documents to reference the new baseline.
+
+## Decisions
+- Scope is documentation-only (no runtime/API/DB schema changes).
+- Fixed values use secure short TTL profile:
+  - Upload signed URL TTL: 5 minutes
+  - Download signed URL TTL: 5 minutes
+  - Accidental deletion recovery window: 7 days
+- GCS is fixed as attachment binary source of record.
+- Event class/outage behavior remains governed by ADR-002.
+- ADR-001 compatibility checklist is N/A for this issue because no event schema change is in scope.
+
+## Implemented artifacts
+- `database/contracts/lin590_gcs_signed_url_and_retention_baseline.md`
+- `docs/runbooks/gcs-signed-url-retention-operations-runbook.md`
+- `docs/DATABASE.md`
+- `docs/runbooks/README.md`
+- `docs/agent_runs/LIN-590/Prompt.md`
+- `docs/agent_runs/LIN-590/Plan.md`
+- `docs/agent_runs/LIN-590/Implement.md`
+- `docs/agent_runs/LIN-590/Documentation.md`
+
+## Acceptance traceability
+
+| Acceptance area | Requirement | Evidence |
+| --- | --- | --- |
+| Functional | Signed URL policy, object naming convention, retention policy are documented | `database/contracts/lin590_gcs_signed_url_and_retention_baseline.md` |
+| Performance | Signed URL issuance SLO/SLI viewpoints are defined | `database/contracts/lin590_gcs_signed_url_and_retention_baseline.md` section 5 |
+| Failure handling | Expired URL reissue and accidental deletion recovery flow are defined | `docs/runbooks/gcs-signed-url-retention-operations-runbook.md` sections 4 and 5 |
+| Operations | Retention policy change procedure is defined | `docs/runbooks/gcs-signed-url-retention-operations-runbook.md` section 6 |
+| Dependency handover | DR handover points for LIN-597 are explicit | `docs/runbooks/gcs-signed-url-retention-operations-runbook.md` section 8 |
+
+## Validation results
+- `make validate`: failed in local environment due to missing TypeScript dependencies.
+  - failure path: `make validate` -> `cd typescript && make format` -> `pnpm run format` -> `prettier . --write`
+  - error: `sh: prettier: command not found`
+  - context: `node_modules` missing (`Local package.json exists, but node_modules missing, did you mean to install?`)
+  - assessment: failure is environment dependency setup related, not caused by LIN-590 document diff.
+
+## Pending
+- None.

--- a/docs/agent_runs/LIN-590/Implement.md
+++ b/docs/agent_runs/LIN-590/Implement.md
@@ -1,0 +1,11 @@
+# LIN-590 Implement Rules
+
+- Keep scope strictly documentation-only.
+- Do not change runtime code, DB schema, or infra definitions.
+- Keep policy values fixed to secure short TTL profile:
+  - upload signed URL TTL = 5 minutes
+  - download signed URL TTL = 5 minutes
+  - accidental deletion protection window = 7 days
+- Keep class/outage decisions aligned with ADR-002 SSOT.
+- Keep schema compatibility note explicit: ADR-001 is N/A for this issue because no event schema change is included.
+- Keep contracts and runbook mutually referential to avoid drift.

--- a/docs/agent_runs/LIN-590/Plan.md
+++ b/docs/agent_runs/LIN-590/Plan.md
@@ -1,0 +1,16 @@
+# LIN-590 Plan
+
+## Milestones
+1. Create LIN-590 baseline contract under `database/contracts`.
+2. Create GCS operations runbook under `docs/runbooks`.
+3. Update DB and runbook index documents with new references.
+4. Record run memory (prompt/plan/implement/documentation) and acceptance traceability.
+
+## Validation commands
+- make validate
+
+## Acceptance checks
+- Functional: signed URL policy, naming convention, and retention policy are documented.
+- Performance: signed URL SLO/SLI viewpoints are defined.
+- Failure: accidental deletion and expired URL recovery/reissue flow is defined.
+- Operations: retention policy change procedure is documented.

--- a/docs/agent_runs/LIN-590/Prompt.md
+++ b/docs/agent_runs/LIN-590/Prompt.md
@@ -1,0 +1,18 @@
+# LIN-590 Prompt
+
+## Goal
+- Fix one v0 baseline for GCS attachment operations by documenting signed URL policy, object key naming, retention policy, and recovery behavior.
+- Keep outputs implementation-ready for LIN-597 DR handover.
+
+## Non-goals
+- Runtime API implementation
+- DB schema changes
+- CDN optimization details
+- Terraform or infra rollout changes
+
+## Done conditions
+- Signed URL policy is fixed with concrete TTL values.
+- Object key naming convention is fixed and unambiguous.
+- Versioning/retention/accidental-deletion recovery baseline is documented.
+- Retention policy change operation flow is documented.
+- References are linked from `docs/DATABASE.md` and runbooks index.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -7,3 +7,4 @@
 - `auth-firebase-principal-operations-runbook.md`: Firebase Auth and `uid -> principal_id` operations baseline (REST/WS error policy, logs/metrics, and outage triage).
 - `session-resume-dragonfly-operations-runbook.md`: Session/resume/TTL continuity baseline on Dragonfly, including degraded behavior and TTL rollout/rollback procedure.
 - `scylla-node-loss-backup-runbook.md`: Scylla node-loss continuity decisions and minimum backup/restore execution baseline for v0.
+- `gcs-signed-url-retention-operations-runbook.md`: GCS attachment signed URL issuance/reissue flow, accidental deletion recovery, and retention policy change baseline.

--- a/docs/runbooks/gcs-signed-url-retention-operations-runbook.md
+++ b/docs/runbooks/gcs-signed-url-retention-operations-runbook.md
@@ -1,0 +1,150 @@
+# GCS Signed URL and Retention Operations Runbook (Draft)
+
+- Status: Draft
+- Last updated: 2026-02-27
+- Owner scope: v0 attachment binary operations baseline
+- References:
+  - `database/contracts/lin590_gcs_signed_url_and_retention_baseline.md`
+  - `docs/adr/ADR-002-class-ab-event-classification-and-delivery-boundary.md`
+  - `docs/DATABASE.md`
+  - `LIN-590`
+  - `LIN-597`
+
+## 1. Purpose and scope
+
+This runbook defines execution steps for signed URL issuance flow, expired URL reissuance, accidental deletion recovery, and retention policy updates for v0 attachment binaries on GCS.
+
+In scope:
+
+- Normal signed URL issuance to upload completion checks
+- Expired URL reissuance flow
+- Recovery flow for accidental deletion within 7-day protection window
+- Retention policy change procedure with impact checks
+
+Out of scope:
+
+- CDN optimization
+- Public object distribution model
+- Infrastructure-as-code implementation details
+
+## 2. Fixed baseline summary
+
+| item | value |
+| --- | --- |
+| Upload signed URL TTL | 5 minutes |
+| Download signed URL TTL | 5 minutes |
+| Object key pattern | `v0/tenant/{tenant_id}/guild/{guild_id}/channel/{channel_id}/message/{message_id}/asset/{asset_id}/{filename}` |
+| Versioning | Enabled |
+| Recovery protection window | 7 days |
+
+## 3. Procedure A: Normal issuance and upload completion
+
+### 3.1 Start conditions
+
+- Valid attachment metadata exists (`tenant/guild/channel/message/asset` identifiers).
+- Request is authorized by current application auth rules.
+
+### 3.2 Steps
+
+1. Build object key using fixed naming convention.
+2. Issue upload signed URL with `TTL=5 minutes`.
+3. Client uploads object to issued URL.
+4. Verify object existence and metadata linkage.
+5. Issue download signed URL with `TTL=5 minutes` only when needed by consumer path.
+
+### 3.3 Close conditions
+
+- Upload completes within URL validity window.
+- Object key and metadata mapping are consistent.
+
+## 4. Procedure B: Expired URL reissuance
+
+### 4.1 Start conditions
+
+- Upload or download request fails with expiration-class error.
+
+### 4.2 Steps
+
+1. Confirm original URL is expired (not authz deny / not object missing).
+2. Generate a new signed URL with the same key and baseline TTL.
+3. Return deterministic retry instruction to caller.
+4. Record reissuance metrics (`expired_url_ratio`, `reissue_count`).
+
+### 4.3 Close conditions
+
+- Caller receives new URL and can retry path.
+- Expired URL is not reused.
+
+## 5. Procedure C: Accidental deletion recovery
+
+### 5.1 Start conditions
+
+- Object missing/deleted is detected for an existing metadata record.
+- Deletion event timestamp is within 7-day protection window.
+
+### 5.2 Steps
+
+1. Identify target object key and affected scope (tenant/guild/channel/message/asset).
+2. Inspect available object versions.
+3. Restore the latest valid version to active state.
+4. Re-validate object availability and metadata linkage.
+5. Reissue download signed URL.
+6. Log incident timeline and root cause candidate.
+
+### 5.3 If outside protection window
+
+1. Mark as unrecoverable in-place.
+2. Escalate with impact scope and user-facing mitigation plan.
+3. Create follow-up action items for prevention.
+
+### 5.4 Close conditions
+
+- Recovery completed and object can be downloaded again, or escalation is formally recorded for unrecoverable case.
+
+## 6. Procedure D: Retention policy change
+
+### 6.1 Pre-check
+
+1. Define business reason and target value change.
+2. Estimate storage and recovery impact.
+3. Confirm compatibility with DR requirements (LIN-597 dependency).
+4. Prepare rollback criteria before apply.
+
+### 6.2 Apply sequence
+
+1. Apply policy update in staging-equivalent environment first.
+2. Validate new and existing objects follow expected lifecycle behavior.
+3. Apply to target environment after validation pass.
+4. Update related contract/runbook docs in the same change set.
+
+### 6.3 Post-check
+
+1. Verify no unexpected early physical deletion.
+2. Verify recovery path still works within configured protection window.
+3. Verify monitoring dashboards reflect new thresholds/targets.
+
+### 6.4 Rollback rule
+
+- If unexpected deletion or recovery regression is detected, roll back to previous retention configuration immediately and open incident tracking.
+
+## 7. Monitoring and alert viewpoints
+
+Minimum monitor items:
+
+- Signed URL issuance latency (`p95`, `p99`)
+- Signed URL issuance success rate
+- Expired URL ratio / reissuance ratio
+- Recovery success/failure counts for accidental deletion
+
+Initial alert viewpoints:
+
+1. Issuance success drops below SLO target.
+2. Expired URL ratio spikes above baseline for sustained windows.
+3. Recovery failure occurs within 7-day protection window.
+
+## 8. Handover checklist for LIN-597 (DR v0)
+
+1. Recovery start/close conditions are objective and testable.
+2. 7-day recovery-window rule is reflected in DR tabletop scenarios.
+3. Incident recording template includes object key scope and recovery timing.
+4. Runbook links remain valid from parent/child issue references.


### PR DESCRIPTION
概要
- `database/contracts/lin590_gcs_signed_url_and_retention_baseline.md` に、GCS添付を SoR とする責務分離、命名規約、TTL、保持、復旧方針を定義
- `docs/runbooks/gcs-signed-url-retention-operations-runbook.md` に、署名URL発行/再発行、誤削除対応、保持期間変更時の運用手順を追加
- `docs/DATABASE.md` と `docs/runbooks/README.md` を更新し、LIN-590 基準文書の参照を追加
- `docs/agent_runs/LIN-590/` に Prompt / Plan / Implement / Documentation を追加

ADR-001 チェック
- 判定: イベントスキーマ変更なし（対象外）
- 互換性判断: ランタイム契約・運用文書の追加のみで、既存イベント契約への破壊的変更なし

テスト
- 未実行（ドキュメント変更のみのため、CI結果で確認）