### PR TITLE
Add reviewer agent command restriction notice

### DIFF
--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -35,5 +35,5 @@ Output format:
 - dropped_as_low_confidence: list
 - final_summary: string
 
-Do not edit files.
+Do not edit files. Do not run commands that modify files (including redirects like `>`/`>>`/`tee`, in-place edits, file create/delete/rename, or git write operations). Use read-only commands only.
 """

--- a/.codex/agents/reviewer_coding_rules.toml
+++ b/.codex/agents/reviewer_coding_rules.toml
@@ -41,5 +41,5 @@ Output requirements:
 - Include exact file and line range when possible.
 - If no rule violations are found, explicitly return `no_findings=true`.
 
-Do not edit files.
+Do not edit files. Do not run commands that modify files (including redirects like `>`/`>>`/`tee`, in-place edits, file create/delete/rename, or git write operations). Use read-only commands only.
 """

--- a/.codex/agents/reviewer_correctness.toml
+++ b/.codex/agents/reviewer_correctness.toml
@@ -18,5 +18,5 @@ Output requirements:
 - For each finding provide: risk, evidence, minimal fix, and how to test.
 - Include exact file and line range when possible.
 
-Do not edit files.
+Do not edit files. Do not run commands that modify files (including redirects like `>`/`>>`/`tee`, in-place edits, file create/delete/rename, or git write operations). Use read-only commands only.
 """

--- a/.codex/agents/reviewer_performance.toml
+++ b/.codex/agents/reviewer_performance.toml
@@ -22,5 +22,5 @@ Output requirements:
 - For each finding provide: risk, evidence, minimal fix, and how to test/measure.
 - Include exact file and line range when possible.
 
-Do not edit files.
+Do not edit files. Do not run commands that modify files (including redirects like `>`/`>>`/`tee`, in-place edits, file create/delete/rename, or git write operations). Use read-only commands only.
 """

--- a/.codex/agents/reviewer_security.toml
+++ b/.codex/agents/reviewer_security.toml
@@ -20,5 +20,5 @@ Output requirements:
 - For each finding provide: risk, evidence, minimal fix, and how to test.
 - Include exact file and line range when possible.
 
-Do not edit files.
+Do not edit files. Do not run commands that modify files (including redirects like `>`/`>>`/`tee`, in-place edits, file create/delete/rename, or git write operations). Use read-only commands only.
 """

--- a/.codex/agents/reviewer_simple.toml
+++ b/.codex/agents/reviewer_simple.toml
@@ -56,5 +56,5 @@ Constraints:
 - Use severity P0/P1/P2/P3 and confidence 0.00-1.00.
 - Include exact file and line range when possible.
 - If no findings, set no_findings=true and provide residual risks briefly.
-- Do not edit files.
+- Do not edit files or run commands that modify files (including redirects like `>`/`>>`/`tee`, in-place edits, file create/delete/rename, or git write operations). Use read-only commands only.
 """

--- a/.codex/agents/reviewer_test_quality.toml
+++ b/.codex/agents/reviewer_test_quality.toml
@@ -17,5 +17,5 @@ Output requirements:
 - For each finding provide: risk, evidence, minimal fix, and how to test.
 - Include exact file and line range when possible.
 
-Do not edit files.
+Do not edit files. Do not run commands that modify files (including redirects like `>`/`>>`/`tee`, in-place edits, file create/delete/rename, or git write operations). Use read-only commands only.
 """

--- a/.codex/agents/reviewer_ui.toml
+++ b/.codex/agents/reviewer_ui.toml
@@ -25,5 +25,5 @@ Output format:
 - warnings: list
 - summary: short string
 
-Do not edit files.
+Do not edit files. Do not run commands that modify files (including redirects like `>`/`>>`/`tee`, in-place edits, file create/delete/rename, or git write operations). Use read-only commands only.
 """

--- a/.codex/agents/reviewer_ui_guard.toml
+++ b/.codex/agents/reviewer_ui_guard.toml
@@ -28,5 +28,5 @@ Output format:
 - matched_files: list
 - rationale: short string
 
-Do not edit files.
+Do not edit files. Do not run commands that modify files (including redirects like `>`/`>>`/`tee`, in-place edits, file create/delete/rename, or git write operations). Use read-only commands only.
 """


### PR DESCRIPTION
## Summary
- ポリシー文書のレビューエージェント設定に、ファイル変更を伴うコマンド実行を禁止する旨を追記
- `command` 権限で動くサブエージェントに対しても、リードオンリーな操作に徹することを明文化

## Testing
- Not run (not requested)