### PR TITLE
auth周辺のレビュー指摘修正と fail-close 強化

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -1,22 +1,17 @@
 # Documentation
 
-## TypeScript FSD移行メモ
+## Current status
+- Now: auth 修正・追加テスト・最終レビューまで完了。
+- Next: PR作成と最終説明。
 
-- `typescript/src` のトップレベルは `app / entities / features / shared / widgets / test` のみとし、非FSD直下ディレクトリを解消。
-- 既存UI実装は変更せず、物理配置と import パスのみを更新。
-- `widgets` レイヤは `widgets/<slice>/ui` の形に統一し、`widgets/legacy` は廃止。
-- `widgets/<slice>/index.ts` を Public API として配置し、外部からはスライス単位の import を優先。
-- 既存の mock-design 系コードに対する ESLint 緩和設定は `src/widgets/**/*` に適用して維持。
+## Decisions
+- AuthZ runtime の fail-close を優先し、allow-all fallback を除去する。
+- 認証状態同期とエラー分類の不整合は frontend 側で明示的に扱う。
 
-## TypeScript FSD理想系（2026-03-03 更新）
+## How to run / demo
+- Primary validate: `make validate`
+- Rust tests: `cd rust && cargo test -p linklynx_backend`
+- TS focused tests: `cd typescript && npm run test -- src/entities/auth/api/principal-provisioning.test.ts src/features/route-guard/ui/protected-preview-gate.test.tsx src/features/route-guard/ui/protected-preview-gate.browser.test.tsx src/features/auth-flow/model/error-message.test.ts src/app/providers/auth-bridge.test.tsx`
 
-- `widgets` はレイアウト/複合表示の単位に限定:
-  - `app-shell`, `channel-sidebar`, `chat`, `member-list`, `panels`, `server-list`
-- ユースケース中心のスライスは `features` へ集約:
-  - `auth-guard`, `context-menus`, `dm-friends`, `forum`, `modals`, `notifications`,
-    `pickers`, `settings`, `special`, `threads`, `user-profile`, `voice`
-- `features/index.ts` を更新し、移動したスライスをPublic APIとして再公開。
-- FSD境界の自動検査を追加:
-  - 実体: `typescript/scripts/check-fsd.mjs`
-  - 実行: `make ts-fsd-check` または `cd typescript && make fsd-check`
-  - `cd typescript && make lint` 実行時にも `fsd-check` を先行実行。
+## Known issues / follow-ups
+- 最終レビュー結果: findings 0件 / blocking なし。

--- a/Implement.md
+++ b/Implement.md
@@ -1,49 +1,33 @@
 # Implement
 
-## 2026-03-03
-- `docs/TYPESCRIPT.md` を確認し、FSDレイヤ要件を基準に移行方針を確定。
-- 以下の非FSDトップレベルをFSDレイヤ配下へ移動:
-  - `typescript/src/components/ui` → `typescript/src/shared/ui/legacy`
-  - `typescript/src/components/*` (ui除く) → `typescript/src/widgets/legacy/ui/*`
-  - `typescript/src/hooks` → `typescript/src/shared/model/legacy/hooks`
-  - `typescript/src/lib` → `typescript/src/shared/lib/legacy`
-  - `typescript/src/services` → `typescript/src/shared/api/legacy`
-  - `typescript/src/stores` → `typescript/src/shared/model/legacy/stores`
-  - `typescript/src/types` → `typescript/src/shared/model/legacy/types`
-  - `typescript/src/providers` → `typescript/src/app/providers`
-- 全 `@/components|hooks|lib|providers|services|stores|types` import を新パスへ一括更新。
-- `typescript/eslint.config.mjs` の許可パス/緩和対象を新ディレクトリ構造へ更新。
-- 検証:
-  - `cd typescript && npm run typecheck` ✅
-  - `cd typescript && npm run lint` ✅
+## Execution policy
+- Plan.md の順序で実装する。
+- scope 外変更は行わない。
+- 各マイルストーンでテストを実行し、失敗時は即修正する。
 
-## 2026-03-03 (widgets/legacy 廃止対応)
-- `typescript/src/widgets/legacy/ui/*` を `typescript/src/widgets/<slice>/ui` へ移動し、`widgets/legacy` を削除。
-- `auth-guard` は `typescript/src/widgets/auth-guard/ui/auth-guard.tsx` として再配置。
-- 各 `widgets/<slice>/index.ts` を追加し、Public API をスライス単位で公開。
-- `@/widgets/legacy/ui/*` import を新構造へ置換:
-  - ルート参照: `@/widgets/<slice>`
-  - 深い参照: `@/widgets/<slice>/ui/...`
-- widget 間参照の一部を Public API 経由に整理:
-  - 例: `panels` → `threads`, `modals` → `user-profile`
-- `typescript/eslint.config.mjs` の緩和対象を `src/widgets/legacy/**/*` から `src/widgets/**/*` に更新。
-- 検証:
-  - `cd typescript && npm run typecheck` ✅
-  - `cd typescript && npm run lint` ✅
-
-## 2026-03-03 (理想系へ再配置 + FSDチェック導入)
-- `widgets` 偏重を解消するため、下記スライスを `widgets` から `features` へ移動:
-  - `auth-guard`, `context-menus`, `dm-friends`, `forum`, `modals`, `notifications`,
-    `pickers`, `settings`, `special`, `threads`, `user-profile`, `voice`
-- `@/widgets/<slice>` 参照を `@/features/<slice>` へ一括置換し、`app/widgets/features` の参照整合を維持。
-- `typescript/src/features/index.ts` に移動済みスライスの export を追加し、Public APIを集約。
-- TypeScript専用FSDチェックを追加:
-  - `typescript/scripts/check-fsd.mjs`
-  - `typescript/package.json` に `fsd:check` 追加
-  - `typescript/Makefile` に `fsd-check` 追加、`lint` 前に実行
-  - ルート `Makefile` に `ts-fsd-check` 追加
-- `typescript/eslint.config.mjs` にて、旧 `widgets` から `features` へ移動したモックUI群へ既存緩和ルールを適用。
-- 検証:
-  - `make ts-fsd-check` ✅
-  - `cd typescript && npm run typecheck` ✅
-  - `cd typescript && make lint` ✅
+## Progress log
+- 2026-03-04: auth 関連コードを backend/frontend で探索。
+- 2026-03-04: reviewer 実行で P1/P2/P3 指摘を取得。
+- 2026-03-04: Backend 修正を反映。
+  - `rust/apps/api/src/authz/runtime.rs`: デフォルト/unknown/spicedb フォールバックを `noop_unavailable` へ変更し fail-close 化。
+  - `rust/apps/api/src/main/http_routes.rs`: `/internal/auth/metrics` を認証ミドルウェア配下へ移動。
+  - `rust/apps/api/src/authz/tests.rs` と `rust/apps/api/src/main/tests.rs`: 上記挙動を検証するテストを追加。
+- 2026-03-04: Frontend 修正を反映。
+  - `typescript/src/app/providers/auth-bridge.tsx` + `typescript/src/shared/model/stores/auth-store.ts`:
+    未認証/不整合セッション時の `currentUser` クリアを追加。
+  - `typescript/src/entities/auth/api/principal-provisioning.ts`:
+    `token-unavailable` を `network-request-failed` へ潰さず維持。
+  - `typescript/src/features/auth-flow/model/error-message.ts` と
+    `typescript/src/features/route-guard/ui/protected-preview-gate.tsx`:
+    `token-unavailable` をセッション失効系として扱うよう調整。
+  - `typescript/src/app/providers/auth-bridge.test.tsx` と
+    `typescript/src/features/route-guard/ui/protected-preview-gate.browser.test.tsx` を追加。
+- 2026-03-04: 検証実行。
+  - `cd rust && cargo test -p linklynx_backend` ✅
+  - `cd typescript && npm run test -- src/entities/auth/api/principal-provisioning.test.ts src/features/auth-flow/model/error-message.test.ts src/features/route-guard/ui/protected-preview-gate.test.tsx src/features/route-guard/ui/protected-preview-gate.browser.test.tsx src/app/providers/auth-bridge.test.tsx` ✅
+  - `make validate` ✅
+- 2026-03-04: 再レビュー実行。
+  - `reviewer_simple`: gate=pass（P1以上なし）
+  - `reviewer`: gate=pass（P1以上なし、P3の追加テスト改善余地のみ）
+- 2026-03-04: P3追補後の最終レビュー実行。
+  - `reviewer_simple`: gate=pass（findings 0件、blockingなし）

--- a/Plan.md
+++ b/Plan.md
@@ -1,23 +1,31 @@
 # Plan
 
-1. `docs/TYPESCRIPT.md` を読み、現行構造との差分を把握する。 ✅
-2. 非FSDトップレベル (`components/hooks/lib/providers/services/stores/types`) をFSDレイヤ配下に再配置する。 ✅
-3. 全importを新パスへ一括更新する。 ✅
-4. ESLint設定の対象パスを新構造に合わせる。 ✅
-5. TypeScript typecheck / lint で参照整合性を確認する。 ✅
+## Rules
+- validation/review で失敗したら次に進まず修正する。
 
-## Follow-up (widgets/legacy廃止)
+## Milestones
+### M1: Backend auth hardening
+- Acceptance criteria:
+  - [x] `AUTHZ_PROVIDER` 未設定/不正/未実装時に allow-all へ落ちない。
+  - [x] auth metrics エンドポイントが認証保護される。
+- Validation:
+  - `cd rust && cargo test -p linklynx_backend`
 
-1. `typescript/src/widgets/legacy` の中身を `widgets/<slice>/ui` へ再配置する。 ✅
-2. `@/widgets/legacy/ui/*` import を新しい `widgets` スライス参照へ置換する。 ✅
-3. `widgets` 各スライスに Public API (`index.ts`) を用意する。 ✅
-4. `eslint.config.mjs` の `legacy` 前提パスを新構成へ更新する。 ✅
-5. TypeScript typecheck / lint を再実行する。 ✅
+### M2: Frontend auth consistency
+- Acceptance criteria:
+  - [x] AuthBridge が未認証遷移時に stale user を残さない。
+  - [x] principal provisioning が `token-unavailable` を正しく扱う。
+- Validation:
+  - `cd typescript && npm run test -- src/entities/auth/api/principal-provisioning.test.ts src/features/auth-flow/model/error-message.test.ts`
 
-## Follow-up (理想系化)
+### M3: Route guard regression tests
+- Acceptance criteria:
+  - [x] route guard の 401/403/503 分岐をカバーするテストが追加される。
+- Validation:
+  - `cd typescript && npm run test -- src/features/route-guard/ui/protected-preview-gate.test.tsx src/features/route-guard/ui/protected-preview-gate.browser.test.tsx src/app/providers/auth-bridge.test.tsx`
 
-1. `widgets` のうちユースケース中心スライスを `features` へ再配置する。 ✅
-2. `@/widgets/<slice>` import を `@/features/<slice>` に一括更新する。 ✅
-3. `features/index.ts` で再配置スライスの Public API を公開する。 ✅
-4. TypeScript専用の FSD境界チェックを追加し、`make ts-fsd-check` で実行可能にする。 ✅
-5. `fsd-check / typecheck / lint` で整合性を確認する。 ✅
+### M4: Review loop
+- Acceptance criteria:
+  - [x] `reviewer` 再実行で blocking finding がない。
+- Validation:
+  - `reviewer`: gate=pass（P1以上なし）

--- a/Prompt.md
+++ b/Prompt.md
@@ -1,7 +1,25 @@
 # Prompt
 
-- 依頼: `typescript` ディレクトリをFSDに準拠させる。
-- 制約: UI/挙動は変えず、主にファイル名・ディレクトリ構造を修正する。
-- 準拠基準: `docs/TYPESCRIPT.md` のレイヤ構造 (`app -> widgets -> features -> entities -> shared`) とセグメント方針。
-- 追加依頼: `/legacy/` を完全排除し、`widgets` 偏重を是正して `features` 中心の理想構成へ再配置する。
-- 追加依頼: TypeScript の FSD 境界チェックを導入し、`make` から実行できるようにする。
+## Goals
+- auth 関連の backend/frontend 実装を探索し、レビューエージェント指摘を解消する。
+- レビュー指摘のうち特に blocking (P1) を優先し、レビューOKになるまで修正を反復する。
+
+## Non-goals
+- auth 以外の機能改善。
+- UI デザイン変更。
+
+## Deliverables
+- AuthZ の fail-close 方針に沿った runtime 挙動。
+- auth 関連エンドポイントの保護強化。
+- frontend 認証状態同期とエラー分類の不整合修正。
+- 追加/更新テストとその実行結果。
+
+## Done when
+- [ ] reviewer 指摘の blocking finding が解消されている。
+- [ ] auth 関連の追加/更新テストが通過している。
+- [ ] reviewer 再実行で重大指摘がなくなる。
+
+## Constraints
+- Perf: auth 処理のホットパスで不要な追加処理を避ける。
+- Security: ADR-004 fail-close 方針を満たす。
+- Compatibility: auth API 契約を壊さない（必要最小限の挙動修正のみ）。

--- a/rust/apps/api/src/authz/runtime.rs
+++ b/rust/apps/api/src/authz/runtime.rs
@@ -1,4 +1,4 @@
-const DEFAULT_AUTHZ_PROVIDER: &str = "noop";
+const DEFAULT_AUTHZ_PROVIDER: &str = "noop_unavailable";
 const DEFAULT_ALLOW_ALL_UNTIL: &str = "2026-06-30";
 
 /// 実行時向けの認可実装を生成する。
@@ -62,27 +62,27 @@ pub fn build_runtime_authorizer() -> Arc<dyn Authorizer> {
         "spicedb" => {
             warn!(
                 provider = "spicedb",
-                fallback = "noop",
+                fallback = "noop_unavailable",
                 allow_all_until = %allow_all_until,
                 supported_action_count = supported_actions.len(),
-                "AUTHZ_PROVIDER=spicedb is not implemented yet; fallback to noop allow-all"
+                "AUTHZ_PROVIDER=spicedb is not implemented yet; fallback to noop unavailable mode"
             );
             Arc::new(NoopAllowAllAuthorizer::new(
                 allow_all_until,
-                NoopAuthorizerMode::Allow,
+                NoopAuthorizerMode::Unavailable,
             ))
         }
         _ => {
             warn!(
                 provider = %provider,
-                fallback = "noop",
+                fallback = "noop_unavailable",
                 allow_all_until = %allow_all_until,
                 supported_action_count = supported_actions.len(),
-                "unknown AUTHZ_PROVIDER; fallback to noop allow-all"
+                "unknown AUTHZ_PROVIDER; fallback to noop unavailable mode"
             );
             Arc::new(NoopAllowAllAuthorizer::new(
                 allow_all_until,
-                NoopAuthorizerMode::Allow,
+                NoopAuthorizerMode::Unavailable,
             ))
         }
     }

--- a/rust/apps/api/src/authz/tests.rs
+++ b/rust/apps/api/src/authz/tests.rs
@@ -25,6 +25,13 @@ mod tests {
             }
             env::set_var(name, value);
         }
+
+        fn remove(&mut self, name: &str) {
+            if !self.backups.iter().any(|(saved, _)| saved == name) {
+                self.backups.push((name.to_owned(), env::var(name).ok()));
+            }
+            env::remove_var(name);
+        }
     }
 
     impl Drop for ScopedEnv {
@@ -58,7 +65,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn runtime_provider_spicedb_falls_back_to_allow_all() {
+    async fn runtime_provider_spicedb_falls_back_to_unavailable() {
         let _guard = env_lock().lock().await;
         let mut scoped = ScopedEnv::new();
         scoped.set("AUTHZ_PROVIDER", "spicedb");
@@ -71,11 +78,12 @@ mod tests {
             action: AuthzAction::Connect,
         };
 
-        assert!(authorizer.check(&input).await.is_ok());
+        let error = authorizer.check(&input).await.unwrap_err();
+        assert_eq!(error.kind, AuthzErrorKind::DependencyUnavailable);
     }
 
     #[tokio::test]
-    async fn runtime_provider_unknown_falls_back_to_allow_all() {
+    async fn runtime_provider_unknown_falls_back_to_unavailable() {
         let _guard = env_lock().lock().await;
         let mut scoped = ScopedEnv::new();
         scoped.set("AUTHZ_PROVIDER", "unknown");
@@ -90,7 +98,26 @@ mod tests {
             action: AuthzAction::View,
         };
 
-        assert!(authorizer.check(&input).await.is_ok());
+        let error = authorizer.check(&input).await.unwrap_err();
+        assert_eq!(error.kind, AuthzErrorKind::DependencyUnavailable);
+    }
+
+    #[tokio::test]
+    async fn runtime_provider_default_falls_back_to_unavailable() {
+        let _guard = env_lock().lock().await;
+        let mut scoped = ScopedEnv::new();
+        scoped.remove("AUTHZ_PROVIDER");
+        scoped.set("AUTHZ_ALLOW_ALL_UNTIL", "2026-06-30");
+
+        let authorizer = build_runtime_authorizer();
+        let input = AuthzCheckInput {
+            principal_id: PrincipalId(1001),
+            resource: AuthzResource::Session,
+            action: AuthzAction::Connect,
+        };
+
+        let error = authorizer.check(&input).await.unwrap_err();
+        assert_eq!(error.kind, AuthzErrorKind::DependencyUnavailable);
     }
 
     #[tokio::test]

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -10,6 +10,7 @@ fn app_with_state(state: AppState) -> Router {
 
     let protected_routes = Router::new()
         .route("/protected/ping", get(protected_ping))
+        .route("/internal/auth/metrics", get(auth_metrics_handler))
         .route("/guilds", get(list_guilds).post(create_guild))
         .route(
             "/guilds/{guild_id}/channels",
@@ -25,7 +26,6 @@ fn app_with_state(state: AppState) -> Router {
         .route("/health", get(health_check))
         .route("/ws", get(ws_handler))
         .route("/auth/ws-ticket", post(issue_ws_ticket))
-        .route("/internal/auth/metrics", get(auth_metrics_handler))
         .merge(protected_routes)
         .with_state(state)
         .layer(cors)

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -270,6 +270,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn auth_metrics_endpoint_rejects_missing_token() {
+        let app = app_for_test().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/internal/auth/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn auth_metrics_endpoint_rejects_invalid_token() {
+        let app = app_for_test().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/internal/auth/metrics")
+                    .header("authorization", "Bearer invalid-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn auth_metrics_endpoint_rejects_expired_token() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}", unix_timestamp_seconds().saturating_sub(1));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/internal/auth/metrics")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn auth_metrics_endpoint_accepts_valid_token() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/internal/auth/metrics")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert!(json.get("token_verify_success_total").is_some());
+        assert!(json.get("principal_cache_hit_ratio").is_some());
+    }
+
+    #[tokio::test]
     async fn protected_endpoint_accepts_valid_token() {
         let app = app_for_test().await;
         let token = format!("u-1:{}", unix_timestamp_seconds() + 300);

--- a/typescript/src/app/(auth)/login/page.tsx
+++ b/typescript/src/app/(auth)/login/page.tsx
@@ -41,10 +41,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
 
         <p className="mt-6 text-sm text-discord-text-muted">
           アカウントをお持ちでないですか？{" "}
-          <Link
-            href={APP_ROUTES.register}
-            className="text-discord-text-link hover:underline"
-          >
+          <Link href={APP_ROUTES.register} className="text-discord-text-link hover:underline">
             新規登録
           </Link>
         </p>

--- a/typescript/src/app/providers/auth-bridge.test.tsx
+++ b/typescript/src/app/providers/auth-bridge.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import type { AuthSessionContextValue } from "@/entities/auth";
+import { render, waitFor } from "@/test/test-utils";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { useAuthStore } from "@/shared/model/stores/auth-store";
+
+const useAuthSessionMock = vi.hoisted(() =>
+  vi.fn<() => AuthSessionContextValue>(() => ({
+    status: "unauthenticated",
+    user: null,
+    getIdToken: () => Promise.resolve(null),
+  })),
+);
+
+vi.mock("@/entities/auth", () => ({
+  useAuthSession: useAuthSessionMock,
+}));
+
+import { AuthBridge } from "./auth-bridge";
+
+describe("AuthBridge", () => {
+  afterEach(() => {
+    useAuthStore.setState({
+      currentUser: null,
+      status: "online",
+      customStatus: null,
+    });
+    vi.clearAllMocks();
+  });
+
+  test("認証済みセッションを auth-store へ同期する", async () => {
+    useAuthSessionMock.mockReturnValue({
+      status: "authenticated",
+      user: {
+        uid: "uid-1",
+        email: "alice@example.com",
+        emailVerified: true,
+      },
+      getIdToken: () => Promise.resolve("token-1"),
+    });
+
+    render(<AuthBridge />);
+
+    await waitFor(() => {
+      const currentUser = useAuthStore.getState().currentUser;
+      expect(currentUser?.id).toBe("uid-1");
+      expect(currentUser?.username).toBe("alice");
+    });
+  });
+
+  test("未認証セッションへ遷移したら auth-store の currentUser をクリアする", async () => {
+    useAuthStore.setState({
+      currentUser: {
+        id: "uid-old",
+        username: "old-user",
+        displayName: "old-user",
+        avatar: null,
+        status: "online",
+        customStatus: null,
+        bot: false,
+      },
+      status: "online",
+      customStatus: null,
+    });
+    useAuthSessionMock.mockReturnValue({
+      status: "unauthenticated",
+      user: null,
+      getIdToken: () => Promise.resolve(null),
+    });
+
+    render(<AuthBridge />);
+
+    await waitFor(() => {
+      expect(useAuthStore.getState().currentUser).toBeNull();
+    });
+  });
+
+  test("認証状態でも user が null の場合は auth-store の currentUser をクリアする", async () => {
+    useAuthStore.setState({
+      currentUser: {
+        id: "uid-old",
+        username: "old-user",
+        displayName: "old-user",
+        avatar: null,
+        status: "online",
+        customStatus: null,
+        bot: false,
+      },
+      status: "online",
+      customStatus: null,
+    });
+    useAuthSessionMock.mockReturnValue({
+      status: "authenticated",
+      user: null,
+      getIdToken: () => Promise.resolve("token-1"),
+    });
+
+    render(<AuthBridge />);
+
+    await waitFor(() => {
+      expect(useAuthStore.getState().currentUser).toBeNull();
+    });
+  });
+});

--- a/typescript/src/app/providers/auth-bridge.tsx
+++ b/typescript/src/app/providers/auth-bridge.tsx
@@ -12,9 +12,11 @@ import type { User } from "@/shared/model/types/user";
 export function AuthBridge() {
   const session = useAuthSession();
   const setCurrentUser = useAuthStore((s) => s.setCurrentUser);
+  const clearCurrentUser = useAuthStore((s) => s.clearCurrentUser);
 
   useEffect(() => {
     if (session.status !== "authenticated" || session.user === null) {
+      clearCurrentUser();
       return;
     }
 
@@ -32,7 +34,7 @@ export function AuthBridge() {
     };
 
     setCurrentUser(mocUser);
-  }, [session, setCurrentUser]);
+  }, [clearCurrentUser, session, setCurrentUser]);
 
   return null;
 }

--- a/typescript/src/entities/auth/api/principal-provisioning.test.ts
+++ b/typescript/src/entities/auth/api/principal-provisioning.test.ts
@@ -141,6 +141,25 @@ describe("ensurePrincipalProvisionedForCurrentUser", () => {
     expect(result.error.status).toBe(503);
   });
 
+  test("IDトークン取得失敗時は token-unavailable を返す", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "http://localhost:8080";
+    setCurrentUser({
+      getIdToken: () => Promise.reject(new Error("token unavailable")),
+    });
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await ensurePrincipalProvisionedForCurrentUser();
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected error result");
+    }
+
+    expect(result.error.code).toBe("token-unavailable");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test("fetch 失敗時は network-request-failed を返す", async () => {
     process.env.NEXT_PUBLIC_API_URL = "http://localhost:8080";
     setCurrentUser({

--- a/typescript/src/entities/auth/api/principal-provisioning.ts
+++ b/typescript/src/entities/auth/api/principal-provisioning.ts
@@ -106,7 +106,7 @@ export async function ensurePrincipalProvisionedForCurrentUser(params?: {
       return {
         ok: false,
         error: createPrincipalProvisionError({
-          code: "network-request-failed",
+          code: "token-unavailable",
           message: fetchResult.error.message,
         }),
       };

--- a/typescript/src/entities/auth/model/principal-provisioning.ts
+++ b/typescript/src/entities/auth/model/principal-provisioning.ts
@@ -1,5 +1,6 @@
 export type PrincipalProvisionErrorCode =
   | "unauthenticated"
+  | "token-unavailable"
   | "email-not-verified"
   | "principal-not-mapped"
   | "auth-unavailable"

--- a/typescript/src/features/auth-flow/model/error-message.test.ts
+++ b/typescript/src/features/auth-flow/model/error-message.test.ts
@@ -68,6 +68,17 @@ describe("auth flow error message", () => {
     expect(message).toBe("ネットワークエラーが発生しました。接続を確認して再試行してください。");
   });
 
+  test("principal確保の token-unavailable は再ログイン文言を返す", () => {
+    const message = getPrincipalProvisionErrorMessage({
+      code: "token-unavailable",
+      message: "token unavailable",
+      backendCode: null,
+      requestId: null,
+      status: null,
+    });
+    expect(message).toBe("セッションが無効です。再度ログインしてください。");
+  });
+
   test("password reset の完了メッセージを固定化する", () => {
     expect(PASSWORD_RESET_COMPLETION_MESSAGE).toBe(
       "メールアドレスが登録されている場合、パスワード再設定メールを送信しました。",

--- a/typescript/src/features/auth-flow/model/error-message.ts
+++ b/typescript/src/features/auth-flow/model/error-message.ts
@@ -102,6 +102,7 @@ function appendRequestIdSuffix(message: string, requestId: string | null): strin
 export function getPrincipalProvisionErrorMessage(error: PrincipalProvisionError): string {
   switch (error.code) {
     case "unauthenticated":
+    case "token-unavailable":
       return "セッションが無効です。再度ログインしてください。";
     case "email-not-verified":
       return "メール確認が未完了です。確認後に再試行してください。";

--- a/typescript/src/features/route-guard/ui/protected-preview-gate.browser.test.tsx
+++ b/typescript/src/features/route-guard/ui/protected-preview-gate.browser.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import type { AuthSessionContextValue, PrincipalProvisionResult } from "@/entities";
+import { render, screen, waitFor } from "@/test/test-utils";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const useAuthSessionMock = vi.hoisted(() =>
+  vi.fn<() => AuthSessionContextValue>(() => ({
+    status: "authenticated",
+    user: {
+      uid: "uid-1",
+      email: "user@example.com",
+      emailVerified: true,
+    },
+    getIdToken: () => Promise.resolve("token-1"),
+  })),
+);
+const ensurePrincipalProvisionedForCurrentUserMock = vi.hoisted(() =>
+  vi.fn<() => Promise<PrincipalProvisionResult>>(() =>
+    Promise.resolve({
+      ok: true,
+      data: {
+        principalId: 1001,
+        firebaseUid: "uid-1",
+        requestId: "req-1",
+      },
+    }),
+  ),
+);
+const locationReplaceMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/entities", () => ({
+  ensurePrincipalProvisionedForCurrentUser: ensurePrincipalProvisionedForCurrentUserMock,
+  useAuthSession: useAuthSessionMock,
+}));
+
+import { ProtectedPreviewGate } from "./protected-preview-gate";
+
+describe("ProtectedPreviewGate browser behavior", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "location", "get").mockReturnValue({
+      replace: locationReplaceMock,
+      pathname: "/channels/me",
+      search: "?tab=all",
+    } as unknown as Location);
+    locationReplaceMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  test("token-unavailable は session-expired 理由でログインへリダイレクトする", async () => {
+    useAuthSessionMock.mockReturnValue({
+      status: "authenticated",
+      user: {
+        uid: "uid-1",
+        email: "user@example.com",
+        emailVerified: true,
+      },
+      getIdToken: () => Promise.resolve("token-1"),
+    });
+    ensurePrincipalProvisionedForCurrentUserMock.mockResolvedValue({
+      ok: false,
+      error: {
+        code: "token-unavailable",
+        message: "token unavailable",
+        backendCode: null,
+        requestId: null,
+        status: null,
+      },
+    });
+
+    render(
+      <ProtectedPreviewGate guard={null}>
+        <p>protected content</p>
+      </ProtectedPreviewGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("ログインが必要です")).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(locationReplaceMock).toHaveBeenCalledTimes(1);
+    });
+    const firstCall = locationReplaceMock.mock.calls[0];
+    expect(firstCall?.[0]).toContain("reason=session-expired");
+    expect(firstCall?.[0]).toContain("returnTo=%2Fchannels%2Fme%3Ftab%3Dall");
+  });
+
+  test("403 は forbidden ガード画面を表示し、ログインリダイレクトしない", async () => {
+    useAuthSessionMock.mockReturnValue({
+      status: "authenticated",
+      user: {
+        uid: "uid-1",
+        email: "user@example.com",
+        emailVerified: true,
+      },
+      getIdToken: () => Promise.resolve("token-1"),
+    });
+    ensurePrincipalProvisionedForCurrentUserMock.mockResolvedValue({
+      ok: false,
+      error: {
+        code: "principal-not-mapped",
+        message: "forbidden",
+        backendCode: "AUTH_PRINCIPAL_NOT_MAPPED",
+        requestId: "req-403",
+        status: 403,
+      },
+    });
+
+    render(
+      <ProtectedPreviewGate guard={null}>
+        <p>protected content</p>
+      </ProtectedPreviewGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("アクセス権限がありません")).toBeTruthy();
+    });
+    expect(locationReplaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/typescript/src/features/route-guard/ui/protected-preview-gate.tsx
+++ b/typescript/src/features/route-guard/ui/protected-preview-gate.tsx
@@ -94,7 +94,11 @@ export function ProtectedPreviewGate({ guard, children }: ProtectedPreviewGatePr
       };
     }
 
-    if (provisionResult.error.status === 401 || provisionResult.error.code === "unauthenticated") {
+    if (
+      provisionResult.error.status === 401 ||
+      provisionResult.error.code === "unauthenticated" ||
+      provisionResult.error.code === "token-unavailable"
+    ) {
       return {
         visibleGuard: "unauthenticated",
         loginReason: "session-expired",

--- a/typescript/src/shared/model/stores/auth-store.ts
+++ b/typescript/src/shared/model/stores/auth-store.ts
@@ -7,6 +7,7 @@ type AuthState = {
   customStatus: string | null;
 
   setCurrentUser: (user: User) => void;
+  clearCurrentUser: () => void;
   setStatus: (status: UserStatus) => void;
   setCustomStatus: (text: string | null) => void;
 };
@@ -17,6 +18,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   customStatus: null,
 
   setCurrentUser: (user) => set({ currentUser: user }),
+  clearCurrentUser: () => set({ currentUser: null }),
   setStatus: (status) => set({ status }),
   setCustomStatus: (text) => set({ customStatus: text }),
 }));


### PR DESCRIPTION
## 概要
Auth関連の backend / frontend を探索し、レビュー指摘（P1/P2/P3）を修正しました。
最終的に reviewer gate は pass（blocking なし、findings 0）です。

## 変更内容
- Backend
  - `AUTHZ_PROVIDER` 未設定・未知値・`spicedb` 指定時の挙動を `noop_unavailable` フォールバックに変更し、fail-close を徹底
  - `/internal/auth/metrics` を認証ミドルウェア配下へ移動
  - metrics エンドポイントの `missing/invalid/expired/valid` ケースの回帰テストを追加
- Frontend
  - `AuthBridge` で未認証/不整合セッション時に `currentUser` をクリア
  - `principal-provisioning` で `token-unavailable` を潰さず保持
  - route guard とエラーメッセージで `token-unavailable` をセッション失効系として扱うよう統一
  - 上記の回帰テストを追加

## 意図
- AuthZ の fail-close 方針（ADR-004）に沿って、誤って allow-all になる経路を排除するため
- 認証メトリクスの外部露出を防止するため
- セッション不整合時の UI ステート残留や誤分類を防ぎ、認証導線の一貫性を上げるため

## 受け入れ条件との対応
- `AUTHZ_PROVIDER` 未設定/不正/未実装時に allow-all へ落ちない: 対応済み
- auth metrics エンドポイントが認証保護される: 対応済み
- AuthBridge が stale user を残さない: 対応済み
- `token-unavailable` の分類と誘導が一貫している: 対応済み
- 追加回帰テスト: 対応済み

## テスト
- `make validate` ✅
- `cd rust && cargo test -p linklynx_backend` ✅
- `cd typescript && npm run test -- src/entities/auth/api/principal-provisioning.test.ts src/features/auth-flow/model/error-message.test.ts src/features/route-guard/ui/protected-preview-gate.test.tsx src/features/route-guard/ui/protected-preview-gate.browser.test.tsx src/app/providers/auth-bridge.test.tsx` ✅

## 互換性 / マイグレーション
- DBマイグレーションなし
- 破壊的変更なし（認証・認可失敗時の挙動を fail-close 方向へ明確化）

## レビュー結果
- reviewer（最終）: gate pass / findings 0 / blocking なし

## ADR-001 チェック
- イベントスキーマ変更: なし（本PRはAuth/AuthZ挙動とテストのみ）

## Linear
- 関連チケット: なし（このPRは auth 領域レビュー修正の独立対応）
