### PR TITLE
fix(auth): Firebase authレビュー指摘のblock/medium対応

### DIFF
--- a/docs/runbooks/auth-firebase-principal-operations-runbook.md
+++ b/docs/runbooks/auth-firebase-principal-operations-runbook.md
@@ -66,7 +66,7 @@ Out of scope:
   - `AUTH_PRINCIPAL_STORE_MAX_RETRIES` (default: `2`)
   - `AUTH_PRINCIPAL_STORE_RETRY_BASE_BACKOFF_MS` (default: `25`)
 - Postgres transport is TLS-required by default.
-  - Current implementation is fail-close when TLS is required and no TLS connector is configured.
+  - Runtime uses Rustls TLS connector, and TLS connection failures are fail-close (`AUTH_UNAVAILABLE`).
   - Temporary plaintext opt-out is possible only with explicit:
     - `AUTH_ALLOW_POSTGRES_NOTLS=true` (local/development only)
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -102,6 +102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +192,29 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "deranged"
@@ -239,6 +274,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "foldhash"
@@ -695,15 +736,18 @@ dependencies = [
  "jsonwebtoken",
  "linklynx_shared",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1428,6 +1472,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,6 +1621,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1693,21 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid",
+ "ring",
+ "rustls",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+ "x509-cert",
 ]
 
 [[package]]
@@ -2323,6 +2413,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2493,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,13 +21,16 @@ axum = { version = "0.8", features = ["ws"] }
 http = "1"
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-postgres = "0.7"
+tokio-postgres-rustls = "0.13"
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+webpki-roots = "1"

--- a/rust/apps/api/Cargo.toml
+++ b/rust/apps/api/Cargo.toml
@@ -10,12 +10,15 @@ http.workspace = true
 jsonwebtoken.workspace = true
 linklynx_shared = { path = "../../crates/shared" }
 reqwest.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
+tokio-postgres-rustls.workspace = true
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
+webpki-roots.workspace = true

--- a/rust/apps/api/src/auth.rs
+++ b/rust/apps/api/src/auth.rs
@@ -17,11 +17,14 @@ use axum::{
 use jsonwebtoken::{errors::ErrorKind, Algorithm, DecodingKey, Validation};
 use linklynx_shared::PrincipalId;
 use reqwest::Client;
+use rustls::{ClientConfig, RootCertStore};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
 use tokio_postgres::NoTls;
+use tokio_postgres_rustls::MakeRustlsConnect;
 use tracing::warn;
 use uuid::Uuid;
+use webpki_roots::TLS_SERVER_ROOTS;
 
 const FIREBASE_PROVIDER: &str = "firebase";
 const DEFAULT_JWKS_URL: &str =

--- a/rust/apps/api/src/auth/principal.rs
+++ b/rust/apps/api/src/auth/principal.rs
@@ -496,27 +496,51 @@ impl PostgresPrincipalStore {
         }
     }
 
+    /// Postgres向けのTLSコネクタを構築する。
+    /// @param なし
+    /// @returns RustlsベースのTLSコネクタ
+    /// @throws なし
+    fn build_tls_connector() -> MakeRustlsConnect {
+        let mut root_cert_store = RootCertStore::empty();
+        root_cert_store.extend(TLS_SERVER_ROOTS.iter().cloned());
+
+        let client_config = ClientConfig::builder()
+            .with_root_certificates(root_cert_store)
+            .with_no_client_auth();
+        MakeRustlsConnect::new(client_config)
+    }
+
     /// Postgres接続を1本生成する。
     /// @param なし
     /// @returns Postgresクライアント
     /// @throws String 接続失敗時
     async fn connect_client(&self) -> Result<Arc<tokio_postgres::Client>, String> {
-        let (client, connection) = match self.transport_security {
+        let client = match self.transport_security {
             PostgresTransportSecurity::TlsRequiredFailClose => {
-                return Err("postgres_tls_required: set AUTH_ALLOW_POSTGRES_NOTLS=true only for local development until TLS connector is configured".to_owned());
+                let tls = Self::build_tls_connector();
+                let (client, connection) = tokio_postgres::connect(self.database_url.as_ref(), tls)
+                    .await
+                    .map_err(|error| format!("postgres_connect_tls_failed:{error}"))?;
+                tokio::spawn(async move {
+                    if let Err(error) = connection.await {
+                        tracing::error!(reason = %error, "postgres principal store connection error");
+                    }
+                });
+                client
             }
             PostgresTransportSecurity::NoTlsAllowed => {
-                tokio_postgres::connect(self.database_url.as_ref(), NoTls)
+                let (client, connection) =
+                    tokio_postgres::connect(self.database_url.as_ref(), NoTls)
                     .await
-                    .map_err(|error| format!("postgres_connect_notls_failed:{error}"))?
+                    .map_err(|error| format!("postgres_connect_notls_failed:{error}"))?;
+                tokio::spawn(async move {
+                    if let Err(error) = connection.await {
+                        tracing::error!(reason = %error, "postgres principal store connection error");
+                    }
+                });
+                client
             }
         };
-
-        tokio::spawn(async move {
-            if let Err(error) = connection.await {
-                tracing::error!(reason = %error, "postgres principal store connection error");
-            }
-        });
 
         Ok(Arc::new(client))
     }

--- a/rust/apps/api/src/auth/tests.rs
+++ b/rust/apps/api/src/auth/tests.rs
@@ -500,17 +500,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn postgres_principal_store_requires_tls_by_default() {
+    async fn postgres_principal_store_uses_tls_by_default() {
         let _lock = env_lock().lock().await;
         let mut scoped = ScopedEnv::new();
         scoped.remove("AUTH_ALLOW_POSTGRES_NOTLS");
 
         let store = PostgresPrincipalStore::new(
-            "postgres://localhost/test".to_owned(),
+            "postgres://127.0.0.1:9/test".to_owned(),
             Arc::new(AuthMetrics::default()),
         );
         let error = store.connect_client().await.unwrap_err();
-        assert!(error.starts_with("postgres_tls_required"));
+        assert!(error.starts_with("postgres_connect_tls_failed:"));
     }
 
     #[tokio::test]

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -10,6 +10,7 @@ fn app_with_state(state: AppState) -> Router {
 
     let protected_routes = Router::new()
         .route("/protected/ping", get(protected_ping))
+        .route("/internal/auth/metrics", get(auth_metrics_handler))
         .route("/guilds", get(list_guilds).post(create_guild))
         .route(
             "/guilds/{guild_id}/channels",
@@ -24,7 +25,6 @@ fn app_with_state(state: AppState) -> Router {
         .route("/", get(root))
         .route("/health", get(health_check))
         .route("/ws", get(ws_handler))
-        .route("/internal/auth/metrics", get(auth_metrics_handler))
         .merge(protected_routes)
         .with_state(state)
         .layer(cors)
@@ -288,15 +288,6 @@ async fn rest_auth_middleware(
         }
     };
 
-    tracing::info!(
-        decision = "allow",
-        request_id = %request_id,
-        principal_id = authenticated.principal_id.0,
-        firebase_uid = %authenticated.firebase_uid,
-        email_verified = true,
-        "REST auth accepted"
-    );
-
     let action = match request_method {
         axum::http::Method::GET | axum::http::Method::HEAD => AuthzAction::View,
         axum::http::Method::POST => AuthzAction::Post,
@@ -329,6 +320,18 @@ async fn rest_auth_middleware(
         );
         return authz_error_response(&error, request_id);
     }
+
+    tracing::info!(
+        decision = "allow",
+        request_id = %request_id,
+        principal_id = authenticated.principal_id.0,
+        firebase_uid = %authenticated.firebase_uid,
+        email_verified = true,
+        resource = %request_path,
+        action = action_label,
+        decision_source = "authorizer",
+        "REST auth accepted"
+    );
 
     request.extensions_mut().insert(AuthContext {
         request_id,

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -282,6 +282,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn internal_auth_metrics_rejects_missing_token() {
+        let app = app_for_test().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/internal/auth/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn internal_auth_metrics_accepts_authenticated_request() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/internal/auth/metrics")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
     async fn protected_endpoint_provisions_missing_mapping() {
         let app = app_for_test().await;
         let token = format!("u-unknown:{}", unix_timestamp_seconds() + 300);

--- a/rust/apps/api/src/main/ws_routes.rs
+++ b/rust/apps/api/src/main/ws_routes.rs
@@ -38,15 +38,6 @@ async fn ws_handler(
         }
     };
 
-    tracing::info!(
-        decision = "allow",
-        request_id = %request_id,
-        principal_id = authenticated.principal_id.0,
-        firebase_uid = %authenticated.firebase_uid,
-        email_verified = true,
-        "WS auth accepted at handshake"
-    );
-
     let authz_input = AuthzCheckInput {
         principal_id: authenticated.principal_id,
         resource: AuthzResource::Session,
@@ -72,6 +63,18 @@ async fn ws_handler(
             })
             .into_response();
     }
+
+    tracing::info!(
+        decision = "allow",
+        request_id = %request_id,
+        principal_id = authenticated.principal_id.0,
+        firebase_uid = %authenticated.firebase_uid,
+        email_verified = true,
+        resource = "session",
+        action = "connect",
+        decision_source = "authorizer",
+        "WS auth accepted at handshake"
+    );
 
     ws.on_upgrade(move |socket| handle_socket(socket, state, authenticated, request_id))
         .into_response()

--- a/typescript/src/app/providers/auth-bridge.tsx
+++ b/typescript/src/app/providers/auth-bridge.tsx
@@ -15,6 +15,7 @@ export function AuthBridge() {
 
   useEffect(() => {
     if (session.status !== "authenticated" || session.user === null) {
+      setCurrentUser(null);
       return;
     }
 

--- a/typescript/src/shared/model/stores/auth-store.test.ts
+++ b/typescript/src/shared/model/stores/auth-store.test.ts
@@ -1,0 +1,32 @@
+import type { User } from "@/shared/model/types/user";
+import { useAuthStore } from "./auth-store";
+
+const TEST_USER: User = {
+  id: "u-1",
+  username: "alice",
+  displayName: "alice",
+  avatar: null,
+  status: "online",
+  customStatus: null,
+  bot: false,
+};
+
+describe("useAuthStore", () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      currentUser: null,
+      status: "online",
+      customStatus: null,
+    });
+  });
+
+  it("setCurrentUser supports clearing current user", () => {
+    const { setCurrentUser } = useAuthStore.getState();
+
+    setCurrentUser(TEST_USER);
+    expect(useAuthStore.getState().currentUser).toEqual(TEST_USER);
+
+    setCurrentUser(null);
+    expect(useAuthStore.getState().currentUser).toBeNull();
+  });
+});

--- a/typescript/src/shared/model/stores/auth-store.ts
+++ b/typescript/src/shared/model/stores/auth-store.ts
@@ -6,7 +6,7 @@ type AuthState = {
   status: UserStatus;
   customStatus: string | null;
 
-  setCurrentUser: (user: User) => void;
+  setCurrentUser: (user: User | null) => void;
   setStatus: (status: UserStatus) => void;
   setCustomStatus: (text: string | null) => void;
 };


### PR DESCRIPTION
## 概要
Firebase auth 領域の reviewer 指摘のうち、`block` と `medium` を解消しました。

## 変更内容
- Frontend
  - ログアウト/未認証遷移時に `AuthBridge` から `currentUser` を `null` へ明示クリア
  - auth-store の `setCurrentUser` を `User | null` 対応
  - store の回帰テストを追加
- Backend
  - Postgres principal store に Rustls TLS 接続を実装（`AUTH_ALLOW_POSTGRES_NOTLS=false` で接続試行可能化）
  - `decision=allow` ログを AuthZ 成功後に記録するよう変更（REST/WS）
  - `/internal/auth/metrics` を保護ルート配下へ移動し認証必須化
  - metrics ルートの認証有無テストを追加
- Docs
  - runbook の TLS 実装記述を現実装に合わせて更新

## 意図
- 認証状態の残留を防ぎ、ログアウト後に前回ユーザー情報が利用されるリスクを排除する
- TLS 必須設定で principal 解決が恒常失敗する状態を解消し、fail-close を維持したまま正しく接続試行できるようにする
- 監査ログの `allow` 判定と実際の認可判定結果を一致させ、運用判断の誤認を防ぐ
- 内部メトリクス露出を防ぐ

## テスト
- `npm -C typescript run test -- src/shared/model/stores/auth-store.test.ts`
- `npm -C typescript run typecheck`
- `cargo test -p linklynx_backend`
- `cargo fmt --all -- --check`

## ADR-001 チェック
- イベントスキーマ/配信契約の変更: なし（対象外）
