### PR TITLE
docs: v1認証実装に合わせてRUNBOOK文言を整理

### DIFF
--- a/docs/agent_runs/LIN-586/Documentation.md
+++ b/docs/agent_runs/LIN-586/Documentation.md
@@ -10,7 +10,8 @@
 - REST error mapping: 401/403/503.
 - WS token expiry behavior: in-band reauth request with deadline and fail-close close-code mapping.
 - Dependency failure behavior: fail-close (`503` for REST, `1011` for WS).
-- Runtime principal store default: `DATABASE_URL` missing => fail-close; in-memory seed fallback is explicit opt-in (`AUTH_ALLOW_IN_MEMORY_PRINCIPAL_STORE=true`).
+- Runtime principal store default: `DATABASE_URL` missing => fail-close.
+  - `AUTH_ALLOW_IN_MEMORY_PRINCIPAL_STORE` was removed in this pass and is not used by the current v1 baseline.
 - Postgres principal store transport policy: TLS is required by default (fail-close) and plaintext is allowed only when `AUTH_ALLOW_POSTGRES_NOTLS=true` is explicitly set for local/development.
 - JWKS missing-`kid` handling: per-`kid` + global backoff with unavailable-class preservation during dependency outage windows.
 

--- a/docs/runbooks/auth-firebase-principal-operations-runbook.md
+++ b/docs/runbooks/auth-firebase-principal-operations-runbook.md
@@ -98,7 +98,7 @@ Minimum required log fields on authentication decision paths:
 - `decision` (`allow` / `deny` / `unavailable`)
 - `error_class` (for non-allow decisions)
 - `reason`
-- `provision_action` (`none` / `created` / `reused` / `conflict`)
+- `provision_action` (`created_or_reused` / `failed`) on provisioning-attempt log events.
 
 Operational rule:
 


### PR DESCRIPTION
## 概要
- v0/v1移行後の運用ドキュメントに残っていた旧仕様記載を、現行実装と一致するように修正します。
- 本PRは認証周辺のドキュメント整合のみを対象とします。

## 変更内容
- docs/agent_runs/LIN-586/Documentation.md
  - AUTH_ALLOW_IN_MEMORY_PRINCIPAL_STORE に関する記述を削除し、現行v1ベースラインで未使用であることを明記
- docs/runbooks/auth-firebase-principal-operations-runbook.md
  - provision_action の許容値を実装ログに合わせて created_or_reused と failed に更新

## 影響範囲
- 実行コードは一切変更せず、ドキュメント差分のみ
- v1認証runbookの運用整合性を改善

## テスト
- 未実行（ドキュメント変更のみ）

## 備考
- PRタイトル/説明は日本語で作成済み