### PR TITLE
reviewerエージェント設定をread-onlyに統一

### DIFF
--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
-sandbox_mode = "command"
+sandbox_mode = "read-only"
 developer_instructions = """
 You are the meta reviewer.
 

--- a/.codex/agents/reviewer_coding_rules.toml
+++ b/.codex/agents/reviewer_coding_rules.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
-sandbox_mode = "command"
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a coding-rules reviewer.
 

--- a/.codex/agents/reviewer_correctness.toml
+++ b/.codex/agents/reviewer_correctness.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
-sandbox_mode = "command"
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a correctness reviewer.
 

--- a/.codex/agents/reviewer_performance.toml
+++ b/.codex/agents/reviewer_performance.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex-spark"
 model_reasoning_effort = "high"
-sandbox_mode = "command"
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a performance reviewer.
 

--- a/.codex/agents/reviewer_security.toml
+++ b/.codex/agents/reviewer_security.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
-sandbox_mode = "command"
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a security reviewer.
 

--- a/.codex/agents/reviewer_simple.toml
+++ b/.codex/agents/reviewer_simple.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "medium"
-sandbox_mode = "command"
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a lightweight unified reviewer.
 

--- a/.codex/agents/reviewer_test_quality.toml
+++ b/.codex/agents/reviewer_test_quality.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex-spark"
 model_reasoning_effort = "medium"
-sandbox_mode = "command"
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a test-quality reviewer.
 

--- a/.codex/agents/reviewer_ui.toml
+++ b/.codex/agents/reviewer_ui.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex"
 model_reasoning_effort = "medium"
-sandbox_mode = "command"
+sandbox_mode = "read-only"
 developer_instructions = """
 You are the UI reviewer.
 

--- a/.codex/agents/reviewer_ui_guard.toml
+++ b/.codex/agents/reviewer_ui_guard.toml
@@ -1,6 +1,6 @@
 model = "gpt-5.3-codex-spark"
 model_reasoning_effort = "low"
-sandbox_mode = "command"
+sandbox_mode = "read-only"
 developer_instructions = """
 You are the UI change guard.
 


### PR DESCRIPTION
## 概要
reviewer 系エージェントが `agent type is currently not available` で起動できない問題を解消するため、agent 設定の sandbox モードを見直しました。

## 変更内容
- `.codex/agents/reviewer*.toml` の `sandbox_mode` を `command` から `read-only` に統一
- 対象は reviewer 系 9 ファイル

## 変更の意図
- 現行ランタイムでは reviewer 系の `sandbox_mode = "command"` 設定時に起動不可となるケースがあり、レビューゲートが実行できませんでした。
- reviewer 系の役割は読み取り中心であり、`read-only` が責務と安全性の両面で適切です。

## 動作確認
- `spawn_agent(agent_type="reviewer")` が起動し `ok` 応答
- `spawn_agent(agent_type="reviewer_simple")` が起動し `ok` 応答
- `spawn_agent(agent_type="reviewer_ui_guard")` が起動し `ok` 応答
- `spawn_agent(agent_type="reviewer_ui")` が起動し `ok` 応答

## 影響範囲
- `.codex/agents/` 配下の reviewer 系設定のみ
- アプリケーション本体コード・DB・API 契約への影響なし
