### PR TITLE
[v1/Auth-04] パスワードリセット責務を実装反映: Firebase委譲 + ローカルreset経路を無効化

### DIFF
--- a/docs/runbooks/auth-firebase-principal-operations-runbook.md
+++ b/docs/runbooks/auth-firebase-principal-operations-runbook.md
@@ -10,6 +10,7 @@
   - [LIN-621](https://linear.app/linklynx-ai/issue/LIN-621)
   - [LIN-622](https://linear.app/linklynx-ai/issue/LIN-622)
   - [LIN-624](https://linear.app/linklynx-ai/issue/LIN-624)
+  - [LIN-623](https://linear.app/linklynx-ai/issue/LIN-623)
 
 ## 1. Purpose and scope
 
@@ -79,6 +80,12 @@ Out of scope:
 - Concurrency safety:
   - Provisioning must be idempotent under duplicate/concurrent first-login requests.
   - Conflict-unresolved paths are fail-close (`403`).
+
+### 2.6 Password reset / verification email responsibility
+
+- Application runtime does not manage local password hashes or reset tokens.
+- Password reset and verification emails are delegated to Firebase standard capabilities.
+- Local fallback reset paths are prohibited.
 
 ## 3. Required logs and audit fields
 


### PR DESCRIPTION
## 概要
パスワードリセット責務を Firebase 委譲へ固定するため、運用runbookへ reset/verification email の責務境界を追加しました。

## 変更内容
- `docs/runbooks/auth-firebase-principal-operations-runbook.md` を更新
  - LIN-623 参照を追加
  - `2.6 Password reset / verification email responsibility` を追加
    - ローカルpassword hash/reset token を運用しない
    - reset/verification email は Firebase 標準機能へ委譲
    - ローカルfallback reset経路を禁止

## 意図
- アプリ側ローカルreset運用へ戻る経路を防ぎ、v1方針（Firebase委譲）を運用契約として固定するため。

## Acceptance Criteria 対応
- local reset更新経路を持たない方針を runbook で明文化
- Firebase委譲方針を実装・運用文書で整合
- reset失敗時の運用前提を downstream チームが参照可能

## テスト
- `make validate` ✅

## Linear
- LIN-623
