### PR TITLE
LIN-504 Mock adapter + factory の差し替え境界を実装

### DIFF
--- a/docs/agent_runs/LIN-483/Documentation.md
+++ b/docs/agent_runs/LIN-483/Documentation.md
@@ -2,7 +2,7 @@
 
 ## Status
 - Started: 2026-02-28
-- Current: LIN-503 implemented (ready to PR)
+- Current: LIN-504 implemented (ready to PR)
 
 ## Decisions
 - LIN-483 の実子は LIN-503 -> LIN-504 の順で実施する。
@@ -21,11 +21,18 @@
   - `make rust-lint`: passed
 - Reviewer gate (`reviewer`): passed (`P1+` none)
 - UI gate (`reviewer_ui_guard` / `reviewer_ui`): `false` (UI変更なし) / skipped
-- PR: pending
+- PR: https://github.com/LinkLynx-AI/LinkLynx-AI/pull/728
+- Base branch: `codex/lin-483-feat_add_ui_mock`
+- Merge status: merged (auto-merge)
 
 ### LIN-504
-- Branch: pending
-- Validation: pending
-- Reviewer gate (`reviewer`): pending
-- UI gate (`reviewer_ui_guard` / `reviewer_ui`): pending
+- Branch: `codex/lin-504-mock-adapter-factory`
+- Validation:
+  - `cd typescript && npm run lint`: passed
+  - `cd typescript && npm run typecheck`: passed
+  - `cd typescript && npm run test`: passed (6 files / 16 tests)
+  - `make validate`: passed
+  - `make rust-lint`: passed
+- Reviewer gate (`reviewer`): passed (`P1+` none)
+- UI gate (`reviewer_ui_guard` / `reviewer_ui`): `true` / passed (`P1+` none)
 - PR: pending

--- a/typescript/src/app/(auth)/_components/auth-route-preview.tsx
+++ b/typescript/src/app/(auth)/_components/auth-route-preview.tsx
@@ -1,15 +1,8 @@
-import { APP_ROUTES } from "@/shared/config";
+import type { AuthRouteContent } from "@/entities";
 
-type AuthRoutePreviewProps = {
-  title: string;
-  description: string;
-  links: Array<{
-    label: string;
-    href: string;
-  }>;
-};
+type AuthRoutePreviewProps = AuthRouteContent;
 
-export function AuthRoutePreview({ title, description, links }: AuthRoutePreviewProps) {
+export function AuthRoutePreview({ title, description, links, footerLink }: AuthRoutePreviewProps) {
   return (
     <main className="flex min-h-screen items-center justify-center bg-[var(--llx-bg-tertiary)] px-4 py-10 text-[var(--llx-text-primary)]">
       <section className="w-full max-w-md rounded-xl border border-[var(--llx-divider)] bg-[var(--llx-bg-primary)] p-8">
@@ -22,7 +15,7 @@ export function AuthRoutePreview({ title, description, links }: AuthRoutePreview
         <div className="mt-8 space-y-3">
           {links.map((link) => (
             <a
-              key={link.href}
+              key={`${link.href}-${link.label}`}
               href={link.href}
               className="flex items-center justify-between rounded-md border border-[var(--llx-divider)] px-4 py-3 text-sm text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
             >
@@ -33,10 +26,10 @@ export function AuthRoutePreview({ title, description, links }: AuthRoutePreview
         </div>
 
         <a
-          href={APP_ROUTES.home}
+          href={footerLink.href}
           className="mt-6 inline-flex text-sm text-[var(--llx-brand-blurple)] transition hover:opacity-90"
         >
-          ホームへ戻る
+          {footerLink.label}
         </a>
       </section>
     </main>

--- a/typescript/src/app/(auth)/login/page.tsx
+++ b/typescript/src/app/(auth)/login/page.tsx
@@ -1,17 +1,9 @@
-import { APP_ROUTES } from "@/shared/config";
+import { createUiGateway } from "@/entities";
 import { AuthRoutePreview } from "@/app/(auth)/_components/auth-route-preview";
 
-export default function LoginPage() {
-  return (
-    <AuthRoutePreview
-      title="ログイン"
-      description="未実装の認証処理を想定した導線プレビューです。"
-      links={[
-        { label: "新規登録へ", href: APP_ROUTES.register },
-        { label: "メール確認へ", href: APP_ROUTES.verifyEmail },
-        { label: "パスワード再設定へ", href: APP_ROUTES.passwordReset },
-        { label: "ログイン後の遷移先 (@me)", href: APP_ROUTES.channels.me },
-      ]}
-    />
-  );
+export default async function LoginPage() {
+  const uiGateway = createUiGateway();
+  const content = await uiGateway.auth.getRouteContent("login");
+
+  return <AuthRoutePreview {...content} />;
 }

--- a/typescript/src/app/(auth)/password-reset/page.tsx
+++ b/typescript/src/app/(auth)/password-reset/page.tsx
@@ -1,16 +1,9 @@
-import { APP_ROUTES } from "@/shared/config";
+import { createUiGateway } from "@/entities";
 import { AuthRoutePreview } from "@/app/(auth)/_components/auth-route-preview";
 
-export default function PasswordResetPage() {
-  return (
-    <AuthRoutePreview
-      title="パスワード再設定"
-      description="申請・再設定・完了の遷移確認用プレビューです。"
-      links={[
-        { label: "ログインへ戻る", href: APP_ROUTES.login },
-        { label: "新規登録へ", href: APP_ROUTES.register },
-        { label: "メール確認へ", href: APP_ROUTES.verifyEmail },
-      ]}
-    />
-  );
+export default async function PasswordResetPage() {
+  const uiGateway = createUiGateway();
+  const content = await uiGateway.auth.getRouteContent("password-reset");
+
+  return <AuthRoutePreview {...content} />;
 }

--- a/typescript/src/app/(auth)/register/page.tsx
+++ b/typescript/src/app/(auth)/register/page.tsx
@@ -1,16 +1,9 @@
-import { APP_ROUTES } from "@/shared/config";
+import { createUiGateway } from "@/entities";
 import { AuthRoutePreview } from "@/app/(auth)/_components/auth-route-preview";
 
-export default function RegisterPage() {
-  return (
-    <AuthRoutePreview
-      title="新規登録"
-      description="登録フォームのUI先行レビュー用ページです。"
-      links={[
-        { label: "ログインへ", href: APP_ROUTES.login },
-        { label: "メール確認へ", href: APP_ROUTES.verifyEmail },
-        { label: "ホームへ", href: APP_ROUTES.home },
-      ]}
-    />
-  );
+export default async function RegisterPage() {
+  const uiGateway = createUiGateway();
+  const content = await uiGateway.auth.getRouteContent("register");
+
+  return <AuthRoutePreview {...content} />;
 }

--- a/typescript/src/app/(auth)/verify-email/page.tsx
+++ b/typescript/src/app/(auth)/verify-email/page.tsx
@@ -1,16 +1,9 @@
-import { APP_ROUTES } from "@/shared/config";
+import { createUiGateway } from "@/entities";
 import { AuthRoutePreview } from "@/app/(auth)/_components/auth-route-preview";
 
-export default function VerifyEmailPage() {
-  return (
-    <AuthRoutePreview
-      title="メール確認"
-      description="待機・再送・完了の導線を確認するためのプレビューです。"
-      links={[
-        { label: "ログインへ", href: APP_ROUTES.login },
-        { label: "パスワード再設定へ", href: APP_ROUTES.passwordReset },
-        { label: "認証後の遷移先 (@me)", href: APP_ROUTES.channels.me },
-      ]}
-    />
-  );
+export default async function VerifyEmailPage() {
+  const uiGateway = createUiGateway();
+  const content = await uiGateway.auth.getRouteContent("verify-email");
+
+  return <AuthRoutePreview {...content} />;
 }

--- a/typescript/src/app/(protected)/_components/channel-shell-preview.tsx
+++ b/typescript/src/app/(protected)/_components/channel-shell-preview.tsx
@@ -1,67 +1,91 @@
-import { APP_ROUTES, buildChannelRoute } from "@/shared/config";
+import type { ChannelListItem, MemberListItem, ServerRailItem } from "@/entities";
+import { cn } from "@/shared/lib";
 
-export function ChannelShellServerRail() {
+type ChannelShellServerRailProps = {
+  items: ReadonlyArray<ServerRailItem>;
+};
+
+type ChannelShellSidebarProps = {
+  sectionLabel: string;
+  items: ReadonlyArray<ChannelListItem>;
+};
+
+type ChannelShellMemberListProps = {
+  items: ReadonlyArray<MemberListItem>;
+};
+
+export function ChannelShellServerRail({ items }: ChannelShellServerRailProps) {
   return (
     <div className="space-y-3 p-3">
-      <div className="h-12 w-12 rounded-2xl bg-[var(--llx-brand-blurple)]" />
-      <div className="h-12 w-12 rounded-full bg-[var(--llx-bg-primary)]" />
-      <div className="h-12 w-12 rounded-full bg-[var(--llx-bg-primary)]" />
-      <div className="h-12 w-12 rounded-full bg-[var(--llx-bg-primary)]" />
+      {items.map((item) => (
+        <a
+          key={item.id}
+          href={item.href}
+          className={cn(
+            "flex h-12 w-12 items-center justify-center text-xs font-semibold transition",
+            item.selected
+              ? "rounded-2xl bg-[var(--llx-brand-blurple)] text-white"
+              : "rounded-full bg-[var(--llx-bg-primary)] text-[var(--llx-text-secondary)] hover:bg-[var(--llx-bg-selected)]",
+          )}
+          aria-label={item.label}
+          aria-current={item.selected ? "page" : undefined}
+        >
+          {item.label}
+        </a>
+      ))}
     </div>
   );
 }
 
-export function ChannelShellSidebar() {
+function formatChannelLabel(item: ChannelListItem): string {
+  if (item.kind === "text") {
+    return `# ${item.label}`;
+  }
+
+  return item.label;
+}
+
+export function ChannelShellSidebar({ sectionLabel, items }: ChannelShellSidebarProps) {
   return (
     <div className="p-3">
       <p className="px-2 py-2 text-xs uppercase tracking-[0.2em] text-[var(--llx-header-secondary)]">
-        Channels
+        {sectionLabel}
       </p>
       <div className="mt-2 space-y-1">
-        <a
-          href={APP_ROUTES.channels.me}
-          className="block rounded px-2 py-2 text-sm text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-        >
-          @me
-        </a>
-        <a
-          href={buildChannelRoute("guild-1", "channel-general")}
-          className="block rounded bg-[var(--llx-bg-selected)] px-2 py-2 text-sm text-[var(--llx-text-primary)]"
-        >
-          # general
-        </a>
-        <a
-          href={buildChannelRoute("guild-1", "channel-random")}
-          className="block rounded px-2 py-2 text-sm text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-        >
-          # random
-        </a>
-        <a
-          href={APP_ROUTES.settings.profile}
-          className="block rounded px-2 py-2 text-sm text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-        >
-          設定へ
-        </a>
+        {items.map((item) => (
+          <a
+            key={item.id}
+            href={item.href}
+            className={cn(
+              "block rounded px-2 py-2 text-sm transition",
+              item.selected
+                ? "bg-[var(--llx-bg-selected)] text-[var(--llx-text-primary)]"
+                : "text-[var(--llx-text-secondary)] hover:bg-[var(--llx-bg-selected)]",
+            )}
+            aria-current={item.selected ? "page" : undefined}
+          >
+            {formatChannelLabel(item)}
+          </a>
+        ))}
       </div>
     </div>
   );
 }
 
-export function ChannelShellMemberList() {
+export function ChannelShellMemberList({ items }: ChannelShellMemberListProps) {
   return (
     <div className="space-y-2 p-3">
       <p className="text-xs uppercase tracking-[0.2em] text-[var(--llx-header-secondary)]">
         Members
       </p>
-      <div className="rounded bg-[var(--llx-bg-primary)] px-2 py-2 text-sm text-[var(--llx-text-secondary)]">
-        Alice
-      </div>
-      <div className="rounded bg-[var(--llx-bg-primary)] px-2 py-2 text-sm text-[var(--llx-text-secondary)]">
-        Bob
-      </div>
-      <div className="rounded bg-[var(--llx-bg-primary)] px-2 py-2 text-sm text-[var(--llx-text-secondary)]">
-        Carol
-      </div>
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className="rounded bg-[var(--llx-bg-primary)] px-2 py-2 text-sm text-[var(--llx-text-secondary)]"
+        >
+          {item.name}
+        </div>
+      ))}
     </div>
   );
 }

--- a/typescript/src/app/(protected)/_components/settings-shell-preview.tsx
+++ b/typescript/src/app/(protected)/_components/settings-shell-preview.tsx
@@ -1,43 +1,51 @@
-import { APP_ROUTES } from "@/shared/config";
+import type { SettingsShellNavigation } from "@/entities";
+import { cn } from "@/shared/lib";
 
-export function SettingsShellSidebar() {
+type SettingsShellSidebarProps = {
+  navigation: SettingsShellNavigation;
+};
+
+type SettingsShellCloseRailProps = {
+  closeLink: SettingsShellNavigation["closeLink"];
+  closeHint: SettingsShellNavigation["closeHint"];
+};
+
+export function SettingsShellSidebar({ navigation }: SettingsShellSidebarProps) {
   return (
     <div className="space-y-1 p-3">
       <p className="px-2 py-2 text-xs uppercase tracking-[0.2em] text-[var(--llx-header-secondary)]">
-        Settings
+        {navigation.sectionLabel}
       </p>
-      <a
-        href={APP_ROUTES.settings.profile}
-        className="block rounded bg-[var(--llx-bg-selected)] px-2 py-2 text-sm text-[var(--llx-text-primary)]"
-      >
-        プロフィール
-      </a>
-      <a
-        href={APP_ROUTES.settings.appearance}
-        className="block rounded px-2 py-2 text-sm text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-      >
-        外観
-      </a>
-      <a
-        href={APP_ROUTES.channels.me}
-        className="block rounded px-2 py-2 text-sm text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-      >
-        チャンネルへ戻る
-      </a>
+      {navigation.items.map((item) => (
+        <a
+          key={item.id}
+          href={item.href}
+          className={cn(
+            "block rounded px-2 py-2 text-sm transition",
+            item.selected
+              ? "bg-[var(--llx-bg-selected)] text-[var(--llx-text-primary)]"
+              : "text-[var(--llx-text-secondary)] hover:bg-[var(--llx-bg-selected)]",
+          )}
+          aria-current={item.selected ? "page" : undefined}
+        >
+          {item.label}
+        </a>
+      ))}
     </div>
   );
 }
 
-export function SettingsShellCloseRail() {
+export function SettingsShellCloseRail({ closeLink, closeHint }: SettingsShellCloseRailProps) {
   return (
     <div className="flex flex-col items-center gap-2 text-[var(--llx-text-muted)]">
       <a
-        href={APP_ROUTES.channels.me}
+        href={closeLink.href}
         className="flex h-9 w-9 items-center justify-center rounded-full border border-[var(--llx-divider)] bg-[var(--llx-bg-secondary)] text-sm transition hover:bg-[var(--llx-bg-selected)]"
+        aria-label={closeLink.label}
       >
         ✕
       </a>
-      <span className="text-xs">ESC</span>
+      <span className="text-xs">{closeHint}</span>
     </div>
   );
 }

--- a/typescript/src/app/(protected)/channels/@me/page.tsx
+++ b/typescript/src/app/(protected)/channels/@me/page.tsx
@@ -1,5 +1,5 @@
 import { ProtectedPreviewGate } from "@/features";
-import { APP_ROUTES } from "@/shared/config";
+import { createUiGateway } from "@/entities";
 import { ChannelShellLayout, ShellStatePlaceholder } from "@/widgets";
 import {
   ChannelShellMemberList,
@@ -15,31 +15,39 @@ type ChannelsMePageProps = {
 };
 
 export default async function ChannelsMePage({ searchParams }: ChannelsMePageProps) {
-  const previewState = await resolveProtectedPreviewState(searchParams);
+  const uiGateway = createUiGateway();
+  const [previewState, shellNavigation, content] = await Promise.all([
+    resolveProtectedPreviewState(searchParams),
+    uiGateway.guild.getChannelShellNavigation(),
+    uiGateway.message.getChannelsMeContent(),
+  ]);
+  const shellNavigationForMe = {
+    ...shellNavigation,
+    serverRailItems: shellNavigation.serverRailItems.map((item) => ({
+      ...item,
+      selected: item.id === "home",
+    })),
+    channelItems: shellNavigation.channelItems.map((item) => ({
+      ...item,
+      selected: item.id === "me",
+    })),
+  };
 
   const mainContent =
     previewState.state === null ? (
       <section className="space-y-4">
-        <h1 className="text-2xl font-semibold text-[var(--llx-text-primary)]">
-          @me ダッシュボード
-        </h1>
-        <p className="text-sm text-[var(--llx-text-muted)]">
-          保護ルートの表示プレビューです。`?state=loading|empty|error|readonly|disabled` または
-          `?guard=unauthenticated|forbidden|not-found` を付与して状態を確認できます。
-        </p>
+        <h1 className="text-2xl font-semibold text-[var(--llx-text-primary)]">{content.title}</h1>
+        <p className="text-sm text-[var(--llx-text-muted)]">{content.description}</p>
         <div className="flex flex-wrap gap-3">
-          <a
-            href={`${APP_ROUTES.channels.me}?state=loading`}
-            className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-          >
-            loading
-          </a>
-          <a
-            href={`${APP_ROUTES.channels.me}?guard=unauthenticated`}
-            className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-          >
-            unauthenticated
-          </a>
+          {content.quickActions.map((action) => (
+            <a
+              key={`${action.href}-${action.label}`}
+              href={action.href}
+              className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
+            >
+              {action.label}
+            </a>
+          ))}
         </div>
       </section>
     ) : (
@@ -49,9 +57,14 @@ export default async function ChannelsMePage({ searchParams }: ChannelsMePagePro
   return (
     <ProtectedPreviewGate guard={previewState.guard}>
       <ChannelShellLayout
-        serverRail={<ChannelShellServerRail />}
-        channelSidebar={<ChannelShellSidebar />}
-        memberList={<ChannelShellMemberList />}
+        serverRail={<ChannelShellServerRail items={shellNavigationForMe.serverRailItems} />}
+        channelSidebar={
+          <ChannelShellSidebar
+            sectionLabel={shellNavigationForMe.sectionLabel}
+            items={shellNavigationForMe.channelItems}
+          />
+        }
+        memberList={<ChannelShellMemberList items={shellNavigationForMe.memberItems} />}
         mainContent={mainContent}
       />
     </ProtectedPreviewGate>

--- a/typescript/src/app/(protected)/channels/[guildId]/[channelId]/page.tsx
+++ b/typescript/src/app/(protected)/channels/[guildId]/[channelId]/page.tsx
@@ -1,5 +1,6 @@
 import { ProtectedPreviewGate } from "@/features";
-import { APP_ROUTES } from "@/shared/config";
+import { createUiGateway } from "@/entities";
+import { buildChannelRoute } from "@/shared/config";
 import { ChannelShellLayout, ShellStatePlaceholder } from "@/widgets";
 import {
   ChannelShellMemberList,
@@ -20,31 +21,47 @@ type ChannelPageProps = {
 };
 
 export default async function ChannelPage({ params, searchParams }: ChannelPageProps) {
+  const uiGateway = createUiGateway();
   const previewState = await resolveProtectedPreviewState(searchParams);
   const resolvedParams = await Promise.resolve(params);
+  const [shellNavigation, content] = await Promise.all([
+    uiGateway.guild.getChannelShellNavigation(),
+    uiGateway.message.getChannelContent({
+      guildId: resolvedParams.guildId,
+      channelId: resolvedParams.channelId,
+    }),
+  ]);
+  const activeChannelRoute = buildChannelRoute(resolvedParams.guildId, resolvedParams.channelId);
+  const activeServerId = resolvedParams.guildId.startsWith("guild-")
+    ? `srv-${resolvedParams.guildId.slice("guild-".length)}`
+    : "srv-1";
+  const shellNavigationForChannel = {
+    ...shellNavigation,
+    serverRailItems: shellNavigation.serverRailItems.map((item) => ({
+      ...item,
+      selected: item.id === activeServerId,
+    })),
+    channelItems: shellNavigation.channelItems.map((item) => ({
+      ...item,
+      selected: item.href === activeChannelRoute,
+    })),
+  };
 
   const mainContent =
     previewState.state === null ? (
       <section className="space-y-4">
-        <h1 className="text-2xl font-semibold text-[var(--llx-text-primary)]">
-          #{resolvedParams.channelId} ({resolvedParams.guildId})
-        </h1>
-        <p className="text-sm text-[var(--llx-text-muted)]">
-          チャンネル詳細ルートのプレビューです。状態切替は `state` / `guard` クエリで確認できます。
-        </p>
+        <h1 className="text-2xl font-semibold text-[var(--llx-text-primary)]">{content.title}</h1>
+        <p className="text-sm text-[var(--llx-text-muted)]">{content.description}</p>
         <div className="flex flex-wrap gap-3">
-          <a
-            href={`${APP_ROUTES.channels.me}?state=empty`}
-            className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-          >
-            empty
-          </a>
-          <a
-            href={`${APP_ROUTES.channels.me}?guard=not-found`}
-            className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-          >
-            not-found
-          </a>
+          {content.quickActions.map((action) => (
+            <a
+              key={`${action.href}-${action.label}`}
+              href={action.href}
+              className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
+            >
+              {action.label}
+            </a>
+          ))}
         </div>
       </section>
     ) : (
@@ -54,9 +71,14 @@ export default async function ChannelPage({ params, searchParams }: ChannelPageP
   return (
     <ProtectedPreviewGate guard={previewState.guard}>
       <ChannelShellLayout
-        serverRail={<ChannelShellServerRail />}
-        channelSidebar={<ChannelShellSidebar />}
-        memberList={<ChannelShellMemberList />}
+        serverRail={<ChannelShellServerRail items={shellNavigationForChannel.serverRailItems} />}
+        channelSidebar={
+          <ChannelShellSidebar
+            sectionLabel={shellNavigationForChannel.sectionLabel}
+            items={shellNavigationForChannel.channelItems}
+          />
+        }
+        memberList={<ChannelShellMemberList items={shellNavigationForChannel.memberItems} />}
         mainContent={mainContent}
       />
     </ProtectedPreviewGate>

--- a/typescript/src/app/(protected)/settings/appearance/page.tsx
+++ b/typescript/src/app/(protected)/settings/appearance/page.tsx
@@ -1,5 +1,5 @@
 import { ProtectedPreviewGate } from "@/features";
-import { APP_ROUTES } from "@/shared/config";
+import { createUiGateway } from "@/entities";
 import { SettingsShellLayout, ShellStatePlaceholder } from "@/widgets";
 import {
   SettingsShellCloseRail,
@@ -16,28 +16,35 @@ type AppearanceSettingsPageProps = {
 export default async function AppearanceSettingsPage({
   searchParams,
 }: AppearanceSettingsPageProps) {
-  const previewState = await resolveProtectedPreviewState(searchParams);
+  const uiGateway = createUiGateway();
+  const [previewState, navigation, content] = await Promise.all([
+    resolveProtectedPreviewState(searchParams),
+    uiGateway.guild.getSettingsShellNavigation(),
+    uiGateway.message.getAppearanceSettingsContent(),
+  ]);
+  const appearanceNavigation = {
+    ...navigation,
+    items: navigation.items.map((item) => ({
+      ...item,
+      selected: item.id === "appearance",
+    })),
+  };
 
-  const content =
+  const mainContent =
     previewState.state === null ? (
       <section className="space-y-4">
-        <h1 className="text-2xl font-semibold text-[var(--llx-text-primary)]">外観設定</h1>
-        <p className="text-sm text-[var(--llx-text-muted)]">
-          テーマ切替導線のプレビューです。`state=disabled` などの共通状態を確認できます。
-        </p>
+        <h1 className="text-2xl font-semibold text-[var(--llx-text-primary)]">{content.title}</h1>
+        <p className="text-sm text-[var(--llx-text-muted)]">{content.description}</p>
         <div className="flex flex-wrap gap-3">
-          <a
-            href={`${APP_ROUTES.settings.appearance}?state=disabled`}
-            className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-          >
-            disabled
-          </a>
-          <a
-            href={`${APP_ROUTES.settings.appearance}?state=error`}
-            className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-          >
-            error
-          </a>
+          {content.quickActions.map((action) => (
+            <a
+              key={`${action.href}-${action.label}`}
+              href={action.href}
+              className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
+            >
+              {action.label}
+            </a>
+          ))}
         </div>
       </section>
     ) : (
@@ -47,9 +54,14 @@ export default async function AppearanceSettingsPage({
   return (
     <ProtectedPreviewGate guard={previewState.guard}>
       <SettingsShellLayout
-        sidebar={<SettingsShellSidebar />}
-        closeRail={<SettingsShellCloseRail />}
-        content={content}
+        sidebar={<SettingsShellSidebar navigation={appearanceNavigation} />}
+        closeRail={
+          <SettingsShellCloseRail
+            closeLink={appearanceNavigation.closeLink}
+            closeHint={appearanceNavigation.closeHint}
+          />
+        }
+        content={mainContent}
       />
     </ProtectedPreviewGate>
   );

--- a/typescript/src/app/(protected)/settings/profile/page.tsx
+++ b/typescript/src/app/(protected)/settings/profile/page.tsx
@@ -1,5 +1,5 @@
 import { ProtectedPreviewGate } from "@/features";
-import { APP_ROUTES } from "@/shared/config";
+import { createUiGateway } from "@/entities";
 import { SettingsShellLayout, ShellStatePlaceholder } from "@/widgets";
 import {
   SettingsShellCloseRail,
@@ -14,28 +14,35 @@ type ProfileSettingsPageProps = {
 };
 
 export default async function ProfileSettingsPage({ searchParams }: ProfileSettingsPageProps) {
-  const previewState = await resolveProtectedPreviewState(searchParams);
+  const uiGateway = createUiGateway();
+  const [previewState, navigation, content] = await Promise.all([
+    resolveProtectedPreviewState(searchParams),
+    uiGateway.guild.getSettingsShellNavigation(),
+    uiGateway.message.getProfileSettingsContent(),
+  ]);
+  const profileNavigation = {
+    ...navigation,
+    items: navigation.items.map((item) => ({
+      ...item,
+      selected: item.id === "profile",
+    })),
+  };
 
-  const content =
+  const mainContent =
     previewState.state === null ? (
       <section className="space-y-4">
-        <h1 className="text-2xl font-semibold text-[var(--llx-text-primary)]">プロフィール設定</h1>
-        <p className="text-sm text-[var(--llx-text-muted)]">
-          設定App Shellのプレビューです。`state` クエリで共通プレースホルダを確認できます。
-        </p>
+        <h1 className="text-2xl font-semibold text-[var(--llx-text-primary)]">{content.title}</h1>
+        <p className="text-sm text-[var(--llx-text-muted)]">{content.description}</p>
         <div className="flex flex-wrap gap-3">
-          <a
-            href={`${APP_ROUTES.settings.profile}?state=readonly`}
-            className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-          >
-            readonly
-          </a>
-          <a
-            href={`${APP_ROUTES.settings.profile}?guard=forbidden`}
-            className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
-          >
-            forbidden
-          </a>
+          {content.quickActions.map((action) => (
+            <a
+              key={`${action.href}-${action.label}`}
+              href={action.href}
+              className="rounded-md border border-[var(--llx-divider)] px-3 py-2 text-xs text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
+            >
+              {action.label}
+            </a>
+          ))}
         </div>
       </section>
     ) : (
@@ -45,9 +52,14 @@ export default async function ProfileSettingsPage({ searchParams }: ProfileSetti
   return (
     <ProtectedPreviewGate guard={previewState.guard}>
       <SettingsShellLayout
-        sidebar={<SettingsShellSidebar />}
-        closeRail={<SettingsShellCloseRail />}
-        content={content}
+        sidebar={<SettingsShellSidebar navigation={profileNavigation} />}
+        closeRail={
+          <SettingsShellCloseRail
+            closeLink={profileNavigation.closeLink}
+            closeHint={profileNavigation.closeHint}
+          />
+        }
+        content={mainContent}
       />
     </ProtectedPreviewGate>
   );

--- a/typescript/src/app/(public)/invite/[code]/page.tsx
+++ b/typescript/src/app/(public)/invite/[code]/page.tsx
@@ -1,4 +1,4 @@
-import { APP_ROUTES } from "@/shared/config";
+import { createUiGateway } from "@/entities";
 
 type InvitePageParams = Promise<{ code: string }> | { code: string };
 
@@ -7,7 +7,9 @@ type InvitePageProps = {
 };
 
 export default async function InvitePage({ params }: InvitePageProps) {
+  const uiGateway = createUiGateway();
   const resolvedParams = await Promise.resolve(params);
+  const content = await uiGateway.guild.getInvitePageContent(resolvedParams.code);
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-[var(--llx-bg-tertiary)] px-4 py-10 text-[var(--llx-text-primary)]">
@@ -15,25 +17,21 @@ export default async function InvitePage({ params }: InvitePageProps) {
         <p className="text-xs uppercase tracking-[0.2em] text-[var(--llx-header-secondary)]">
           Invite
         </p>
-        <h1 className="mt-3 text-2xl font-semibold">招待コードを確認</h1>
-        <p className="mt-2 text-sm text-[var(--llx-text-muted)]">
-          招待コード{" "}
-          <span className="font-medium text-[var(--llx-text-primary)]">{resolvedParams.code}</span>
-          の表示プレビューです。
-        </p>
+        <h1 className="mt-3 text-2xl font-semibold">{content.title}</h1>
+        <p className="mt-2 text-sm text-[var(--llx-text-muted)]">{content.description}</p>
 
         <div className="mt-8 grid gap-3">
           <a
-            href={APP_ROUTES.login}
+            href={content.primaryAction.href}
             className="rounded-md bg-[var(--llx-brand-blurple)] px-4 py-3 text-center text-sm font-medium text-white transition hover:brightness-110"
           >
-            ログインして参加
+            {content.primaryAction.label}
           </a>
           <a
-            href={APP_ROUTES.home}
+            href={content.secondaryAction.href}
             className="rounded-md border border-[var(--llx-divider)] px-4 py-3 text-center text-sm text-[var(--llx-text-secondary)] transition hover:bg-[var(--llx-bg-selected)]"
           >
-            ホームへ戻る
+            {content.secondaryAction.label}
           </a>
         </div>
       </section>

--- a/typescript/src/entities/ui-gateway/api/create-ui-gateway.test.ts
+++ b/typescript/src/entities/ui-gateway/api/create-ui-gateway.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { createUiGateway } from "./create-ui-gateway";
+
+describe("createUiGateway", () => {
+  test("provider 未指定時は mock を返す", async () => {
+    const gateway = createUiGateway();
+    const content = await gateway.auth.getRouteContent("login");
+
+    expect(content.title).toBe("ログイン");
+  });
+
+  test("provider が不正値なら fail-fast する", () => {
+    expect(() => createUiGateway({ provider: "unknown-provider" })).toThrow(
+      "Invalid NEXT_PUBLIC_UI_GATEWAY_PROVIDER:",
+    );
+  });
+
+  test("provider=api 指定時は mock にフォールバックする", async () => {
+    const gateway = createUiGateway({ provider: "api" });
+    const content = await gateway.auth.getRouteContent("login");
+
+    expect(content.title).toBe("ログイン");
+  });
+
+  test("環境変数指定の provider も同じルールで解決する", () => {
+    const originalProvider = process.env.NEXT_PUBLIC_UI_GATEWAY_PROVIDER;
+    try {
+      process.env.NEXT_PUBLIC_UI_GATEWAY_PROVIDER = "invalid";
+      expect(() => createUiGateway()).toThrow("Invalid NEXT_PUBLIC_UI_GATEWAY_PROVIDER:");
+    } finally {
+      if (originalProvider === undefined) {
+        delete process.env.NEXT_PUBLIC_UI_GATEWAY_PROVIDER;
+      } else {
+        process.env.NEXT_PUBLIC_UI_GATEWAY_PROVIDER = originalProvider;
+      }
+    }
+  });
+});

--- a/typescript/src/entities/ui-gateway/api/create-ui-gateway.ts
+++ b/typescript/src/entities/ui-gateway/api/create-ui-gateway.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import type { UiGateway, UiGatewayProvider } from "../model";
+import { createMockUiGateway } from "./mock-ui-gateway";
+
+type CreateUiGatewayOptions = {
+  provider?: string;
+};
+
+const UI_GATEWAY_PROVIDER_SCHEMA = z.enum(["mock", "api"]);
+
+function resolveUiGatewayProvider(provider: string | undefined): UiGatewayProvider {
+  if (provider === undefined) {
+    return "mock";
+  }
+
+  const parsedProvider = UI_GATEWAY_PROVIDER_SCHEMA.safeParse(provider);
+
+  if (!parsedProvider.success) {
+    throw new Error(
+      `Invalid NEXT_PUBLIC_UI_GATEWAY_PROVIDER: ${provider}. Allowed values are 'mock' or 'api'.`,
+    );
+  }
+
+  return parsedProvider.data;
+}
+
+/**
+ * UI Gateway のprovider設定から利用実体を生成する。
+ */
+export function createUiGateway(options: CreateUiGatewayOptions = {}): UiGateway {
+  const provider = resolveUiGatewayProvider(
+    options.provider ?? process.env.NEXT_PUBLIC_UI_GATEWAY_PROVIDER,
+  );
+
+  if (provider === "mock") {
+    return createMockUiGateway();
+  }
+
+  // LIN-504 では API adapter 未実装のため、provider=api でも表示確認を継続できるよう mock へフォールバックする。
+  return createMockUiGateway();
+}

--- a/typescript/src/entities/ui-gateway/api/index.ts
+++ b/typescript/src/entities/ui-gateway/api/index.ts
@@ -1,0 +1,1 @@
+export { createUiGateway } from "./create-ui-gateway";

--- a/typescript/src/entities/ui-gateway/api/mock-ui-gateway.ts
+++ b/typescript/src/entities/ui-gateway/api/mock-ui-gateway.ts
@@ -1,0 +1,229 @@
+import { APP_ROUTES, buildChannelRoute } from "@/shared/config";
+import type {
+  AuthRouteContent,
+  AuthRouteKind,
+  ChannelShellNavigation,
+  InvitePageContent,
+  MessagePreviewContent,
+  ModerationQueueContent,
+  PermissionPreviewContent,
+  SettingsShellNavigation,
+  UiGateway,
+} from "../model";
+
+const AUTH_ROUTE_CONTENT: Record<AuthRouteKind, AuthRouteContent> = {
+  login: {
+    title: "ログイン",
+    description: "未実装の認証処理を想定した導線プレビューです。",
+    links: [
+      { label: "新規登録へ", href: APP_ROUTES.register },
+      { label: "メール確認へ", href: APP_ROUTES.verifyEmail },
+      { label: "パスワード再設定へ", href: APP_ROUTES.passwordReset },
+      { label: "ログイン後の遷移先 (@me)", href: APP_ROUTES.channels.me },
+    ],
+    footerLink: { label: "ホームへ戻る", href: APP_ROUTES.home },
+  },
+  register: {
+    title: "新規登録",
+    description: "登録フォームのUI先行レビュー用ページです。",
+    links: [
+      { label: "ログインへ", href: APP_ROUTES.login },
+      { label: "メール確認へ", href: APP_ROUTES.verifyEmail },
+      { label: "ホームへ", href: APP_ROUTES.home },
+    ],
+    footerLink: { label: "ホームへ戻る", href: APP_ROUTES.home },
+  },
+  "verify-email": {
+    title: "メール確認",
+    description: "確認メール送信後の状態を想定した画面プレビューです。",
+    links: [
+      { label: "ログインへ", href: APP_ROUTES.login },
+      { label: "パスワード再設定へ", href: APP_ROUTES.passwordReset },
+      { label: "認証後の遷移先 (@me)", href: APP_ROUTES.channels.me },
+    ],
+    footerLink: { label: "ホームへ戻る", href: APP_ROUTES.home },
+  },
+  "password-reset": {
+    title: "パスワード再設定",
+    description: "パスワード再設定フローの表示確認用プレビューです。",
+    links: [
+      { label: "ログインへ戻る", href: APP_ROUTES.login },
+      { label: "新規登録へ", href: APP_ROUTES.register },
+      { label: "メール確認へ", href: APP_ROUTES.verifyEmail },
+    ],
+    footerLink: { label: "ホームへ戻る", href: APP_ROUTES.home },
+  },
+};
+
+const CHANNEL_SHELL_NAVIGATION: ChannelShellNavigation = {
+  sectionLabel: "Channels",
+  serverRailItems: [
+    { id: "home", label: "Home", href: APP_ROUTES.channels.me, selected: true },
+    {
+      id: "srv-1",
+      label: "AB",
+      href: buildChannelRoute("guild-1", "channel-general"),
+      selected: false,
+    },
+    {
+      id: "srv-2",
+      label: "CD",
+      href: buildChannelRoute("guild-2", "channel-general"),
+      selected: false,
+    },
+    {
+      id: "srv-3",
+      label: "EF",
+      href: buildChannelRoute("guild-3", "channel-general"),
+      selected: false,
+    },
+  ],
+  channelItems: [
+    { id: "me", label: "@me", href: APP_ROUTES.channels.me, kind: "dm", selected: false },
+    {
+      id: "general",
+      label: "general",
+      href: buildChannelRoute("guild-1", "channel-general"),
+      kind: "text",
+      selected: true,
+    },
+    {
+      id: "random",
+      label: "random",
+      href: buildChannelRoute("guild-1", "channel-random"),
+      kind: "text",
+      selected: false,
+    },
+    {
+      id: "settings",
+      label: "設定へ",
+      href: APP_ROUTES.settings.profile,
+      kind: "settings",
+      selected: false,
+    },
+  ],
+  memberItems: [
+    { id: "alice", name: "Alice" },
+    { id: "bob", name: "Bob" },
+    { id: "carol", name: "Carol" },
+  ],
+};
+
+const SETTINGS_SHELL_NAVIGATION: SettingsShellNavigation = {
+  sectionLabel: "Settings",
+  items: [
+    { id: "profile", label: "プロフィール", href: APP_ROUTES.settings.profile, selected: true },
+    { id: "appearance", label: "外観", href: APP_ROUTES.settings.appearance, selected: false },
+    { id: "back", label: "チャンネルへ戻る", href: APP_ROUTES.channels.me, selected: false },
+  ],
+  closeLink: { label: "閉じる", href: APP_ROUTES.channels.me },
+  closeHint: "ESC",
+};
+
+const CHANNELS_ME_CONTENT: MessagePreviewContent = {
+  title: "@me ダッシュボード",
+  description:
+    "保護ルートの表示プレビューです。`?state=loading|empty|error|readonly|disabled` または `?guard=unauthenticated|forbidden|not-found` を付与して状態を確認できます。",
+  quickActions: [
+    { label: "loading", href: `${APP_ROUTES.channels.me}?state=loading` },
+    { label: "unauthenticated", href: `${APP_ROUTES.channels.me}?guard=unauthenticated` },
+  ],
+};
+
+const PROFILE_SETTINGS_CONTENT: MessagePreviewContent = {
+  title: "プロフィール設定",
+  description: "設定App Shellのプレビューです。`state` クエリで共通プレースホルダを確認できます。",
+  quickActions: [
+    { label: "readonly", href: `${APP_ROUTES.settings.profile}?state=readonly` },
+    { label: "forbidden", href: `${APP_ROUTES.settings.profile}?guard=forbidden` },
+  ],
+};
+
+const APPEARANCE_SETTINGS_CONTENT: MessagePreviewContent = {
+  title: "外観設定",
+  description: "テーマ切替導線のプレビューです。`state=disabled` などの共通状態を確認できます。",
+  quickActions: [
+    { label: "disabled", href: `${APP_ROUTES.settings.appearance}?state=disabled` },
+    { label: "error", href: `${APP_ROUTES.settings.appearance}?state=error` },
+  ],
+};
+
+const MODERATION_PERMISSION_CONTENT: PermissionPreviewContent = {
+  title: "権限表示プレビュー",
+  description: "role別の閲覧/投稿可否を表形式で確認するためのモックデータです。",
+  rows: [
+    { id: "admin", roleName: "Admin", canRead: true, canPost: true },
+    { id: "mod", roleName: "Moderator", canRead: true, canPost: true },
+    { id: "member", roleName: "Member", canRead: true, canPost: false },
+  ],
+};
+
+const MODERATION_QUEUE_CONTENT: ModerationQueueContent = {
+  title: "通報キュー",
+  description: "最小モデレーションUI向けの queue/list/detail プレビュー用モックです。",
+  reports: [
+    { id: "r-001", title: "スパム投稿", status: "open", reporter: "Alice" },
+    { id: "r-002", title: "荒らし行為", status: "investigating", reporter: "Bob" },
+  ],
+};
+
+/**
+ * UI Skeleton 用のモックGatewayを生成する。
+ */
+export function createMockUiGateway(): UiGateway {
+  return {
+    auth: {
+      getRouteContent(kind) {
+        return Promise.resolve(AUTH_ROUTE_CONTENT[kind]);
+      },
+    },
+    guild: {
+      getChannelShellNavigation() {
+        return Promise.resolve(CHANNEL_SHELL_NAVIGATION);
+      },
+      getSettingsShellNavigation() {
+        return Promise.resolve(SETTINGS_SHELL_NAVIGATION);
+      },
+      getInvitePageContent(code: string): Promise<InvitePageContent> {
+        const normalizedCode = code.trim();
+
+        return Promise.resolve({
+          title: "招待コードを確認",
+          description: `招待コード ${normalizedCode} の表示プレビューです。`,
+          primaryAction: { label: "ログインして参加", href: APP_ROUTES.login },
+          secondaryAction: { label: "ホームへ戻る", href: APP_ROUTES.home },
+        });
+      },
+    },
+    message: {
+      getChannelsMeContent() {
+        return Promise.resolve(CHANNELS_ME_CONTENT);
+      },
+      getChannelContent(input) {
+        return Promise.resolve({
+          title: `#${input.channelId} (${input.guildId})`,
+          description:
+            "チャンネル詳細ルートのプレビューです。状態切替は `state` / `guard` クエリで確認できます。",
+          quickActions: [
+            { label: "empty", href: `${APP_ROUTES.channels.me}?state=empty` },
+            { label: "not-found", href: `${APP_ROUTES.channels.me}?guard=not-found` },
+          ],
+        });
+      },
+      getProfileSettingsContent() {
+        return Promise.resolve(PROFILE_SETTINGS_CONTENT);
+      },
+      getAppearanceSettingsContent() {
+        return Promise.resolve(APPEARANCE_SETTINGS_CONTENT);
+      },
+    },
+    moderation: {
+      getPermissionPreviewContent() {
+        return Promise.resolve(MODERATION_PERMISSION_CONTENT);
+      },
+      getModerationQueueContent() {
+        return Promise.resolve(MODERATION_QUEUE_CONTENT);
+      },
+    },
+  };
+}

--- a/typescript/src/entities/ui-gateway/index.ts
+++ b/typescript/src/entities/ui-gateway/index.ts
@@ -20,4 +20,6 @@ export type {
   SettingsShellNavigation,
   UiGateway,
   UiGatewayLink,
+  UiGatewayProvider,
 } from "./model";
+export { createUiGateway } from "./api";

--- a/typescript/src/entities/ui-gateway/model/index.ts
+++ b/typescript/src/entities/ui-gateway/model/index.ts
@@ -3,6 +3,8 @@ export type UiGatewayLink = {
   href: string;
 };
 
+export type UiGatewayProvider = "mock" | "api";
+
 export type AuthRouteKind = "login" | "register" | "verify-email" | "password-reset";
 
 export type AuthRouteContent = {


### PR DESCRIPTION
## 概要
- LIN-504 として、`UI Gateway` の mock adapter と factory を実装しました。
- `auth / guild / message / moderation` の各gatewayを `entities/ui-gateway/api` に追加し、`createUiGateway` で provider 切替境界を固定しました。
- 主要画面（認証、channels、settings、invite）の直書きデータを gateway 経由に差し替え、API未接続でも表示確認可能な状態を維持しています。

## 変更内容
- `typescript/src/entities/ui-gateway/api/*`
  - `mock-ui-gateway.ts`: モックデータと各gateway実装
  - `create-ui-gateway.ts`: provider解決とfactory
  - `create-ui-gateway.test.ts`: provider分岐テスト
- `typescript/src/entities/ui-gateway/index.ts`
  - `createUiGateway` 公開
- 画面差し替え
  - `app/(auth)/*` 4ページ
  - `app/(protected)/channels/*` 2ページ
  - `app/(protected)/settings/*` 2ページ
  - `app/(public)/invite/[code]/page.tsx`
  - `app/(protected)/_components/*` の preview コンポーネント
- `docs/agent_runs/LIN-483/Documentation.md`
  - LIN-503/504 の実行証跡更新

## 受け入れ条件との対応
- [x] mock adapter構成とfactory生成ルールが定義されている
- [x] 各UI導線で差し替え位置が明確

## 検証結果
- [x] `cd typescript && npm run lint`
- [x] `cd typescript && npm run typecheck`
- [x] `cd typescript && npm run test`（6 files / 16 tests）
- [x] `make validate`
- [x] `make rust-lint`

## 互換性・移行
- Breaking change: なし
- Migration: なし

## レビュー結果
- blocking findings (`P1+`): なし
- non-blocking suggestions (`P2/P3`): 選択状態表示に関する軽微指摘は対応済み

## UIチェック結果
- `reviewer_ui_guard`: `true`
- `reviewer_ui`: passed（`P1+` なし）

## 関連Issue
- Linear: https://linear.app/linklynx-ai/issue/LIN-504/non-implementation-mock-adapter-factory実装方針と差し替え点固定
- GitHub: https://github.com/LinkLynx-AI/LinkLynx-AI/issues/540
