### PR TITLE
レビューエージェントをcommand権限に昇格

### DIFF
--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
-sandbox_mode = "read-only"
+sandbox_mode = "command"
 developer_instructions = """
 You are the meta reviewer.
 

--- a/.codex/agents/reviewer_coding_rules.toml
+++ b/.codex/agents/reviewer_coding_rules.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
-sandbox_mode = "read-only"
+sandbox_mode = "command"
 developer_instructions = """
 You are a coding-rules reviewer.
 

--- a/.codex/agents/reviewer_correctness.toml
+++ b/.codex/agents/reviewer_correctness.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
-sandbox_mode = "read-only"
+sandbox_mode = "command"
 developer_instructions = """
 You are a correctness reviewer.
 

--- a/.codex/agents/reviewer_performance.toml
+++ b/.codex/agents/reviewer_performance.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex-spark"
 model_reasoning_effort = "high"
-sandbox_mode = "read-only"
+sandbox_mode = "command"
 developer_instructions = """
 You are a performance reviewer.
 

--- a/.codex/agents/reviewer_security.toml
+++ b/.codex/agents/reviewer_security.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
-sandbox_mode = "read-only"
+sandbox_mode = "command"
 developer_instructions = """
 You are a security reviewer.
 

--- a/.codex/agents/reviewer_test_quality.toml
+++ b/.codex/agents/reviewer_test_quality.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex-spark"
 model_reasoning_effort = "medium"
-sandbox_mode = "read-only"
+sandbox_mode = "command"
 developer_instructions = """
 You are a test-quality reviewer.
 

--- a/.codex/agents/reviewer_ui.toml
+++ b/.codex/agents/reviewer_ui.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "medium"
-sandbox_mode = "read-only"
+sandbox_mode = "command"
 developer_instructions = """
 You are the UI reviewer.
 

--- a/.codex/agents/reviewer_ui_guard.toml
+++ b/.codex/agents/reviewer_ui_guard.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex-spark"
 model_reasoning_effort = "low"
-sandbox_mode = "read-only"
+sandbox_mode = "command"
 developer_instructions = """
 You are the UI change guard.
 


### PR DESCRIPTION
## Summary
- リファクタ目的でレビュー関連エージェントの`sandbox_mode`をすべて`command`に更新し、より強い権限を与える
- 指示に沿ってread-onlyな状態だったagentをcommandへ切り替えることでレビュー系処理の整合性を保つ

## Testing
- Not run (not requested)