### PR TITLE
LIN-592 未着手サブタスク判定ドキュメントを追加

### DIFF
--- a/docs/agent_runs/LIN-592/Documentation.md
+++ b/docs/agent_runs/LIN-592/Documentation.md
@@ -1,0 +1,30 @@
+# LIN-592 Documentation Log
+
+## Status
+- 2026-03-01 14:10:08 JST 時点で未着手と判定。
+- 判定のための docs 追記を LIN-592 専用PRとして提出。
+
+## Issue snapshot
+- Parent: LIN-578
+- Order: 14
+- Linear issue: https://linear.app/linklynx-ai/issue/LIN-592
+- GitHub issue: https://github.com/LinkLynx-AI/LinkLynx-AI/issues/643
+- Title: [v0][14] History API: Scyllaページング取得仕様を固定
+- Current status: Backlog
+- completedAt: null
+
+## 判定基準
+- Linear の status type が `backlog` または `unstarted`
+- `completedAt` が null
+- `gh pr list --search "LIN-592 in:title" --state all --limit 20` の結果が 0 件（判定時点）
+
+## 判定結果
+- 未着手（Not Started）
+
+## Blockers
+- LIN-589
+
+## Next action
+1. Blocker の完了状態を再確認して着手可能状態にする。
+2. LIN-592 専用ブランチで実装PRを作成する。
+3. 実装完了時にこの判定ログを更新する。

--- a/docs/agent_runs/LIN-592/Implement.md
+++ b/docs/agent_runs/LIN-592/Implement.md
@@ -1,0 +1,6 @@
+# LIN-592 Implement Rules
+
+- スコープは docs のみ。
+- 1 issue = 1 PR を厳守する。
+- 未着手判定は「Linear status が Backlog/Todo かつ completedAt が null かつ関連PRなし」とする。
+- 判定時点の日時を明記する。

--- a/docs/agent_runs/LIN-592/Plan.md
+++ b/docs/agent_runs/LIN-592/Plan.md
@@ -1,0 +1,14 @@
+# LIN-592 Plan
+
+## Milestones
+1. Linear の最新状態と依存関係を取得する。
+2. GitHub PR の有無を `gh pr list` で確認する。
+3. 未着手判定と次アクションを `docs/agent_runs/LIN-592/Documentation.md` に記録する。
+4. LIN-592 単独変更で PR を作成する。
+
+## Validation commands
+- gh pr list --search "LIN-592 in:title" --state all --limit 20
+
+## Acceptance checks
+- Linear 状態とPR有無の両方が記録されている。
+- 他Issueの変更を含まない。

--- a/docs/agent_runs/LIN-592/Prompt.md
+++ b/docs/agent_runs/LIN-592/Prompt.md
@@ -1,0 +1,14 @@
+# LIN-592 Prompt
+
+## Goal
+- LIN-578 配下の LIN-592 を未着手サブタスクとして判定し、着手前の前提情報を docs に固定する。
+
+## Non-goals
+- アプリケーションコード・インフラコードの実装変更
+- Linear ステータス変更
+- 依存Issueの仕様更新
+
+## Done conditions
+- 未着手判定基準と結果が Documentation.md に明記される。
+- 依存関係と着手条件が Plan.md / Documentation.md に整理される。
+- このIssue専用のPRとして提出される。


### PR DESCRIPTION
## 概要
- LIN-578 のサブタスク LIN-592 を未着手として判定した記録を追加。
- 判定基準（Linear状態・completedAt・PR有無）を docs に明記。
- 1 issue = 1 PR を守るため、LIN-592 だけをスコープにした。

## 変更内容
- `docs/agent_runs/LIN-592/Prompt.md`
- `docs/agent_runs/LIN-592/Plan.md`
- `docs/agent_runs/LIN-592/Implement.md`
- `docs/agent_runs/LIN-592/Documentation.md`

## 判定結果
- LIN-592: 未着手（判定時点で status=Backlog, completedAt=null, PR検索0件）

## テスト
- なし（docsのみ）
