### PR TITLE
[Backend] LIN-457 HTTP共通ミドルウェア（CORS/AuthContext/入力制限）を実装

### DIFF
--- a/docs/agent_runs/LIN-457/Documentation.md
+++ b/docs/agent_runs/LIN-457/Documentation.md
@@ -1,0 +1,31 @@
+# LIN-457 Documentation Log
+
+## Status
+- Implemented LIN-462/LIN-464/LIN-463 scope on branch `codex/lin-457`.
+- Validation completed with `make rust-lint` and `make validate` success.
+
+## Decisions
+- Child issue execution order: LIN-462 -> LIN-464 -> LIN-463.
+- Keep unified HTTP error body shape for new middleware errors.
+- Add `Retry-After: 1` for auth dependency-unavailable (`503`) responses.
+- Extend `AuthContext` with `expires_at_epoch` for downstream middleware reuse.
+- Enforce fail-close input-limit policy for `Transfer-Encoding` and invalid `Content-Length`.
+- Validate CORS allowlist entries as origin URLs (`http|https` + authority).
+- Reject unbounded request bodies when size hint cannot determine upper bound.
+- Normalize allowlist origins to `scheme://authority` to avoid trailing-slash mismatch.
+- Make CORS middleware tests deterministic by using fixed allowlist values in test state.
+
+## Validation
+- `cd rust && cargo test -p linklynx_backend -- --nocapture` passed.
+- `make rust-lint` passed.
+- `make validate` passed.
+- Sub-agent review feedback reflected and re-validated.
+
+## Follow-ups
+- None in this run.
+
+## Added/Used Runtime Config
+- `CORS_ALLOW_ORIGINS` (comma-separated origins)
+- `HTTP_BODY_LIMIT_BYTES` (default `1048576`)
+- `HTTP_REQUEST_TIMEOUT_MILLIS` (default `5000`)
+- `HTTP_RETRY_AFTER_SECONDS` (default `1`)

--- a/docs/agent_runs/LIN-457/Implement.md
+++ b/docs/agent_runs/LIN-457/Implement.md
@@ -1,0 +1,7 @@
+# LIN-457 Implement Rules
+
+- Keep scope to Rust API middleware only.
+- Preserve existing auth error shape (`code`, `message`, `request_id`).
+- Avoid unrelated refactors.
+- Add tests for each contract change.
+- Keep default behavior fail-close where policy is ambiguous.

--- a/docs/agent_runs/LIN-457/Plan.md
+++ b/docs/agent_runs/LIN-457/Plan.md
@@ -1,0 +1,16 @@
+# LIN-457 Plan
+
+## Milestones
+1. LIN-462: CORS allowlist implementation and tests.
+2. LIN-464: Input limit middleware (body/timeout) + unified 429/Retry-After contract.
+3. LIN-463: AuthContext extension + middleware wiring + tests.
+4. Validate and review gates.
+
+## Validation Commands
+- `make validate`
+- `make rust-lint`
+
+## Acceptance Criteria Mapping
+- CORS allowlist and middleware order are explicit in code and tests.
+- 401/403/429 contracts are stable and machine-checkable.
+- Retry-After exists for 429 responses.

--- a/docs/agent_runs/LIN-457/Prompt.md
+++ b/docs/agent_runs/LIN-457/Prompt.md
@@ -1,0 +1,15 @@
+# LIN-457 Prompt
+
+## Goal
+- Implement HTTP common middleware baseline for LIN-457 via child issues LIN-462/LIN-464/LIN-463.
+- Fix middleware order contract to `CORS -> AuthContext -> InputLimit` for protected HTTP endpoints.
+
+## Non-goals
+- No TLS/container runtime hardening changes.
+- No WS behavior redesign beyond AuthContext contract alignment.
+
+## Done Conditions
+- CORS is allowlist-based (no wildcard allow-all in runtime defaults).
+- InputLimit middleware returns unified 429 contract with `Retry-After`.
+- AuthContext contains reusable fields for downstream middleware.
+- Tests cover CORS allowlist behavior, auth contract, and input-limit responses.

--- a/rust/apps/api/src/auth.rs
+++ b/rust/apps/api/src/auth.rs
@@ -10,7 +10,10 @@ use std::{
 
 use async_trait::async_trait;
 use axum::{
-    http::{header::AUTHORIZATION, HeaderMap, StatusCode},
+    http::{
+        header::{AUTHORIZATION, RETRY_AFTER},
+        HeaderMap, HeaderValue, StatusCode,
+    },
     response::{IntoResponse, Response},
     Json,
 };

--- a/rust/apps/api/src/auth/errors.rs
+++ b/rust/apps/api/src/auth/errors.rs
@@ -22,6 +22,23 @@ pub struct AuthContext {
     pub request_id: String,
     pub principal_id: PrincipalId,
     pub firebase_uid: String,
+    pub expires_at_epoch: u64,
+}
+
+impl AuthContext {
+    /// 認証済み主体からAuthContextを生成する。
+    /// @param request_id リクエスト追跡ID
+    /// @param authenticated 認証済み主体
+    /// @returns ハンドラへ注入する認証文脈
+    /// @throws なし
+    pub fn from_authenticated(request_id: String, authenticated: &AuthenticatedPrincipal) -> Self {
+        Self {
+            request_id,
+            principal_id: authenticated.principal_id,
+            firebase_uid: authenticated.firebase_uid.clone(),
+            expires_at_epoch: authenticated.expires_at_epoch,
+        }
+    }
 }
 
 /// 認証エラー種別を表現する。
@@ -195,7 +212,13 @@ pub fn auth_error_response(error: &AuthError, request_id: String) -> Response {
         request_id,
     };
 
-    (error.status_code(), Json(body)).into_response()
+    let mut response = (error.status_code(), Json(body)).into_response();
+    if error.kind == AuthErrorKind::DependencyUnavailable {
+        response
+            .headers_mut()
+            .insert(RETRY_AFTER, HeaderValue::from_static("1"));
+    }
+    response
 }
 
 /// ヘッダーからBearerトークンを抽出する。

--- a/rust/apps/api/src/auth/tests.rs
+++ b/rust/apps/api/src/auth/tests.rs
@@ -121,6 +121,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn auth_error_response_adds_retry_after_on_dependency_unavailable() {
+        let response = auth_error_response(
+            &AuthError::dependency_unavailable("downstream_down"),
+            "req-1".to_owned(),
+        );
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers().get(RETRY_AFTER).unwrap(), "1");
+    }
+
     #[tokio::test]
     async fn jwks_cache_respects_missing_kid_refresh_backoff() {
         let client = Client::builder()

--- a/rust/apps/api/src/main.rs
+++ b/rust/apps/api/src/main.rs
@@ -1,6 +1,7 @@
 mod auth;
 
 use std::{
+    collections::BTreeSet,
     env,
     net::SocketAddr,
     sync::Arc,
@@ -18,7 +19,7 @@ use axum::{
         ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade},
         Extension, State,
     },
-    http::{HeaderMap, Request},
+    http::{HeaderMap, HeaderValue, Request, Uri},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::get,
@@ -28,10 +29,25 @@ use serde::{Deserialize, Serialize};
 use tower_http::cors::{Any, CorsLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+const DEFAULT_WS_REAUTH_GRACE_SECONDS: u64 = 30;
+const DEFAULT_HTTP_BODY_LIMIT_BYTES: usize = 1_048_576;
+const DEFAULT_HTTP_REQUEST_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_HTTP_RETRY_AFTER_SECONDS: u64 = 1;
+const DEFAULT_CORS_ALLOW_ORIGINS: [&str; 2] = ["http://localhost:3000", "http://127.0.0.1:3000"];
+
+#[derive(Clone, Debug)]
+pub(crate) struct HttpMiddlewareConfig {
+    cors_allow_origins: Vec<HeaderValue>,
+    body_limit_bytes: usize,
+    request_timeout: Duration,
+    retry_after_seconds: u64,
+}
+
 #[derive(Clone)]
 pub(crate) struct AppState {
     auth_service: Arc<AuthService>,
     ws_reauth_grace: Duration,
+    http_middleware: HttpMiddlewareConfig,
 }
 
 #[tokio::main]
@@ -71,17 +87,128 @@ fn server_addr() -> SocketAddr {
 fn build_runtime_state() -> AppState {
     let metrics = Arc::new(AuthMetrics::default());
     let auth_service = Arc::new(build_runtime_auth_service(Arc::clone(&metrics)));
-    let ws_reauth_grace = Duration::from_secs(
-        env::var("WS_REAUTH_GRACE_SECONDS")
-            .ok()
-            .and_then(|value| value.parse::<u64>().ok())
-            .unwrap_or(30),
-    );
+    let ws_reauth_grace = Duration::from_secs(parse_env_u64(
+        "WS_REAUTH_GRACE_SECONDS",
+        DEFAULT_WS_REAUTH_GRACE_SECONDS,
+    ));
 
     AppState {
         auth_service,
         ws_reauth_grace,
+        http_middleware: build_http_middleware_config(),
     }
+}
+
+/// HTTPミドルウェア設定を環境変数から構築する。
+/// @param なし
+/// @returns HTTPミドルウェア設定
+/// @throws なし
+fn build_http_middleware_config() -> HttpMiddlewareConfig {
+    let body_limit_u64 = parse_env_u64(
+        "HTTP_BODY_LIMIT_BYTES",
+        DEFAULT_HTTP_BODY_LIMIT_BYTES as u64,
+    );
+    let body_limit_bytes = usize::try_from(body_limit_u64).unwrap_or(DEFAULT_HTTP_BODY_LIMIT_BYTES);
+    let timeout_ms = parse_env_u64(
+        "HTTP_REQUEST_TIMEOUT_MILLIS",
+        DEFAULT_HTTP_REQUEST_TIMEOUT_MS,
+    );
+    let retry_after_seconds =
+        parse_env_u64("HTTP_RETRY_AFTER_SECONDS", DEFAULT_HTTP_RETRY_AFTER_SECONDS);
+
+    HttpMiddlewareConfig {
+        cors_allow_origins: parse_cors_allow_origins(),
+        body_limit_bytes,
+        request_timeout: Duration::from_millis(timeout_ms),
+        retry_after_seconds,
+    }
+}
+
+/// 整数環境変数を取得する。
+/// @param key 環境変数名
+/// @param default_value 既定値
+/// @returns 取得した値または既定値
+/// @throws なし
+fn parse_env_u64(key: &str, default_value: u64) -> u64 {
+    env::var(key)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(default_value)
+}
+
+/// CORS許可Origin一覧を環境変数から取得する。
+/// @param なし
+/// @returns CORS許可Originのヘッダー値一覧
+/// @throws なし
+fn parse_cors_allow_origins() -> Vec<HeaderValue> {
+    let configured = match env::var("CORS_ALLOW_ORIGINS") {
+        Ok(raw) => raw
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .collect::<Vec<String>>(),
+        Err(_) => {
+            tracing::warn!("CORS_ALLOW_ORIGINS is not set; using secure localhost defaults");
+            DEFAULT_CORS_ALLOW_ORIGINS
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>()
+        }
+    };
+
+    let mut unique_values = BTreeSet::new();
+    for value in configured {
+        let Some(normalized) = normalize_origin(&value) else {
+            tracing::warn!(
+                origin = %value,
+                "invalid CORS origin found in CORS_ALLOW_ORIGINS and skipped"
+            );
+            continue;
+        };
+        if HeaderValue::from_str(&normalized).is_err() {
+            tracing::warn!(
+                origin = %normalized,
+                "CORS origin is syntactically invalid as header value and skipped"
+            );
+            continue;
+        }
+        unique_values.insert(normalized);
+    }
+
+    if unique_values.is_empty() {
+        return DEFAULT_CORS_ALLOW_ORIGINS
+            .iter()
+            .map(|origin| HeaderValue::from_str(origin).expect("default CORS origin must be valid"))
+            .collect();
+    }
+
+    unique_values
+        .into_iter()
+        .map(|origin| HeaderValue::from_str(&origin).expect("validated CORS origin must be valid"))
+        .collect()
+}
+
+/// Origin文字列をCORS比較用の正規形式へ変換する。
+/// @param origin Origin文字列
+/// @returns `scheme://authority` 形式の正規化結果
+/// @throws なし
+fn normalize_origin(origin: &str) -> Option<String> {
+    let Ok(uri) = origin.parse::<Uri>() else {
+        return None;
+    };
+
+    let scheme_is_valid = matches!(uri.scheme_str(), Some("http" | "https"));
+    if !scheme_is_valid || uri.authority().is_none() {
+        return None;
+    }
+    if !(uri.path().is_empty() || uri.path() == "/") || uri.query().is_some() {
+        return None;
+    }
+
+    let scheme = uri.scheme_str().expect("scheme validated");
+    let authority = uri.authority().expect("authority validated");
+    Some(format!("{scheme}://{authority}"))
 }
 
 /// 実行時ルータを構築する。

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -1,19 +1,28 @@
+use axum::body::HttpBody as _;
+use axum::http::{
+    header::{CONTENT_LENGTH, RETRY_AFTER, TRANSFER_ENCODING},
+    StatusCode,
+};
+use tower_http::cors::AllowOrigin;
+
 /// 状態付きルータを構築する。
 /// @param state アプリケーション状態
 /// @returns APIルータ
 /// @throws なし
 fn app_with_state(state: AppState) -> Router {
     let cors = CorsLayer::new()
-        .allow_origin(Any)
+        .allow_origin(AllowOrigin::list(state.http_middleware.cors_allow_origins.clone()))
         .allow_methods(Any)
         .allow_headers(Any);
 
-    let protected_routes = Router::new()
-        .route("/v1/protected/ping", get(protected_ping))
-        .route_layer(middleware::from_fn_with_state(
-            state.clone(),
-            rest_auth_middleware,
-        ));
+    let protected_routes = Router::new().route("/v1/protected/ping", get(protected_ping));
+    #[cfg(test)]
+    let protected_routes = protected_routes.route("/v1/protected/slow", get(protected_slow));
+
+    let protected_routes = protected_routes.route_layer(middleware::from_fn_with_state(
+        state.clone(),
+        protected_auth_input_middleware,
+    ));
 
     Router::new()
         .route("/", get(root))
@@ -47,6 +56,7 @@ struct ProtectedPingResponse {
     request_id: String,
     principal_id: i64,
     firebase_uid: String,
+    expires_at_epoch: u64,
 }
 
 /// 認証済みエンドポイントの疎通応答を返す。
@@ -61,7 +71,18 @@ async fn protected_ping(
         request_id: auth_context.request_id,
         principal_id: auth_context.principal_id.0,
         firebase_uid: auth_context.firebase_uid,
+        expires_at_epoch: auth_context.expires_at_epoch,
     })
+}
+
+#[cfg(test)]
+/// テスト用に遅延応答を返す。
+/// @param なし
+/// @returns 遅延後の正常応答
+/// @throws なし
+async fn protected_slow() -> &'static str {
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    "slow-ok"
 }
 
 /// 認証メトリクスを返す。
@@ -72,13 +93,92 @@ async fn auth_metrics_handler(State(state): State<AppState>) -> Json<AuthMetrics
     Json(state.auth_service.metrics().snapshot())
 }
 
-/// REST認証ミドルウェアを実行する。
+#[derive(Debug, Serialize)]
+struct InputLimitErrorBody {
+    code: &'static str,
+    message: &'static str,
+    request_id: String,
+}
+
+/// 入力制限エラーレスポンスを返す。
+/// @param request_id リクエスト追跡ID
+/// @param code エラーコード
+/// @param message エラーメッセージ
+/// @param retry_after_seconds 再試行可能秒数
+/// @returns 入力制限エラーレスポンス
+/// @throws なし
+fn input_limit_error_response(
+    request_id: String,
+    code: &'static str,
+    message: &'static str,
+    retry_after_seconds: u64,
+) -> Response {
+    let mut response = (
+        StatusCode::TOO_MANY_REQUESTS,
+        Json(InputLimitErrorBody {
+            code,
+            message,
+            request_id,
+        }),
+    )
+        .into_response();
+    if let Ok(value) = retry_after_seconds.to_string().parse() {
+        response.headers_mut().insert(RETRY_AFTER, value);
+    }
+    response
+}
+
+#[derive(Debug)]
+enum InputLimitViolation {
+    BodyTooLarge { content_length: u64 },
+    InvalidContentLength,
+    UnsupportedTransferEncoding,
+    UnknownBodySize,
+}
+
+/// Body上限関連の入力制限を検証する。
+/// @param request HTTPリクエスト
+/// @param max_body_bytes 許可する最大Bodyバイト数
+/// @returns 違反なしなら `Ok(())`
+/// @throws なし
+fn validate_body_limit(
+    request: &Request<Body>,
+    max_body_bytes: usize,
+) -> Result<(), InputLimitViolation> {
+    if request.headers().contains_key(TRANSFER_ENCODING) {
+        return Err(InputLimitViolation::UnsupportedTransferEncoding);
+    }
+
+    let Some(content_length_raw) = request.headers().get(CONTENT_LENGTH) else {
+        let body_size_hint = request.body().size_hint();
+        return match body_size_hint.upper() {
+            Some(upper) if upper <= max_body_bytes as u64 => Ok(()),
+            Some(upper) => Err(InputLimitViolation::BodyTooLarge {
+                content_length: upper,
+            }),
+            None => Err(InputLimitViolation::UnknownBodySize),
+        };
+    };
+    let content_length = content_length_raw
+        .to_str()
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .ok_or(InputLimitViolation::InvalidContentLength)?;
+
+    if content_length > max_body_bytes as u64 {
+        return Err(InputLimitViolation::BodyTooLarge { content_length });
+    }
+
+    Ok(())
+}
+
+/// 保護対象HTTPミドルウェアを実行する。
 /// @param state アプリケーション状態
 /// @param request HTTPリクエスト
 /// @param next 次のハンドラ
-/// @returns 認証後レスポンス
+/// @returns 認証・入力制限適用後レスポンス
 /// @throws なし
-async fn rest_auth_middleware(
+async fn protected_auth_input_middleware(
     State(state): State<AppState>,
     mut request: Request<Body>,
     next: Next,
@@ -121,11 +221,71 @@ async fn rest_auth_middleware(
         "REST auth accepted"
     );
 
-    request.extensions_mut().insert(AuthContext {
-        request_id,
-        principal_id: authenticated.principal_id,
-        firebase_uid: authenticated.firebase_uid,
-    });
+    request
+        .extensions_mut()
+        .insert(AuthContext::from_authenticated(request_id.clone(), &authenticated));
 
-    next.run(request).await
+    if let Err(violation) = validate_body_limit(&request, state.http_middleware.body_limit_bytes) {
+        let (code, message, reason, content_length) = match violation {
+            InputLimitViolation::BodyTooLarge { content_length } => (
+                "INPUT_LIMIT_BODY_TOO_LARGE",
+                "request body exceeds allowed size",
+                "request_body_too_large",
+                Some(content_length),
+            ),
+            InputLimitViolation::InvalidContentLength => (
+                "INPUT_LIMIT_CONTENT_LENGTH_INVALID",
+                "content-length header is invalid",
+                "content_length_invalid",
+                None,
+            ),
+            InputLimitViolation::UnsupportedTransferEncoding => (
+                "INPUT_LIMIT_TRANSFER_ENCODING_UNSUPPORTED",
+                "transfer-encoding is not supported",
+                "transfer_encoding_unsupported",
+                None,
+            ),
+            InputLimitViolation::UnknownBodySize => (
+                "INPUT_LIMIT_BODY_SIZE_UNKNOWN",
+                "request body size must be bounded",
+                "request_body_size_unknown",
+                None,
+            ),
+        };
+        tracing::warn!(
+            decision = "deny",
+            request_id = %request_id,
+            content_length,
+            body_limit = state.http_middleware.body_limit_bytes,
+            error_class = "input_limit_body",
+            reason,
+            "HTTP request rejected by input limit"
+        );
+        return input_limit_error_response(
+            request_id,
+            code,
+            message,
+            state.http_middleware.retry_after_seconds,
+        );
+    }
+
+    match tokio::time::timeout(state.http_middleware.request_timeout, next.run(request)).await {
+        Ok(response) => response,
+        Err(_) => {
+            tracing::warn!(
+                decision = "deny",
+                request_id = %request_id,
+                timeout_ms = state.http_middleware.request_timeout.as_millis(),
+                error_class = "input_limit_timeout",
+                reason = "request_timeout",
+                "HTTP request rejected by timeout limit"
+            );
+            input_limit_error_response(
+                request_id,
+                "INPUT_LIMIT_TIMEOUT",
+                "request processing timed out",
+                state.http_middleware.retry_after_seconds,
+            )
+        }
+    }
 }

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -6,7 +6,10 @@ mod tests {
         CachingPrincipalResolver, InMemoryPrincipalCache, InMemoryPrincipalStore,
         PrincipalResolver, TokenVerifier, TokenVerifyError, VerifiedToken,
     };
-    use axum::{body::to_bytes, http::StatusCode};
+    use axum::{
+        body::to_bytes,
+        http::{HeaderValue, Method, StatusCode},
+    };
     use linklynx_shared::PrincipalId;
     use tower::ServiceExt;
 
@@ -36,7 +39,19 @@ mod tests {
         }
     }
 
-    async fn app_for_test() -> Router {
+    fn test_http_middleware_config() -> HttpMiddlewareConfig {
+        HttpMiddlewareConfig {
+            cors_allow_origins: vec![
+                HeaderValue::from_static("http://localhost:3000"),
+                HeaderValue::from_static("http://127.0.0.1:3000"),
+            ],
+            body_limit_bytes: 16 * 1024,
+            request_timeout: Duration::from_secs(5),
+            retry_after_seconds: 1,
+        }
+    }
+
+    async fn app_for_test_with_http_config(http_middleware: HttpMiddlewareConfig) -> Router {
         let metrics = Arc::new(AuthMetrics::default());
         let verifier: Arc<dyn TokenVerifier> = Arc::new(StaticTokenVerifier);
 
@@ -55,9 +70,14 @@ mod tests {
         let state = AppState {
             auth_service,
             ws_reauth_grace: Duration::from_secs(30),
+            http_middleware,
         };
 
         app_with_state(state)
+    }
+
+    async fn app_for_test() -> Router {
+        app_for_test_with_http_config(test_http_middleware_config()).await
     }
 
     #[tokio::test]
@@ -137,6 +157,7 @@ mod tests {
         assert_eq!(json["request_id"], "test-req-id");
         assert_eq!(json["principal_id"], 1001);
         assert_eq!(json["firebase_uid"], "u-1");
+        assert!(json["expires_at_epoch"].as_u64().is_some());
     }
 
     #[tokio::test]
@@ -167,5 +188,151 @@ mod tests {
     fn parse_reauth_token_ignores_non_reauth_messages() {
         let text = r#"{"type":"message.create","body":"hi"}"#;
         assert_eq!(parse_reauth_token(text), None);
+    }
+
+    #[test]
+    fn normalize_origin_removes_trailing_slash() {
+        assert_eq!(
+            normalize_origin("https://app.example.com/"),
+            Some("https://app.example.com".to_owned())
+        );
+    }
+
+    #[test]
+    fn normalize_origin_rejects_path_segments() {
+        assert_eq!(normalize_origin("https://app.example.com/path"), None);
+    }
+
+    #[tokio::test]
+    async fn cors_preflight_allows_allowlisted_origin_without_auth_rejection() {
+        let app = app_for_test().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/v1/protected/ping")
+                    .header("origin", "http://localhost:3000")
+                    .header("access-control-request-method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .unwrap(),
+            "http://localhost:3000"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_preflight_omits_allow_origin_for_non_allowlisted_origin() {
+        let app = app_for_test().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/v1/protected/ping")
+                    .header("origin", "https://malicious.example")
+                    .header("access-control-request-method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(response
+            .headers()
+            .get("access-control-allow-origin")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn protected_endpoint_returns_429_when_body_limit_is_exceeded() {
+        let mut config = test_http_middleware_config();
+        config.body_limit_bytes = 8;
+        let app = app_for_test_with_http_config(config).await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/protected/ping")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("x-request-id", "limit-req-id")
+                    .header("content-length", "16")
+                    .body(Body::from("0123456789ABCDEF"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers().get("retry-after").unwrap(), "1");
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "INPUT_LIMIT_BODY_TOO_LARGE");
+        assert_eq!(json["request_id"], "limit-req-id");
+    }
+
+    #[tokio::test]
+    async fn protected_endpoint_returns_429_for_transfer_encoding_requests() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/protected/ping")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("x-request-id", "te-req-id")
+                    .header("transfer-encoding", "chunked")
+                    .body(Body::from("x"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers().get("retry-after").unwrap(), "1");
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "INPUT_LIMIT_TRANSFER_ENCODING_UNSUPPORTED");
+        assert_eq!(json["request_id"], "te-req-id");
+    }
+
+    #[tokio::test]
+    async fn protected_endpoint_returns_429_when_processing_times_out() {
+        let mut config = test_http_middleware_config();
+        config.request_timeout = Duration::from_millis(1);
+        let app = app_for_test_with_http_config(config).await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/protected/slow")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("x-request-id", "timeout-req-id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers().get("retry-after").unwrap(), "1");
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "INPUT_LIMIT_TIMEOUT");
+        assert_eq!(json["request_id"], "timeout-req-id");
     }
 }


### PR DESCRIPTION
## 概要
LIN-457（HTTP共通ミドルウェア: CORS/認証コンテキスト/入力制限）の実装を行いました。
HTTP保護ルートに対して、`CORS -> AuthContext -> 入力制限` の契約を固定し、401/403/429 および `Retry-After` の応答契約を統一しています。

## 変更内容（What / Why）
- CORS を allowlist ベースへ変更
  - `CORS_ALLOW_ORIGINS`（カンマ区切り）を導入
  - Origin を `scheme://authority` へ正規化して適用（末尾 `/` の不一致を回避）
  - 不正 Origin は fail-close で除外
- AuthContext を拡張
  - `expires_at_epoch` を追加
  - `AuthContext::from_authenticated(...)` を追加し、下流再利用契約を明確化
- 入力制限ミドルウェアを実装
  - `HTTP_BODY_LIMIT_BYTES` による body サイズ上限
  - `HTTP_REQUEST_TIMEOUT_MILLIS` による処理 timeout
  - `HTTP_RETRY_AFTER_SECONDS` による `Retry-After` ヘッダー制御
  - `Transfer-Encoding` 使用時 / 不正 `Content-Length` / サイズ上限超過 / サイズ不明（上限判定不能）を 429 で拒否
- 認証依存障害 (`503`) に `Retry-After: 1` を付与

## 受け入れ条件との対応
- [x] CORS allowlist が適用され、非許可 Origin を拒否できる
- [x] middleware chain の順序を `CORS -> AuthContext -> 入力制限` に固定
- [x] 401/403/429 と `Retry-After` の共通契約を実装
- [x] AuthContext を下流で再利用できる形（期限情報含む）に拡張

## テスト
実行コマンド:
- `make rust-lint`
- `make validate`

結果:
- すべて成功
- Rust backend tests: `33 passed`

## 影響範囲 / 互換性
- 変更ファイル（主）
  - `rust/apps/api/src/main.rs`
  - `rust/apps/api/src/main/http_routes.rs`
  - `rust/apps/api/src/auth/errors.rs`
  - `rust/apps/api/src/main/tests.rs`
  - `rust/apps/api/src/auth/tests.rs`
- DBマイグレーション: なし
- Breaking Change: なし（ただし CORS allowlist 未設定環境は localhost デフォルトで fail-close になるため、環境設定が必要）

## ADR-001 チェック
- 結果: N/A（イベントスキーマ変更なし）
- 互換性判断: 本PRは HTTP middleware / error response 契約の変更のみで、イベント契約には影響しません

## レビュー結果（自己レビュー）
- Blocking findings (`P1+`): なし
- Non-blocking suggestions (`P2/P3`):
  - `CORS_ALLOW_ORIGINS` 未設定時の運用影響を runbook / deploy 手順へ明示すると安全

## UIチェック
- `skipped`（理由: 変更は Rust backend のみで UI 変更なし）

## 関連Issue
- Linear: https://linear.app/linklynx-ai/issue/LIN-457/backend-http共通ミドルウェア-cors認証コンテキスト入力制限
