### PR TITLE
make devでRust APIを同時起動し、rust-devで.envを読み込む

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,9 @@ ts-install: ## 依存パッケージをインストール
 # ============================================
 
 rust-dev: ## Rust 開発サーバーを起動
+	@set -a; \
+	[ -f .env ] && . ./.env; \
+	set +a; \
 	cd rust && cargo run -p linklynx_backend
 
 rust-build: ## Rust を本番用にビルド
@@ -319,7 +322,7 @@ gen: db-doc ## 生成タスクを実行（regex + tbls doc/ER）
 # 開発ワークフロー
 # ============================================
 
-dev: db-up ## 開発環境を起動（DB + Frontend）
+dev: db-up ## 開発環境を起動（DB + Frontend + Rust）
 	@if ! command -v node >/dev/null 2>&1; then \
 		echo "$(RED)Node.js が見つかりません。先に make setup か setup/setup.sh を実行してください$(NC)"; \
 		exit 1; \
@@ -328,10 +331,19 @@ dev: db-up ## 開発環境を起動（DB + Frontend）
 		echo "$(RED)pnpm が見つかりません。先に make setup か setup/setup.sh を実行してください$(NC)"; \
 		exit 1; \
 	fi
-	@echo "$(GREEN)データベースを起動しました。Frontend を起動します:$(NC)"
+	@if ! command -v cargo >/dev/null 2>&1; then \
+		echo "$(RED)cargo が見つかりません。先に make setup か setup/setup.sh を実行してください$(NC)"; \
+		exit 1; \
+	fi
+	@echo "$(GREEN)データベースを起動しました。Frontend と Rust API を起動します:$(NC)"
 	@echo "  Next.js: http://localhost:3000"
+	@echo "  Rust API: http://localhost:8080"
 	@cd typescript && CI=true pnpm install --frozen-lockfile
-	@$(MAKE) ts-dev
+	@set -e; \
+	$(MAKE) rust-dev & \
+	rust_pid=$$!; \
+	trap 'kill $$rust_pid 2>/dev/null || true' INT TERM EXIT; \
+	$(MAKE) ts-dev
 
 test: ## 全テストを実行
 	@echo "$(BLUE)TypeScript テスト実行中...$(NC)"


### PR DESCRIPTION
## 概要
- `make rust-dev` 実行時にルートの `.env` を読み込み、必要な環境変数を Rust プロセスへ渡すように変更
- `make dev` で Rust API を同時起動するように変更（`ts-dev` と並行起動）
- `make dev` に `cargo` 存在チェックを追加
- `make dev` 終了時に Rust 側プロセスを停止する `trap` を追加

## 背景
- `make rust-dev` で `FIREBASE_PROJECT_ID` / `DATABASE_URL` / `AUTH_ALLOW_POSTGRES_NOTLS` が未設定扱いになり起動失敗していた
- `make dev` は従来 Frontend のみを起動していた

## 動作確認
- `make rust-dev`
  - 必須環境変数不足エラーが解消し、`server starting address=0.0.0.0:8080` まで到達することを確認
- `make dev`
  - Rust API と Next.js の同時起動を確認
