### PR TITLE
LIN-624 [v1/Auth-03] email_verified必須チェックを実装

### DIFF
--- a/docs/agent_runs/LIN-624/Documentation.md
+++ b/docs/agent_runs/LIN-624/Documentation.md
@@ -1,0 +1,36 @@
+# LIN-624 Documentation Log
+
+## Status
+- Implemented.
+- Shared auth check, error mapping, tests, and runbook updates are completed.
+- Validation finished: `make rust-lint` passed, `make validate` failed due to missing TypeScript toolchain dependencies in local environment.
+
+## Decisions
+- `email_verified` missing claim is treated as `false` via serde default.
+- Verification gate is enforced immediately after token verification and before principal resolution.
+- New deterministic deny contract:
+  - app code: `AUTH_EMAIL_NOT_VERIFIED`
+  - REST: `403`
+  - WS: `1008`
+- Auth decision logs include `email_verification` field (`passed`/`failed`/`unknown`).
+
+## Changed artifacts
+- `rust/apps/api/src/auth/service.rs`
+- `rust/apps/api/src/auth/firebase.rs`
+- `rust/apps/api/src/auth/errors.rs`
+- `rust/apps/api/src/auth/tests.rs`
+- `rust/apps/api/src/main/http_routes.rs`
+- `rust/apps/api/src/main/ws_routes.rs`
+- `rust/apps/api/src/main/tests.rs`
+- `docs/runbooks/auth-firebase-principal-operations-runbook.md`
+- `docs/agent_runs/LIN-624/Prompt.md`
+- `docs/agent_runs/LIN-624/Plan.md`
+- `docs/agent_runs/LIN-624/Implement.md`
+- `docs/agent_runs/LIN-624/Documentation.md`
+
+## Validation results
+- `make rust-lint`: passed.
+- `make validate`: re-run after final fixes; still fails at `typescript` formatter step because `prettier` is not installed (`node_modules` missing).
+
+## Pending
+- None for LIN-624 code scope.

--- a/docs/agent_runs/LIN-624/Implement.md
+++ b/docs/agent_runs/LIN-624/Implement.md
@@ -1,0 +1,7 @@
+# LIN-624 Implement Rules
+
+- Keep scope limited to auth verification + error mapping + tests + runbook sync.
+- Implement the verification gate only in shared auth path (`AuthService`) to avoid REST/WS drift.
+- Treat `email_verified != true` (including missing claim) as `AUTH_EMAIL_NOT_VERIFIED`.
+- Preserve existing fail-close behavior and existing token/principal error mapping.
+- Do not add endpoint-specific exception branches.

--- a/docs/agent_runs/LIN-624/Plan.md
+++ b/docs/agent_runs/LIN-624/Plan.md
@@ -1,0 +1,18 @@
+# LIN-624 Plan
+
+## Milestones
+1. Extend verified token claims with `email_verified` and enforce check in shared `AuthService`.
+2. Add new auth error kind/app code mapping: `AUTH_EMAIL_NOT_VERIFIED`.
+3. Add audit log field for email verification decision in REST/WS auth logs.
+4. Update tests for verified/unverified behavior and mapping contract.
+5. Sync operations runbook with the new failure class and required log field.
+
+## Validation commands
+- make rust-lint
+- make validate
+
+## Acceptance checks
+- Functional: unverified token is denied consistently in REST and WS.
+- Compatibility: verified + mapped principal still succeeds.
+- Contract: new app code maps to HTTP 403 and WS 1008 without breaking existing 401/403/503 semantics.
+- Observability: auth logs include an email verification decision field.

--- a/docs/agent_runs/LIN-624/Prompt.md
+++ b/docs/agent_runs/LIN-624/Prompt.md
@@ -1,0 +1,17 @@
+# LIN-624 Prompt
+
+## Goal
+- Enforce `email_verified` as a required authentication condition for protected REST/WS paths.
+- Keep REST and WS decision semantics aligned by implementing the check in the shared auth service.
+- Introduce `AUTH_EMAIL_NOT_VERIFIED` with consistent mapping and observable audit logs.
+
+## Non-goals
+- UI/email-flow implementation changes.
+- Endpoint-specific auth exceptions.
+- AuthZ policy changes.
+
+## Done conditions
+- Unverified token is rejected consistently in REST and WS protected paths.
+- Verified token with valid principal mapping preserves existing allow path.
+- Error mapping remains compatible with existing 401/403/503 contract.
+- Auth decision logs include email verification decision result.

--- a/docs/runbooks/auth-firebase-principal-operations-runbook.md
+++ b/docs/runbooks/auth-firebase-principal-operations-runbook.md
@@ -1,7 +1,7 @@
 # Firebase Auth / principal_id Operations Runbook (Draft)
 
 - Status: Draft
-- Last updated: 2026-02-27
+- Last updated: 2026-02-28
 - Owner scope: v0 auth operations baseline for REST/WS shared authentication
 - References:
   - [ADR-005 Dragonfly Outage RateLimit Failure Policy (Hybrid)](../adr/ADR-005-dragonfly-ratelimit-failure-policy.md)
@@ -39,6 +39,7 @@ Out of scope:
 | failure class | REST | WS close code | app-level code |
 | --- | --- | --- | --- |
 | missing/invalid/expired token | `401` | `1008` | `AUTH_MISSING_TOKEN` / `AUTH_INVALID_TOKEN` / `AUTH_TOKEN_EXPIRED` |
+| email not verified | `403` | `1008` | `AUTH_EMAIL_NOT_VERIFIED` |
 | principal mapping missing/invalid | `403` | `1008` | `AUTH_PRINCIPAL_NOT_MAPPED` |
 | auth dependency unavailable (JWKS/cache/store) | `503` | `1011` | `AUTH_UNAVAILABLE` |
 
@@ -75,6 +76,7 @@ Minimum required log fields on authentication decision paths:
 - `request_id`
 - `principal_id` (when resolved)
 - `firebase_uid` (when available)
+- `email_verification` (`passed` / `failed` / `unknown`)
 - `decision` (`allow` / `deny` / `unavailable`)
 - `error_class` (for non-allow decisions)
 - `reason`
@@ -160,12 +162,17 @@ Primary response:
 - REST returns `403`.
 - WS closes with `1008`.
 
-4. Dependency unavailable simulation (JWKS/store):
+4. Email not verified:
+- REST returns `403` with `AUTH_EMAIL_NOT_VERIFIED`.
+- WS closes with `1008`.
+
+5. Dependency unavailable simulation (JWKS/store):
 - REST returns `503`.
 - WS closes with `1011`.
 
-5. Log and metrics checks:
+6. Log and metrics checks:
 - confirm `request_id` presence
+- confirm `email_verification` field is recorded on auth decision logs
 - confirm `principal_id` appears on allow logs
 - confirm metrics counters move for each scenario
 

--- a/rust/apps/api/src/auth/errors.rs
+++ b/rust/apps/api/src/auth/errors.rs
@@ -30,6 +30,7 @@ pub enum AuthErrorKind {
     MissingToken,
     InvalidToken,
     ExpiredToken,
+    EmailNotVerified,
     PrincipalNotMapped,
     DependencyUnavailable,
 }
@@ -75,6 +76,17 @@ impl AuthError {
         }
     }
 
+    /// メール未確認エラーを生成する。
+    /// @param reason 失敗理由
+    /// @returns メール未確認エラー
+    /// @throws なし
+    pub fn email_not_verified(reason: impl Into<String>) -> Self {
+        Self {
+            kind: AuthErrorKind::EmailNotVerified,
+            reason: reason.into(),
+        }
+    }
+
     /// 主体未解決エラーを生成する。
     /// @param reason 失敗理由
     /// @returns 主体未解決エラー
@@ -106,7 +118,9 @@ impl AuthError {
             AuthErrorKind::MissingToken
             | AuthErrorKind::InvalidToken
             | AuthErrorKind::ExpiredToken => StatusCode::UNAUTHORIZED,
-            AuthErrorKind::PrincipalNotMapped => StatusCode::FORBIDDEN,
+            AuthErrorKind::EmailNotVerified | AuthErrorKind::PrincipalNotMapped => {
+                StatusCode::FORBIDDEN
+            }
             AuthErrorKind::DependencyUnavailable => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
@@ -120,6 +134,7 @@ impl AuthError {
             AuthErrorKind::MissingToken => "AUTH_MISSING_TOKEN",
             AuthErrorKind::InvalidToken => "AUTH_INVALID_TOKEN",
             AuthErrorKind::ExpiredToken => "AUTH_TOKEN_EXPIRED",
+            AuthErrorKind::EmailNotVerified => "AUTH_EMAIL_NOT_VERIFIED",
             AuthErrorKind::PrincipalNotMapped => "AUTH_PRINCIPAL_NOT_MAPPED",
             AuthErrorKind::DependencyUnavailable => "AUTH_UNAVAILABLE",
         }
@@ -134,6 +149,7 @@ impl AuthError {
             AuthErrorKind::MissingToken => "authentication token is required",
             AuthErrorKind::InvalidToken => "authentication token is invalid",
             AuthErrorKind::ExpiredToken => "authentication token is expired",
+            AuthErrorKind::EmailNotVerified => "email verification is required",
             AuthErrorKind::PrincipalNotMapped => "principal mapping is not found",
             AuthErrorKind::DependencyUnavailable => "authentication dependency is unavailable",
         }
@@ -159,6 +175,7 @@ impl AuthError {
             AuthErrorKind::MissingToken => "missing_token",
             AuthErrorKind::InvalidToken => "invalid_token",
             AuthErrorKind::ExpiredToken => "expired_token",
+            AuthErrorKind::EmailNotVerified => "email_not_verified",
             AuthErrorKind::PrincipalNotMapped => "principal_not_mapped",
             AuthErrorKind::DependencyUnavailable => "dependency_unavailable",
         }
@@ -172,6 +189,17 @@ impl AuthError {
         match self.kind {
             AuthErrorKind::DependencyUnavailable => "unavailable",
             _ => "deny",
+        }
+    }
+
+    /// メール検証判定結果を返す。
+    /// @param なし
+    /// @returns メール検証結果
+    /// @throws なし
+    pub fn email_verification_result(&self) -> &'static str {
+        match self.kind {
+            AuthErrorKind::EmailNotVerified => "failed",
+            _ => "unknown",
         }
     }
 }

--- a/rust/apps/api/src/auth/firebase.rs
+++ b/rust/apps/api/src/auth/firebase.rs
@@ -98,6 +98,7 @@ impl TokenVerifier for FirebaseTokenVerifier {
 
         Ok(VerifiedToken {
             uid: token_data.claims.sub,
+            email_verified: token_data.claims.email_verified,
             expires_at_epoch: token_data.claims.exp,
         })
     }
@@ -106,6 +107,8 @@ impl TokenVerifier for FirebaseTokenVerifier {
 #[derive(Debug, Deserialize)]
 struct FirebaseClaims {
     sub: String,
+    #[serde(default)]
+    email_verified: bool,
     exp: u64,
     iat: u64,
 }

--- a/rust/apps/api/src/auth/service.rs
+++ b/rust/apps/api/src/auth/service.rs
@@ -22,6 +22,7 @@ pub trait PrincipalResolver: Send + Sync {
 #[derive(Debug, Clone)]
 pub struct VerifiedToken {
     pub uid: String,
+    pub email_verified: bool,
     pub expires_at_epoch: u64,
 }
 
@@ -101,6 +102,10 @@ impl AuthService {
                 return Err(AuthError::dependency_unavailable(reason));
             }
         };
+
+        if !verified.email_verified {
+            return Err(AuthError::email_not_verified("email_not_verified"));
+        }
 
         let principal_id = self
             .resolver

--- a/rust/apps/api/src/auth/tests.rs
+++ b/rust/apps/api/src/auth/tests.rs
@@ -51,9 +51,22 @@ mod tests {
     #[async_trait]
     impl TokenVerifier for StaticTokenVerifier {
         async fn verify(&self, token: &str) -> Result<VerifiedToken, TokenVerifyError> {
-            let Some((uid, exp)) = token.split_once(':') else {
+            let mut segments = token.split(':');
+            let Some(uid) = segments.next() else {
                 return Err(TokenVerifyError::Invalid("token_format_invalid"));
             };
+            let Some(exp) = segments.next() else {
+                return Err(TokenVerifyError::Invalid("token_format_invalid"));
+            };
+            let email_verified = match segments.next() {
+                None => false,
+                Some("true" | "1") => true,
+                Some("false" | "0") => false,
+                Some(_) => return Err(TokenVerifyError::Invalid("token_verified_invalid")),
+            };
+            if segments.next().is_some() {
+                return Err(TokenVerifyError::Invalid("token_format_invalid"));
+            }
 
             let expires_at_epoch = exp
                 .parse::<u64>()
@@ -65,6 +78,7 @@ mod tests {
 
             Ok(VerifiedToken {
                 uid: uid.to_owned(),
+                email_verified,
                 expires_at_epoch,
             })
         }
@@ -88,11 +102,50 @@ mod tests {
         ));
 
         let service = AuthService::new(verifier, resolver, metrics);
-        let token = format!("u-1:{}", unix_timestamp_seconds() + 60);
+        let token = format!("u-1:{}:true", unix_timestamp_seconds() + 60);
 
         let authenticated = service.authenticate_token(&token).await.unwrap();
         assert_eq!(authenticated.principal_id.0, 42);
         assert_eq!(authenticated.firebase_uid, "u-1");
+    }
+
+    #[tokio::test]
+    async fn auth_service_rejects_unverified_email_before_principal_resolution() {
+        let metrics = Arc::new(AuthMetrics::default());
+        let verifier: Arc<dyn TokenVerifier> = Arc::new(StaticTokenVerifier);
+        let resolver: Arc<dyn PrincipalResolver> = Arc::new(CachingPrincipalResolver::new(
+            FIREBASE_PROVIDER.to_owned(),
+            Arc::new(InMemoryPrincipalCache::default()),
+            Arc::new(InMemoryPrincipalStore::default()),
+            Duration::from_secs(30),
+            Arc::clone(&metrics),
+        ));
+
+        let service = AuthService::new(verifier, resolver, metrics);
+        let token = format!("u-unknown:{}:false", unix_timestamp_seconds() + 60);
+        let error = service.authenticate_token(&token).await.unwrap_err();
+
+        assert_eq!(error.kind, AuthErrorKind::EmailNotVerified);
+        assert_eq!(error.app_code(), "AUTH_EMAIL_NOT_VERIFIED");
+    }
+
+    #[tokio::test]
+    async fn auth_service_treats_missing_email_verified_claim_as_unverified() {
+        let metrics = Arc::new(AuthMetrics::default());
+        let verifier: Arc<dyn TokenVerifier> = Arc::new(StaticTokenVerifier);
+        let resolver: Arc<dyn PrincipalResolver> = Arc::new(CachingPrincipalResolver::new(
+            FIREBASE_PROVIDER.to_owned(),
+            Arc::new(InMemoryPrincipalCache::default()),
+            Arc::new(InMemoryPrincipalStore::default()),
+            Duration::from_secs(30),
+            Arc::clone(&metrics),
+        ));
+
+        let service = AuthService::new(verifier, resolver, metrics);
+        let token = format!("u-any:{}", unix_timestamp_seconds() + 60);
+        let error = service.authenticate_token(&token).await.unwrap_err();
+
+        assert_eq!(error.kind, AuthErrorKind::EmailNotVerified);
     }
 
     #[test]
@@ -119,6 +172,15 @@ mod tests {
             AuthError::dependency_unavailable("downstream_down").decision(),
             "unavailable"
         );
+    }
+
+    #[test]
+    fn auth_error_email_not_verified_maps_to_forbidden() {
+        let error = AuthError::email_not_verified("email_not_verified");
+        assert_eq!(error.status_code(), StatusCode::FORBIDDEN);
+        assert_eq!(error.app_code(), "AUTH_EMAIL_NOT_VERIFIED");
+        assert_eq!(error.ws_close_code(), 1008);
+        assert_eq!(error.email_verification_result(), "failed");
     }
 
     #[tokio::test]

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -90,6 +90,7 @@ async fn rest_auth_middleware(
         Err(error) => {
             tracing::warn!(
                 decision = %error.decision(),
+                email_verification = %error.email_verification_result(),
                 request_id = %request_id,
                 error_class = %error.log_class(),
                 reason = %error.reason,
@@ -104,6 +105,7 @@ async fn rest_auth_middleware(
         Err(error) => {
             tracing::warn!(
                 decision = %error.decision(),
+                email_verification = %error.email_verification_result(),
                 request_id = %request_id,
                 error_class = %error.log_class(),
                 reason = %error.reason,
@@ -115,6 +117,7 @@ async fn rest_auth_middleware(
 
     tracing::info!(
         decision = "allow",
+        email_verification = "passed",
         request_id = %request_id,
         principal_id = authenticated.principal_id.0,
         firebase_uid = %authenticated.firebase_uid,

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -17,9 +17,22 @@ mod tests {
     #[async_trait]
     impl TokenVerifier for StaticTokenVerifier {
         async fn verify(&self, token: &str) -> Result<VerifiedToken, TokenVerifyError> {
-            let Some((uid, exp)) = token.split_once(':') else {
+            let mut segments = token.split(':');
+            let Some(uid) = segments.next() else {
                 return Err(TokenVerifyError::Invalid("token_format_invalid"));
             };
+            let Some(exp) = segments.next() else {
+                return Err(TokenVerifyError::Invalid("token_format_invalid"));
+            };
+            let email_verified = match segments.next() {
+                None => false,
+                Some("true" | "1") => true,
+                Some("false" | "0") => false,
+                Some(_) => return Err(TokenVerifyError::Invalid("token_verified_invalid")),
+            };
+            if segments.next().is_some() {
+                return Err(TokenVerifyError::Invalid("token_format_invalid"));
+            }
 
             let exp = exp
                 .parse::<u64>()
@@ -31,6 +44,7 @@ mod tests {
 
             Ok(VerifiedToken {
                 uid: uid.to_owned(),
+                email_verified,
                 expires_at_epoch: exp,
             })
         }
@@ -114,7 +128,7 @@ mod tests {
     #[tokio::test]
     async fn protected_endpoint_accepts_valid_token() {
         let app = app_for_test().await;
-        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let token = format!("u-1:{}:true", unix_timestamp_seconds() + 300);
         let response = app
             .oneshot(
                 Request::builder()
@@ -142,7 +156,7 @@ mod tests {
     #[tokio::test]
     async fn protected_endpoint_returns_forbidden_when_mapping_missing() {
         let app = app_for_test().await;
-        let token = format!("u-unknown:{}", unix_timestamp_seconds() + 300);
+        let token = format!("u-unknown:{}:true", unix_timestamp_seconds() + 300);
         let response = app
             .oneshot(
                 Request::builder()
@@ -155,6 +169,29 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn protected_endpoint_rejects_unverified_email_with_expected_code() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}:false", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/protected/ping")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "AUTH_EMAIL_NOT_VERIFIED");
     }
 
     #[test]

--- a/rust/apps/api/src/main/ws_routes.rs
+++ b/rust/apps/api/src/main/ws_routes.rs
@@ -15,6 +15,7 @@ async fn ws_handler(
         Err(error) => {
             tracing::warn!(
                 decision = %error.decision(),
+                email_verification = %error.email_verification_result(),
                 request_id = %request_id,
                 error_class = %error.log_class(),
                 reason = %error.reason,
@@ -29,6 +30,7 @@ async fn ws_handler(
         Err(error) => {
             tracing::warn!(
                 decision = %error.decision(),
+                email_verification = %error.email_verification_result(),
                 request_id = %request_id,
                 error_class = %error.log_class(),
                 reason = %error.reason,
@@ -40,6 +42,7 @@ async fn ws_handler(
 
     tracing::info!(
         decision = "allow",
+        email_verification = "passed",
         request_id = %request_id,
         principal_id = authenticated.principal_id.0,
         firebase_uid = %authenticated.firebase_uid,
@@ -214,6 +217,7 @@ async fn handle_socket_message(
                             state.auth_service.metrics().record_ws_reauth(false);
                             tracing::warn!(
                                 decision = "deny",
+                                email_verification = "passed",
                                 request_id = %request_id,
                                 error_class = "principal_changed",
                                 reason = "principal_changed",
@@ -228,6 +232,7 @@ async fn handle_socket_message(
                         state.auth_service.metrics().record_ws_reauth(true);
                         tracing::info!(
                             decision = "allow",
+                            email_verification = "passed",
                             request_id = %request_id,
                             principal_id = authenticated.principal_id.0,
                             firebase_uid = %authenticated.firebase_uid,
@@ -246,6 +251,7 @@ async fn handle_socket_message(
                         state.auth_service.metrics().record_ws_reauth(false);
                         tracing::warn!(
                             decision = %error.decision(),
+                            email_verification = %error.email_verification_result(),
                             request_id = %request_id,
                             error_class = %error.log_class(),
                             reason = %error.reason,


### PR DESCRIPTION
## 概要
LIN-624 の実装として、Firebase claims の `email_verified` を認証判定へ組み込み、REST/WS 共通経路で未確認メールを拒否するようにしました。

## 変更内容
- `VerifiedToken` に `email_verified` を追加
- token verify 直後に `email_verified` 判定を追加（`true` 以外は拒否）
- 新規エラー `AUTH_EMAIL_NOT_VERIFIED` を追加
  - REST: `403`
  - WS close code: `1008`
- 認証監査ログに `email_verification` フィールド（`passed` / `failed` / `unknown`）を追加
- 認証系テストを追加・更新（verified/unverified/missing claim）
- runbook 更新: `AUTH_EMAIL_NOT_VERIFIED` と監査ログ必須項目を追記

## 受け入れ基準対応
- unverified token は保護経路で一貫して拒否
  - 共通 `AuthService` で判定
- verified token + 有効 principal は既存通過シナリオを維持
  - 既存成功ケースを維持し回帰テストを追加
- 401/403/503 契約と整合
  - `AUTH_EMAIL_NOT_VERIFIED` は deterministic deny として `403/1008` にマップ

## テスト
- `make rust-lint` ✅
- `make validate` ❌（環境要因）
  - `typescript` の format ステップで `prettier: command not found`
  - `node_modules` 未導入による失敗

## ADR-001 チェック
- イベントスキーマ変更: なし
- 互換性判断: 既存イベント契約への影響なし（ADR-001 は N/A）

## UI チェック
- `skipped`（UI 変更なし）

## 関連
- Linear: https://linear.app/linklynx-ai/issue/LIN-624
