### PR TITLE
feat(auth): redesign login page to Discord UI style (discord-unified.…

### DIFF
--- a/typescript/src/app/(auth)/login/page.tsx
+++ b/typescript/src/app/(auth)/login/page.tsx
@@ -1,7 +1,6 @@
-import { AuthRoutePreview } from "@/app/(auth)/_components/auth-route-preview";
-import { createUiGateway } from "@/entities";
 import { LoginForm } from "@/features";
-import { normalizeReturnToPath, parseLoginRedirectReason } from "@/shared/config";
+import { APP_ROUTES, normalizeReturnToPath, parseLoginRedirectReason } from "@/shared/config";
+import Link from "next/link";
 
 type SearchParamsObject = Record<string, string | string[] | undefined>;
 
@@ -22,17 +21,34 @@ function toSingleValue(value: string | string[] | undefined): string | null {
 }
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
-  const uiGateway = createUiGateway();
-  const [content, resolvedSearchParams] = await Promise.all([
-    uiGateway.auth.getRouteContent("login"),
-    Promise.resolve(searchParams ?? {}),
-  ]);
+  const resolvedSearchParams = await Promise.resolve(searchParams ?? {});
   const returnTo = normalizeReturnToPath(toSingleValue(resolvedSearchParams.returnTo));
   const reason = parseLoginRedirectReason(resolvedSearchParams.reason);
 
   return (
-    <AuthRoutePreview {...content}>
-      <LoginForm returnTo={returnTo} reason={reason} />
-    </AuthRoutePreview>
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-discord-bg-tertiary px-4 py-10">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-5%,rgba(88,101,242,0.18),transparent)]" />
+      </div>
+
+      <section className="relative w-full max-w-[480px] rounded-[4px] bg-discord-bg-primary px-8 py-10 shadow-[0_2px_10px_rgba(0,0,0,0.6),0_8px_40px_rgba(0,0,0,0.4)]">
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-bold text-discord-header-primary">おかえり！</h1>
+          <p className="mt-1 text-base text-discord-text-muted">また会えてうれしいです！</p>
+        </div>
+
+        <LoginForm returnTo={returnTo} reason={reason} />
+
+        <p className="mt-6 text-sm text-discord-text-muted">
+          アカウントをお持ちでないですか？{" "}
+          <Link
+            href={APP_ROUTES.register}
+            className="text-discord-text-link hover:underline"
+          >
+            新規登録
+          </Link>
+        </p>
+      </section>
+    </main>
   );
 }

--- a/typescript/src/features/auth-flow/ui/google-sign-in-button.tsx
+++ b/typescript/src/features/auth-flow/ui/google-sign-in-button.tsx
@@ -15,7 +15,7 @@ export function GoogleSignInButton({ disabled, isSubmitting, onClick }: GoogleSi
       type="button"
       disabled={disabled}
       onClick={onClick}
-      className="inline-flex w-full items-center justify-center rounded-md border border-[var(--llx-divider)] bg-[var(--llx-bg-secondary)] px-4 py-2 text-sm font-medium text-[var(--llx-text-primary)] transition hover:bg-[var(--llx-bg-selected)] disabled:cursor-not-allowed disabled:opacity-60"
+      className="h-10 w-full rounded-[4px] bg-discord-bg-tertiary text-sm font-medium text-discord-text-normal transition hover:bg-discord-bg-mod-hover disabled:cursor-not-allowed disabled:opacity-60"
     >
       {isSubmitting ? "Googleサインイン中..." : "Googleで続行"}
     </button>

--- a/typescript/src/features/auth-flow/ui/login-form.tsx
+++ b/typescript/src/features/auth-flow/ui/login-form.tsx
@@ -8,6 +8,7 @@ import {
   signInWithGooglePopup,
 } from "@/entities";
 import { APP_ROUTES, type LoginRedirectReason, normalizeReturnToPath } from "@/shared/config";
+import Link from "next/link";
 import {
   buildVerifyEmailRoute,
   getGoogleSignInErrorMessage,
@@ -139,39 +140,51 @@ export function LoginForm({ returnTo, reason }: LoginFormProps) {
       }}
     >
       <div className="space-y-2">
-        <label className="block text-xs font-bold uppercase tracking-wider text-discord-header-secondary">
+        <label className="block text-xs font-bold uppercase tracking-[0.06em] text-discord-header-secondary">
           メールアドレス <span className="text-discord-brand-red">*</span>
         </label>
         <input
           type="email"
+          name="email"
           value={form.email}
           onChange={(event) => updateForm("email", event.target.value)}
           autoComplete="email"
-          className="w-full rounded bg-discord-input-bg px-3 py-2.5 text-sm text-discord-text-normal outline-none ring-0 transition focus:ring-2 focus:ring-discord-brand-blurple"
+          placeholder="name@example.com"
+          className="h-10 w-full rounded-[3px] bg-discord-bg-tertiary px-[10px] text-sm text-discord-text-normal outline-none transition placeholder:text-discord-text-muted focus:ring-2 focus:ring-discord-brand-blurple/50"
         />
       </div>
 
       <div className="space-y-2">
-        <label className="block text-xs font-bold uppercase tracking-wider text-discord-header-secondary">
-          パスワード <span className="text-discord-brand-red">*</span>
-        </label>
+        <div className="flex items-center justify-between">
+          <label className="text-xs font-bold uppercase tracking-[0.06em] text-discord-header-secondary">
+            パスワード <span className="text-discord-brand-red">*</span>
+          </label>
+          <Link
+            href={APP_ROUTES.passwordReset}
+            className="text-xs text-discord-text-link hover:underline"
+          >
+            パスワードを忘れた場合
+          </Link>
+        </div>
         <input
           type="password"
+          name="password"
           value={form.password}
           onChange={(event) => updateForm("password", event.target.value)}
           autoComplete="current-password"
-          className="w-full rounded bg-discord-input-bg px-3 py-2.5 text-sm text-discord-text-normal outline-none ring-0 transition focus:ring-2 focus:ring-discord-brand-blurple"
+          placeholder="••••••••"
+          className="h-10 w-full rounded-[3px] bg-discord-bg-tertiary px-[10px] text-sm text-discord-text-normal outline-none transition placeholder:text-discord-text-muted focus:ring-2 focus:ring-discord-brand-blurple/50"
         />
       </div>
 
       {reasonMessage === null ? null : (
-        <p className="rounded-md border border-amber-300/40 bg-amber-300/10 px-3 py-2 text-sm text-amber-200">
+        <p className="rounded-[3px] bg-amber-300/10 px-3 py-2 text-sm text-amber-200">
           {reasonMessage}
         </p>
       )}
 
       {errorMessage === null ? null : (
-        <p className="rounded-md border border-[var(--llx-brand-red)]/40 bg-[var(--llx-brand-red)]/10 px-3 py-2 text-sm text-[var(--llx-brand-red)]">
+        <p className="rounded-[3px] bg-discord-brand-red/10 px-3 py-2 text-sm text-discord-brand-red">
           {errorMessage}
         </p>
       )}
@@ -179,10 +192,16 @@ export function LoginForm({ returnTo, reason }: LoginFormProps) {
       <button
         type="submit"
         disabled={isSubmitting}
-        className="mt-2 w-full rounded bg-discord-brand-blurple px-4 py-3 text-sm font-medium text-white transition hover:bg-discord-btn-blurple-hover disabled:cursor-not-allowed disabled:opacity-50"
+        className="mt-2 h-11 w-full rounded-[4px] bg-discord-brand-blurple text-sm font-medium text-white transition hover:bg-discord-btn-blurple-hover disabled:cursor-not-allowed disabled:opacity-50"
       >
         {submitKind === "email" ? "ログイン中..." : "ログイン"}
       </button>
+
+      <div className="flex items-center gap-3">
+        <div className="h-px flex-1 bg-discord-divider" />
+        <span className="text-xs text-discord-text-muted">または</span>
+        <div className="h-px flex-1 bg-discord-divider" />
+      </div>
 
       <GoogleSignInButton
         disabled={isSubmitting}


### PR DESCRIPTION
…pen)

- Replace two-column layout with centered single-card design
- Apply Discord design tokens from discord-unified.pen:
  - Card: bg-primary (#313338), rounded-[4px], deep shadow
  - Inputs: bg-tertiary (#1E1F22), rounded-[3px], h-10 (TextInput/Default)
  - Button: bg-blurple, rounded-[4px], h-11 (modal button style)
- Move forgot-password link inline with password label
- Add subtle blurple radial gradient background effect
- Clean up unused createUiGateway call