### PR TITLE
[v1/AuthZ-SpiceDB-04] Postgres→SpiceDB Tuple写像と同期実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ SPICEDB_ENDPOINT=http://localhost:50051
 SPICEDB_PRESHARED_KEY=replace-with-dev-spicedb-key
 SPICEDB_REQUEST_TIMEOUT_MS=1000
 SPICEDB_SCHEMA_PATH=database/contracts/lin862_spicedb_namespace_relation_permission_contract.md
+SPICEDB_TUPLE_SYNC_OUTBOX_CLAIM_LIMIT=100
+SPICEDB_TUPLE_SYNC_OUTBOX_LEASE_SECONDS=30
+SPICEDB_TUPLE_SYNC_OUTBOX_RETRY_SECONDS=15
 
 # Rust Backend (optional; if set, value must be valid)
 FIREBASE_AUDIENCE=your-firebase-project-id

--- a/database/contracts/lin864_postgres_spicedb_tuple_sync_contract.md
+++ b/database/contracts/lin864_postgres_spicedb_tuple_sync_contract.md
@@ -1,0 +1,135 @@
+# LIN-864 Postgres -> SpiceDB Tuple写像/同期 実装契約
+
+## Purpose
+
+- target issue: LIN-864
+- LIN-632 / LIN-633 / LIN-862 で固定した写像契約を、実装可能な backfill + 差分同期形へ落とし込む。
+- Postgresの `*_v2` 権限データから canonical relation 名の SpiceDB tuple を生成する。
+- outbox差分同期、失敗検知、最小再同期フックを定義する。
+
+## Scope
+
+In scope:
+- `rust/apps/api/src/authz/tuple_sync.rs` における tuple mapping 実装
+- `guild_roles_v2` / `guild_member_roles_v2` / `channel_role_permission_overrides_v2` / `channel_user_permission_overrides_v2` の backfill
+- `claim_outbox_events` / `mark_outbox_event_sent` / `mark_outbox_event_failed` を使う差分同期ループ
+- 同期失敗の検知メトリクスと full resync フック
+
+Out of scope:
+- SpiceDB Authorizer への本番接続切替（LIN-865）
+- APIハンドラへの認可適用（LIN-866/LIN-867）
+- 本番運用のSLO閾値確定（LIN-868で統合）
+
+## 1. Canonical tuple mapping
+
+### 1.1 Source -> Tuple
+
+| Source | Condition | Tuple |
+| --- | --- | --- |
+| `guild_member_roles_v2` | row exists | `role:{guild_id}/{role_key}#member@user:{user_id}` |
+| `guild_roles_v2` | `allow_manage=true` | `guild:{guild_id}#manager@role:{guild_id}/{role_key}#member` |
+| `guild_roles_v2` | `allow_view=true` | `guild:{guild_id}#viewer@role:{guild_id}/{role_key}#member` |
+| `guild_roles_v2` | `allow_post=true` | `guild:{guild_id}#poster@role:{guild_id}/{role_key}#member` |
+| `channel_role_permission_overrides_v2` | `can_view=true` | `channel:{channel_id}#viewer_role@role:{guild_id}/{role_key}#member` |
+| `channel_role_permission_overrides_v2` | `can_view=false` | `channel:{channel_id}#view_deny_role@role:{guild_id}/{role_key}#member` |
+| `channel_role_permission_overrides_v2` | `can_post=true` | `channel:{channel_id}#poster_role@role:{guild_id}/{role_key}#member` |
+| `channel_role_permission_overrides_v2` | `can_post=false` | `channel:{channel_id}#post_deny_role@role:{guild_id}/{role_key}#member` |
+| `channel_user_permission_overrides_v2` | `can_view=true` | `channel:{channel_id}#viewer_user@user:{user_id}` |
+| `channel_user_permission_overrides_v2` | `can_view=false` | `channel:{channel_id}#view_deny_user@user:{user_id}` |
+| `channel_user_permission_overrides_v2` | `can_post=true` | `channel:{channel_id}#poster_user@user:{user_id}` |
+| `channel_user_permission_overrides_v2` | `can_post=false` | `channel:{channel_id}#post_deny_user@user:{user_id}` |
+
+Rule:
+- tri-state `NULL` は tuple を生成しない（inherit）。
+- backfill出力は重複除去し、決定的順序で生成する。
+
+## 2. Initial backfill contract
+
+### 2.1 Read order
+
+backfillソースは以下順序で取得する。
+
+1. `guild_roles_v2`
+2. `guild_member_roles_v2`
+3. `channel_role_permission_overrides_v2`
+4. `channel_user_permission_overrides_v2`
+
+各クエリは安定順序（`ORDER BY`）を必須とする。
+
+### 2.2 Backfill output
+
+- 出力は `Vec<SpiceDbTuple>` とし、重複を除去する。
+- sink適用時は `Upsert` mutation のみを発行する。
+- 実行結果として最低限以下を返す:
+  - 各source行数
+  - 生成tuple件数
+  - 適用mutation件数
+
+## 3. Delta sync contract (outbox)
+
+### 3.1 Event types
+
+- `authz.tuple.guild_role.v1`
+- `authz.tuple.guild_member_role.v1`
+- `authz.tuple.channel_role_override.v1`
+- `authz.tuple.channel_user_override.v1`
+- `authz.tuple.full_resync.v1`
+
+### 3.2 Operation semantics
+
+- `op=upsert`
+  - 対象行の候補tupleを先に `Delete` し、現行状態tupleを `Upsert` する（置換型同期）。
+- `op=delete`
+  - 対象行に紐づく候補tupleを `Delete` する。
+- `authz.tuple.full_resync.v1`
+  - 1回の full backfill を実行する。
+
+### 3.3 Outbox processing
+
+- claim: `claim_outbox_events(limit, lease_seconds)`
+- success: `mark_outbox_event_sent(id)`
+- failure: `mark_outbox_event_failed(id, retry_seconds)`
+
+同期設定の環境変数:
+- `SPICEDB_TUPLE_SYNC_OUTBOX_CLAIM_LIMIT` (default `100`)
+- `SPICEDB_TUPLE_SYNC_OUTBOX_LEASE_SECONDS` (default `30`)
+- `SPICEDB_TUPLE_SYNC_OUTBOX_RETRY_SECONDS` (default `15`)
+
+## 4. Drift detection and resync hook
+
+- `detect_tuple_drift(expected, observed)` で missing/unexpected を計算する。
+- `build_resync_mutations(report)` で再同期用 mutation を生成する。
+- 運用上の最小フックとして `authz.tuple.full_resync.v1` を outbox投入し、全件再同期をトリガーできることを契約化する。
+
+## 5. Failure detection and observability
+
+実装は少なくとも以下を記録する。
+
+- outbox claim/success/failure 件数
+- full resync 件数
+- backfill実行回数
+- backfill生成tuple件数
+- 適用mutation件数
+- apply失敗件数
+
+失敗時ログには最低限以下を含める。
+- `event_id`
+- `event_type`
+- `aggregate_id`
+- `reason`
+
+## 6. Compatibility policy
+
+- LIN-864は additive 実装とし、既存AuthZ I/Fを破壊しない。
+- SpiceDB Authorizer切替はLIN-865で実施する。
+- deny/unavailable 境界は ADR-004 の fail-close 契約を維持する。
+
+## 7. Validation
+
+```bash
+make rust-lint
+make validate
+```
+
+補足:
+- `make validate` はローカル依存未導入時に TypeScript 側で失敗する場合がある。Rust差分の検証は `make rust-lint` を最低ゲートとする。

--- a/docs/AUTHZ.md
+++ b/docs/AUTHZ.md
@@ -191,3 +191,9 @@ v0 での認可関連 SoR:
 - LIN-632/LIN-633 の tuple写像契約を受け、channel判定の優先順（`user deny > user allow > role deny > role allow > role default > default deny`）を満たす relation/permission を固定する。
 - deny/unavailable の境界は ADR-004 を適用し、判定不能時の fail-open を禁止する。
 - LIN-863 での local/CI 実行基盤手順は `docs/runbooks/authz-spicedb-local-ci-runtime-runbook.md` を参照する。
+
+## 12. LIN-864 Tuple mapping and sync implementation baseline
+
+- Postgres `*_v2` 権限データから canonical relation 名へ変換する実装SSOTは `database/contracts/lin864_postgres_spicedb_tuple_sync_contract.md`。
+- 初期backfill、outbox差分同期、`authz.tuple.full_resync.v1` による最小再同期フックは同契約で固定する。
+- 運用手順は `docs/runbooks/authz-spicedb-tuple-sync-operations-runbook.md` を参照する。

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -209,6 +209,12 @@ The source of truth for SpiceDB namespace/relation/permission design aligned wit
 
 - `database/contracts/lin862_spicedb_namespace_relation_permission_contract.md`
 
+### 2.19 Postgres -> SpiceDB Tuple Mapping/Sync Contract (LIN-864)
+
+The source of truth for Postgres `*_v2` permission data to canonical SpiceDB tuple conversion, initial backfill contract, outbox delta-sync semantics, and full-resync operational hook is:
+
+- `database/contracts/lin864_postgres_spicedb_tuple_sync_contract.md`
+
 ## 3. ScyllaDB の現在状態
 
 基準: `database/scylla/001_lin139_messages.cql`

--- a/docs/agent_runs/LIN-860/Documentation.md
+++ b/docs/agent_runs/LIN-860/Documentation.md
@@ -2,7 +2,7 @@
 
 ## Status
 - In progress.
-- Current child issue: `LIN-863`.
+- Current child issue: `LIN-864`.
 
 ## Decisions
 - Parent/child execution order follows LIN-860 definition (`861 -> 868`).
@@ -118,4 +118,52 @@
 - UI gate (`reviewer_ui_guard` / `reviewer_ui`): unavailable -> UI changesなしで `reviewer_ui` skipped
 - PR URL: https://github.com/LinkLynx-AI/LinkLynx-AI/pull/1031
 - PR base branch: `codex/lin-860`
-- merge/auto-merge status: open（auto-merge pending）
+- merge/auto-merge status: merged (`2026-03-04T05:48:16Z`)
+
+## LIN-864 progress
+- branch: `codex/LIN-864-postgres-spicedb-tuple-sync`
+- objective: Postgres `*_v2` 権限データから canonical SpiceDB tuple への写像、initial backfill、outbox差分同期、失敗検知/再同期フックの実装
+- delivered:
+  - `rust/apps/api/src/authz/tuple_sync.rs`（新規）
+    - canonical relation tuple mapping
+    - backfill input/report 生成
+    - outbox event -> tuple mutation 変換
+    - `claim_outbox_events` / `mark_*` を使う同期サービス
+    - metrics snapshot と full resync hook (`authz.tuple.full_resync.v1`)
+  - `rust/apps/api/src/authz.rs`
+    - `tuple_sync` サブモジュール導入と再エクスポート
+  - `rust/apps/api/src/authz/runtime.rs`
+    - `AUTHZ_PROVIDER=spicedb` 時の tuple sync runtime config 検証ログ追加
+  - `rust/apps/api/src/authz/tests.rs`
+    - tuple mapping/backfill/delta sync/failure/full resync のテスト追加
+  - `database/contracts/lin864_postgres_spicedb_tuple_sync_contract.md`（新規）
+  - `docs/runbooks/authz-spicedb-tuple-sync-operations-runbook.md`（新規）
+  - `docs/AUTHZ.md` / `docs/DATABASE.md` / `docs/runbooks/README.md` / `.env.example` 更新
+
+## Validation results (LIN-864)
+- `make rust-lint`: passed
+- `make validate`: failed（`typescript` の `node_modules` 未導入により `prettier: command not found`）
+
+## Review results (LIN-864)
+- `reviewer_simple`: unavailable in current execution environment（agent type unavailable / subagent model unsupported）
+- Manual self-review fallback:
+  - tuple mapping が LIN-862 canonical relation 名に一致することを Rust テストで固定
+  - outbox差分同期の success/failure/full-resync 経路をテストで固定
+  - 同期失敗時の `mark_outbox_event_failed` と metrics 増分を確認
+  - blocking findings: none
+- `reviewer_ui_guard`: unavailable in current execution environment（agent type unavailable）
+- UI gate fallback:
+  - frontend/UI変更なし
+  - `reviewer_ui`: skipped（UI changesなし）
+
+## Per-child evidence (LIN-864)
+- issue: `LIN-864`
+- branch: `codex/LIN-864-postgres-spicedb-tuple-sync`
+- validation commands and results:
+  - `make rust-lint`: passed
+  - `make validate`: failed（environment dependency missing）
+- reviewer gate (`reviewer_simple`): unavailable -> manual self-review fallback (no blocking findings)
+- UI gate (`reviewer_ui_guard` / `reviewer_ui`): unavailable -> UI changesなしで `reviewer_ui` skipped
+- PR URL: not created yet（`gh auth status` reports invalid token on this environment）
+- PR base branch: `codex/lin-860`（planned）
+- merge/auto-merge status: pending（PR未作成）

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -7,6 +7,7 @@
 - `auth-firebase-principal-operations-runbook.md`: Firebase Auth and `uid -> principal_id` operations baseline (REST/WS error policy, logs/metrics, and outage triage).
 - `authz-noop-allow-all-spicedb-handoff-runbook.md`: Temporary `noop allow-all` exception expiry control and SpiceDB cutover/rollback handoff baseline.
 - `authz-spicedb-local-ci-runtime-runbook.md`: SpiceDB local/CI runtime baseline (env contract, docker startup, health check, and troubleshooting).
+- `authz-spicedb-tuple-sync-operations-runbook.md`: Postgres -> SpiceDB tuple mapping/backfill/outbox delta-sync baseline and full-resync operational hook.
 - `session-resume-dragonfly-operations-runbook.md`: Session/resume/TTL continuity baseline on Dragonfly, including degraded behavior and TTL rollout/rollback procedure.
 - `realtime-nats-core-subject-subscription-runbook.md`: NATS Core subject naming contract, Gateway/Fanout subscribe-unsubscribe lifecycle, reconnect baseline, and outage handling for v0 realtime delivery.
 - `scylla-node-loss-backup-runbook.md`: Scylla node-loss continuity decisions and minimum backup/restore execution baseline for v0.

--- a/docs/runbooks/authz-spicedb-tuple-sync-operations-runbook.md
+++ b/docs/runbooks/authz-spicedb-tuple-sync-operations-runbook.md
@@ -1,0 +1,122 @@
+# AuthZ SpiceDB Tuple Sync Operations Runbook
+
+- Status: Draft
+- Last updated: 2026-03-04
+- Owner scope: LIN-864 tuple mapping/backfill/delta-sync baseline
+- References:
+  - `database/contracts/lin864_postgres_spicedb_tuple_sync_contract.md`
+  - `database/contracts/lin862_spicedb_namespace_relation_permission_contract.md`
+  - `docs/adr/ADR-004-authz-fail-close-and-cache-strategy.md`
+
+## 1. Purpose and scope
+
+This runbook defines the minimum operational procedure for Postgres -> SpiceDB tuple synchronization foundation.
+
+In scope:
+- tuple mapping verification from Postgres `*_v2` permission tables
+- initial backfill procedure
+- outbox-based delta sync procedure
+- full resync trigger (`authz.tuple.full_resync.v1`)
+
+Out of scope:
+- `AUTHZ_PROVIDER=spicedb` request-time check cutover (LIN-865)
+- endpoint-level authorization rollout (LIN-866/LIN-867)
+
+## 2. Runtime config contract
+
+Tuple sync runtime config uses the following env keys:
+
+- `SPICEDB_TUPLE_SYNC_OUTBOX_CLAIM_LIMIT` (default `100`)
+- `SPICEDB_TUPLE_SYNC_OUTBOX_LEASE_SECONDS` (default `30`)
+- `SPICEDB_TUPLE_SYNC_OUTBOX_RETRY_SECONDS` (default `15`)
+
+Notes:
+- Current baseline validates and logs these values in Rust runtime.
+- Actual service wiring/execution loop is performed by follow-up integration work.
+
+## 3. Backfill procedure (foundation)
+
+Backfill source tables:
+1. `guild_roles_v2`
+2. `guild_member_roles_v2`
+3. `channel_role_permission_overrides_v2`
+4. `channel_user_permission_overrides_v2`
+
+Backfill behavior contract:
+- read with stable ordering (`ORDER BY`)
+- generate canonical tuples
+- deduplicate
+- apply as `Upsert` mutations
+
+Validation command:
+
+```bash
+make rust-lint
+```
+
+Relevant test cases:
+- `authz::tests::backfill_builder_deduplicates_tuples`
+- `authz::tests::tuple_mapping_uses_canonical_relations`
+
+## 4. Delta sync procedure (outbox)
+
+Outbox consumption contract:
+- claim: `claim_outbox_events(limit, lease_seconds)`
+- success ack: `mark_outbox_event_sent(id)`
+- failure ack: `mark_outbox_event_failed(id, retry_seconds)`
+
+Supported event types:
+- `authz.tuple.guild_role.v1`
+- `authz.tuple.guild_member_role.v1`
+- `authz.tuple.channel_role_override.v1`
+- `authz.tuple.channel_user_override.v1`
+- `authz.tuple.full_resync.v1`
+
+Operation rules:
+- `op=upsert`: `Delete(candidate tuples)` + `Upsert(desired tuples)`
+- `op=delete`: `Delete(candidate tuples)`
+
+## 5. Full resync trigger (minimum hook)
+
+When drift is detected, insert a `full_resync` event into outbox.
+
+Example payload:
+
+```sql
+INSERT INTO outbox_events (id, event_type, aggregate_id, payload)
+VALUES (
+  9000000001,
+  'authz.tuple.full_resync.v1',
+  'guild:all',
+  '{"reason":"drift_detected"}'::jsonb
+);
+```
+
+Expected behavior:
+- consumer executes one full backfill
+- success -> `mark_outbox_event_sent`
+- failure -> `mark_outbox_event_failed`
+
+## 6. Failure detection and triage
+
+Required monitoring counters:
+- `outbox_claimed_total`
+- `outbox_succeeded_total`
+- `outbox_failed_total`
+- `outbox_full_resync_total`
+- `backfill_runs_total`
+- `backfill_generated_tuples_total`
+- `tuple_mutations_applied_total`
+- `sync_apply_failure_total`
+
+Failure triage checkpoints:
+1. Verify outbox claim/ack function execution errors.
+2. Verify payload schema and event type correctness.
+3. Trigger `authz.tuple.full_resync.v1` when drift or repeated failures persist.
+
+## 7. Verification checklist
+
+1. `make rust-lint` passes.
+2. tuple mapping tests pass for role/user override canonical relations.
+3. sync service tests pass for success/failure/full-resync paths.
+4. runtime logs include tuple sync env configuration when `AUTHZ_PROVIDER=spicedb`.

--- a/rust/apps/api/src/authz.rs
+++ b/rust/apps/api/src/authz.rs
@@ -12,5 +12,8 @@ use tracing::warn;
 
 include!("authz/errors.rs");
 include!("authz/service.rs");
+#[allow(dead_code)]
+mod tuple_sync;
+pub use tuple_sync::*;
 include!("authz/runtime.rs");
 include!("authz/tests.rs");

--- a/rust/apps/api/src/authz/runtime.rs
+++ b/rust/apps/api/src/authz/runtime.rs
@@ -100,6 +100,24 @@ pub fn build_runtime_authorizer() -> Arc<dyn Authorizer> {
         "spicedb" => {
             match build_spicedb_runtime_config_from_env() {
                 Ok(config) => {
+                    match build_spicedb_tuple_sync_runtime_config_from_env() {
+                        Ok(tuple_sync_config) => {
+                            warn!(
+                                provider = "spicedb",
+                                outbox_claim_limit = tuple_sync_config.outbox_claim_limit,
+                                outbox_lease_seconds = tuple_sync_config.outbox_lease_seconds,
+                                outbox_retry_seconds = tuple_sync_config.outbox_retry_seconds,
+                                "AUTHZ_PROVIDER=spicedb tuple sync runtime config is ready"
+                            );
+                        }
+                        Err(reason) => {
+                            warn!(
+                                provider = "spicedb",
+                                reason = %reason,
+                                "AUTHZ_PROVIDER=spicedb tuple sync runtime config is invalid"
+                            );
+                        }
+                    }
                     warn!(
                         provider = "spicedb",
                         endpoint = %config.endpoint,

--- a/rust/apps/api/src/authz/tests.rs
+++ b/rust/apps/api/src/authz/tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use std::sync::OnceLock;
 
     fn env_lock() -> &'static tokio::sync::Mutex<()> {
@@ -167,5 +168,368 @@ mod tests {
             config.schema_path,
             "database/contracts/lin862_spicedb_namespace_relation_permission_contract.md"
         );
+    }
+
+    #[test]
+    fn tuple_mapping_uses_canonical_relations() {
+        let role_row = GuildRolePermissionRow {
+            guild_id: 10,
+            role_key: "member".to_owned(),
+            allow_view: true,
+            allow_post: true,
+            allow_manage: false,
+        };
+        let channel_role_row = ChannelRoleOverrideRow {
+            channel_id: 200,
+            guild_id: 10,
+            role_key: "member".to_owned(),
+            can_view: Some(false),
+            can_post: Some(true),
+        };
+        let channel_user_row = ChannelUserOverrideRow {
+            channel_id: 200,
+            guild_id: 10,
+            user_id: 3000,
+            can_view: Some(true),
+            can_post: Some(false),
+        };
+
+        let mut tuples = Vec::new();
+        tuples.extend(map_guild_role_permissions_to_tuples(&role_row));
+        tuples.extend(map_channel_role_override_to_tuples(&channel_role_row));
+        tuples.extend(map_channel_user_override_to_tuples(&channel_user_row));
+
+        let compact: std::collections::BTreeSet<String> =
+            tuples.iter().map(SpiceDbTuple::compact).collect();
+
+        assert!(compact.contains("guild:10#viewer@role:10/member#member"));
+        assert!(compact.contains("guild:10#poster@role:10/member#member"));
+        assert!(compact.contains("channel:200#view_deny_role@role:10/member#member"));
+        assert!(compact.contains("channel:200#poster_role@role:10/member#member"));
+        assert!(compact.contains("channel:200#viewer_user@user:3000"));
+        assert!(compact.contains("channel:200#post_deny_user@user:3000"));
+    }
+
+    #[test]
+    fn backfill_builder_deduplicates_tuples() {
+        let input = TupleBackfillInput {
+            guild_roles: vec![GuildRolePermissionRow {
+                guild_id: 99,
+                role_key: "admin".to_owned(),
+                allow_view: true,
+                allow_post: true,
+                allow_manage: true,
+            }],
+            guild_member_roles: vec![
+                GuildMemberRoleRow {
+                    guild_id: 99,
+                    user_id: 7,
+                    role_key: "admin".to_owned(),
+                },
+                GuildMemberRoleRow {
+                    guild_id: 99,
+                    user_id: 7,
+                    role_key: "admin".to_owned(),
+                },
+            ],
+            channel_role_overrides: vec![],
+            channel_user_overrides: vec![],
+        };
+
+        let tuples = build_backfill_tuples(&input);
+        let compact: std::collections::BTreeSet<String> =
+            tuples.iter().map(SpiceDbTuple::compact).collect();
+        assert_eq!(tuples.len(), compact.len());
+        assert!(compact.contains("role:99/admin#member@user:7"));
+        assert!(compact.contains("guild:99#manager@role:99/admin#member"));
+        assert!(compact.contains("guild:99#viewer@role:99/admin#member"));
+        assert!(compact.contains("guild:99#poster@role:99/admin#member"));
+    }
+
+    #[test]
+    fn tuple_sync_command_parses_role_event_and_builds_replace_mutations() {
+        let event = TupleSyncOutboxEvent {
+            id: 101,
+            event_type: AUTHZ_TUPLE_EVENT_GUILD_ROLE.to_owned(),
+            aggregate_id: "guild:44/role:member".to_owned(),
+            payload: json!({
+                "op": "upsert",
+                "guild_id": 44,
+                "role_key": "member",
+                "allow_view": true,
+                "allow_post": false,
+                "allow_manage": false
+            }),
+        };
+
+        let command = build_tuple_sync_command(&event).unwrap();
+        let TupleSyncCommand::Mutations(mutations) = command else {
+            panic!("unexpected sync command");
+        };
+
+        let compact: std::collections::BTreeSet<String> = mutations
+            .iter()
+            .map(|mutation| match mutation {
+                SpiceDbTupleMutation::Delete(tuple) => format!("delete:{}", tuple.compact()),
+                SpiceDbTupleMutation::Upsert(tuple) => format!("upsert:{}", tuple.compact()),
+            })
+            .collect();
+
+        assert!(compact.contains("delete:guild:44#manager@role:44/member#member"));
+        assert!(compact.contains("delete:guild:44#viewer@role:44/member#member"));
+        assert!(compact.contains("delete:guild:44#poster@role:44/member#member"));
+        assert!(compact.contains("upsert:guild:44#viewer@role:44/member#member"));
+        assert_eq!(compact.len(), 4);
+    }
+
+    #[test]
+    fn tuple_drift_report_and_resync_mutation_are_consistent() {
+        let expected = vec![
+            SpiceDbTuple::new("guild:1", "viewer", "role:1/member#member"),
+            SpiceDbTuple::new("guild:1", "poster", "role:1/member#member"),
+        ];
+        let observed = vec![
+            SpiceDbTuple::new("guild:1", "viewer", "role:1/member#member"),
+            SpiceDbTuple::new("guild:1", "manager", "role:1/member#member"),
+        ];
+
+        let report = detect_tuple_drift(&expected, &observed);
+        assert!(report.has_drift());
+        assert_eq!(report.missing_tuples.len(), 1);
+        assert_eq!(report.unexpected_tuples.len(), 1);
+
+        let mutations = build_resync_mutations(&report);
+        assert_eq!(mutations.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn tuple_sync_service_processes_outbox_successfully() {
+        let outbox_store = Arc::new(InMemoryTupleSyncOutboxStore::new(vec![TupleSyncOutboxEvent {
+            id: 1,
+            event_type: AUTHZ_TUPLE_EVENT_GUILD_MEMBER_ROLE.to_owned(),
+            aggregate_id: "guild:10/user:20/role:member".to_owned(),
+            payload: json!({
+                "op": "upsert",
+                "guild_id": 10,
+                "user_id": 20,
+                "role_key": "member"
+            }),
+        }]));
+        let sink = Arc::new(InMemoryTupleMutationSink::default());
+        let service = AuthzTupleSyncService::new(
+            Arc::clone(&outbox_store) as Arc<dyn TupleSyncOutboxStore>,
+            Arc::new(StaticTupleBackfillSource::default()),
+            Arc::clone(&sink) as Arc<dyn TupleMutationSink>,
+            Arc::new(AuthzTupleSyncMetrics::default()),
+            SpiceDbTupleSyncRuntimeConfig::default(),
+        );
+
+        let report = service.run_sync_once().await.unwrap();
+        assert_eq!(report.claimed_events, 1);
+        assert_eq!(report.succeeded_events, 1);
+        assert_eq!(report.failed_events, 0);
+        assert_eq!(report.applied_mutations, 2);
+        assert_eq!(outbox_store.sent_ids().await, vec![1]);
+        assert!(outbox_store.failed_entries().await.is_empty());
+
+        let tuples = sink.snapshot().await;
+        let compact: std::collections::BTreeSet<String> =
+            tuples.iter().map(SpiceDbTuple::compact).collect();
+        assert!(compact.contains("role:10/member#member@user:20"));
+
+        let metrics = service.metrics().snapshot();
+        assert_eq!(metrics.outbox_claimed_total, 1);
+        assert_eq!(metrics.outbox_succeeded_total, 1);
+        assert_eq!(metrics.outbox_failed_total, 0);
+        assert_eq!(metrics.tuple_mutations_applied_total, 2);
+    }
+
+    #[tokio::test]
+    async fn tuple_sync_service_marks_failed_when_sink_errors() {
+        let outbox_store = Arc::new(InMemoryTupleSyncOutboxStore::new(vec![TupleSyncOutboxEvent {
+            id: 2,
+            event_type: AUTHZ_TUPLE_EVENT_GUILD_MEMBER_ROLE.to_owned(),
+            aggregate_id: "guild:10/user:20/role:member".to_owned(),
+            payload: json!({
+                "op": "upsert",
+                "guild_id": 10,
+                "user_id": 20,
+                "role_key": "member"
+            }),
+        }]));
+        let sink = Arc::new(InMemoryTupleMutationSink::default());
+        sink.set_failure_reason(Some("sink_down".to_owned())).await;
+
+        let service = AuthzTupleSyncService::new(
+            Arc::clone(&outbox_store) as Arc<dyn TupleSyncOutboxStore>,
+            Arc::new(StaticTupleBackfillSource::default()),
+            Arc::clone(&sink) as Arc<dyn TupleMutationSink>,
+            Arc::new(AuthzTupleSyncMetrics::default()),
+            SpiceDbTupleSyncRuntimeConfig::default(),
+        );
+
+        let report = service.run_sync_once().await.unwrap();
+        assert_eq!(report.claimed_events, 1);
+        assert_eq!(report.succeeded_events, 0);
+        assert_eq!(report.failed_events, 1);
+        assert!(outbox_store.sent_ids().await.is_empty());
+        assert_eq!(
+            outbox_store.failed_entries().await,
+            vec![(2, SpiceDbTupleSyncRuntimeConfig::default().outbox_retry_seconds)]
+        );
+
+        let metrics = service.metrics().snapshot();
+        assert_eq!(metrics.outbox_failed_total, 1);
+        assert_eq!(metrics.sync_apply_failure_total, 1);
+    }
+
+    #[tokio::test]
+    async fn tuple_sync_service_executes_full_resync_event() {
+        let outbox_store = Arc::new(InMemoryTupleSyncOutboxStore::new(vec![TupleSyncOutboxEvent {
+            id: 3,
+            event_type: AUTHZ_TUPLE_EVENT_FULL_RESYNC.to_owned(),
+            aggregate_id: "guild:all".to_owned(),
+            payload: json!({
+                "reason": "drift_detected"
+            }),
+        }]));
+        let sink = Arc::new(InMemoryTupleMutationSink::default());
+        let backfill_source = Arc::new(StaticTupleBackfillSource {
+            guild_roles: vec![GuildRolePermissionRow {
+                guild_id: 1,
+                role_key: "member".to_owned(),
+                allow_view: true,
+                allow_post: false,
+                allow_manage: false,
+            }],
+            guild_member_roles: vec![GuildMemberRoleRow {
+                guild_id: 1,
+                user_id: 88,
+                role_key: "member".to_owned(),
+            }],
+            channel_role_overrides: Vec::new(),
+            channel_user_overrides: Vec::new(),
+        });
+
+        let service = AuthzTupleSyncService::new(
+            Arc::clone(&outbox_store) as Arc<dyn TupleSyncOutboxStore>,
+            backfill_source as Arc<dyn TupleBackfillSource>,
+            Arc::clone(&sink) as Arc<dyn TupleMutationSink>,
+            Arc::new(AuthzTupleSyncMetrics::default()),
+            SpiceDbTupleSyncRuntimeConfig::default(),
+        );
+
+        let report = service.run_sync_once().await.unwrap();
+        assert_eq!(report.claimed_events, 1);
+        assert_eq!(report.succeeded_events, 1);
+        assert_eq!(report.failed_events, 0);
+        assert_eq!(report.full_resync_events, 1);
+        assert_eq!(outbox_store.sent_ids().await, vec![3]);
+
+        let tuples = sink.snapshot().await;
+        let compact: std::collections::BTreeSet<String> =
+            tuples.iter().map(SpiceDbTuple::compact).collect();
+        assert!(compact.contains("role:1/member#member@user:88"));
+        assert!(compact.contains("guild:1#viewer@role:1/member#member"));
+
+        let metrics = service.metrics().snapshot();
+        assert_eq!(metrics.outbox_full_resync_total, 1);
+        assert_eq!(metrics.backfill_runs_total, 1);
+        assert_eq!(metrics.backfill_generated_tuples_total, 2);
+    }
+
+    #[tokio::test]
+    async fn spicedb_tuple_sync_runtime_config_parses_env_values() {
+        let _guard = env_lock().lock().await;
+        let mut scoped = ScopedEnv::new();
+        scoped.set("SPICEDB_TUPLE_SYNC_OUTBOX_CLAIM_LIMIT", "250");
+        scoped.set("SPICEDB_TUPLE_SYNC_OUTBOX_LEASE_SECONDS", "45");
+        scoped.set("SPICEDB_TUPLE_SYNC_OUTBOX_RETRY_SECONDS", "20");
+
+        let config = build_spicedb_tuple_sync_runtime_config_from_env().unwrap();
+        assert_eq!(config.outbox_claim_limit, 250);
+        assert_eq!(config.outbox_lease_seconds, 45);
+        assert_eq!(config.outbox_retry_seconds, 20);
+    }
+
+    #[derive(Default)]
+    struct StaticTupleBackfillSource {
+        guild_roles: Vec<GuildRolePermissionRow>,
+        guild_member_roles: Vec<GuildMemberRoleRow>,
+        channel_role_overrides: Vec<ChannelRoleOverrideRow>,
+        channel_user_overrides: Vec<ChannelUserOverrideRow>,
+    }
+
+    #[async_trait]
+    impl TupleBackfillSource for StaticTupleBackfillSource {
+        async fn list_guild_roles(&self) -> Result<Vec<GuildRolePermissionRow>, String> {
+            Ok(self.guild_roles.clone())
+        }
+
+        async fn list_guild_member_roles(&self) -> Result<Vec<GuildMemberRoleRow>, String> {
+            Ok(self.guild_member_roles.clone())
+        }
+
+        async fn list_channel_role_overrides(&self) -> Result<Vec<ChannelRoleOverrideRow>, String> {
+            Ok(self.channel_role_overrides.clone())
+        }
+
+        async fn list_channel_user_overrides(&self) -> Result<Vec<ChannelUserOverrideRow>, String> {
+            Ok(self.channel_user_overrides.clone())
+        }
+    }
+
+    struct InMemoryTupleSyncOutboxStore {
+        events: tokio::sync::Mutex<Vec<TupleSyncOutboxEvent>>,
+        sent_ids: tokio::sync::Mutex<Vec<i64>>,
+        failed_entries: tokio::sync::Mutex<Vec<(i64, u32)>>,
+    }
+
+    impl InMemoryTupleSyncOutboxStore {
+        fn new(events: Vec<TupleSyncOutboxEvent>) -> Self {
+            Self {
+                events: tokio::sync::Mutex::new(events),
+                sent_ids: tokio::sync::Mutex::new(Vec::new()),
+                failed_entries: tokio::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        async fn sent_ids(&self) -> Vec<i64> {
+            self.sent_ids.lock().await.clone()
+        }
+
+        async fn failed_entries(&self) -> Vec<(i64, u32)> {
+            self.failed_entries.lock().await.clone()
+        }
+    }
+
+    #[async_trait]
+    impl TupleSyncOutboxStore for InMemoryTupleSyncOutboxStore {
+        async fn claim_outbox_events(
+            &self,
+            limit: u32,
+            _lease_seconds: u32,
+        ) -> Result<Vec<TupleSyncOutboxEvent>, String> {
+            let mut events = self.events.lock().await;
+            let take = usize::min(events.len(), limit as usize);
+            Ok(events.drain(..take).collect())
+        }
+
+        async fn mark_outbox_event_sent(&self, event_id: i64) -> Result<(), String> {
+            self.sent_ids.lock().await.push(event_id);
+            Ok(())
+        }
+
+        async fn mark_outbox_event_failed(
+            &self,
+            event_id: i64,
+            retry_seconds: u32,
+        ) -> Result<(), String> {
+            self.failed_entries
+                .lock()
+                .await
+                .push((event_id, retry_seconds));
+            Ok(())
+        }
     }
 }

--- a/rust/apps/api/src/authz/tuple_sync.rs
+++ b/rust/apps/api/src/authz/tuple_sync.rs
@@ -1,0 +1,1354 @@
+use std::{
+    collections::BTreeSet,
+    env,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::RwLock;
+use tokio_postgres::Client;
+
+const DEFAULT_TUPLE_SYNC_OUTBOX_CLAIM_LIMIT: u32 = 100;
+const DEFAULT_TUPLE_SYNC_OUTBOX_LEASE_SECONDS: u32 = 30;
+const DEFAULT_TUPLE_SYNC_OUTBOX_RETRY_SECONDS: u32 = 15;
+
+const GUILD_MANAGER_RELATION: &str = "manager";
+const GUILD_VIEWER_RELATION: &str = "viewer";
+const GUILD_POSTER_RELATION: &str = "poster";
+
+const ROLE_MEMBER_RELATION: &str = "member";
+
+const CHANNEL_VIEWER_ROLE_RELATION: &str = "viewer_role";
+const CHANNEL_VIEW_DENY_ROLE_RELATION: &str = "view_deny_role";
+const CHANNEL_POSTER_ROLE_RELATION: &str = "poster_role";
+const CHANNEL_POST_DENY_ROLE_RELATION: &str = "post_deny_role";
+
+const CHANNEL_VIEWER_USER_RELATION: &str = "viewer_user";
+const CHANNEL_VIEW_DENY_USER_RELATION: &str = "view_deny_user";
+const CHANNEL_POSTER_USER_RELATION: &str = "poster_user";
+const CHANNEL_POST_DENY_USER_RELATION: &str = "post_deny_user";
+
+pub const AUTHZ_TUPLE_EVENT_GUILD_ROLE: &str = "authz.tuple.guild_role.v1";
+pub const AUTHZ_TUPLE_EVENT_GUILD_MEMBER_ROLE: &str = "authz.tuple.guild_member_role.v1";
+pub const AUTHZ_TUPLE_EVENT_CHANNEL_ROLE_OVERRIDE: &str = "authz.tuple.channel_role_override.v1";
+pub const AUTHZ_TUPLE_EVENT_CHANNEL_USER_OVERRIDE: &str = "authz.tuple.channel_user_override.v1";
+pub const AUTHZ_TUPLE_EVENT_FULL_RESYNC: &str = "authz.tuple.full_resync.v1";
+
+/// SpiceDB tuple同期の実行時設定を表現する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpiceDbTupleSyncRuntimeConfig {
+    pub outbox_claim_limit: u32,
+    pub outbox_lease_seconds: u32,
+    pub outbox_retry_seconds: u32,
+}
+
+impl Default for SpiceDbTupleSyncRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            outbox_claim_limit: DEFAULT_TUPLE_SYNC_OUTBOX_CLAIM_LIMIT,
+            outbox_lease_seconds: DEFAULT_TUPLE_SYNC_OUTBOX_LEASE_SECONDS,
+            outbox_retry_seconds: DEFAULT_TUPLE_SYNC_OUTBOX_RETRY_SECONDS,
+        }
+    }
+}
+
+/// 実行時環境変数からtuple同期設定を構築する。
+/// @param なし
+/// @returns tuple同期設定
+/// @throws String 設定値が不正な場合
+pub fn build_spicedb_tuple_sync_runtime_config_from_env(
+) -> Result<SpiceDbTupleSyncRuntimeConfig, String> {
+    Ok(SpiceDbTupleSyncRuntimeConfig {
+        outbox_claim_limit: parse_optional_u32_env(
+            "SPICEDB_TUPLE_SYNC_OUTBOX_CLAIM_LIMIT",
+            DEFAULT_TUPLE_SYNC_OUTBOX_CLAIM_LIMIT,
+        )?,
+        outbox_lease_seconds: parse_optional_u32_env(
+            "SPICEDB_TUPLE_SYNC_OUTBOX_LEASE_SECONDS",
+            DEFAULT_TUPLE_SYNC_OUTBOX_LEASE_SECONDS,
+        )?,
+        outbox_retry_seconds: parse_optional_u32_env(
+            "SPICEDB_TUPLE_SYNC_OUTBOX_RETRY_SECONDS",
+            DEFAULT_TUPLE_SYNC_OUTBOX_RETRY_SECONDS,
+        )?,
+    })
+}
+
+/// SpiceDBのobject#relation@subjectを表現する。
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct SpiceDbTuple {
+    pub object: String,
+    pub relation: String,
+    pub subject: String,
+}
+
+impl SpiceDbTuple {
+    /// tupleを生成する。
+    /// @param object リソースオブジェクト
+    /// @param relation リレーション名
+    /// @param subject サブジェクト
+    /// @returns tuple
+    /// @throws なし
+    pub fn new(
+        object: impl Into<String>,
+        relation: impl Into<String>,
+        subject: impl Into<String>,
+    ) -> Self {
+        Self {
+            object: object.into(),
+            relation: relation.into(),
+            subject: subject.into(),
+        }
+    }
+
+    /// tupleを compact 表記へ変換する。
+    /// @param なし
+    /// @returns `object#relation@subject` 形式文字列
+    /// @throws なし
+    pub fn compact(&self) -> String {
+        format!("{}#{}@{}", self.object, self.relation, self.subject)
+    }
+}
+
+/// guild_roles_v2 由来の権限行を表現する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuildRolePermissionRow {
+    pub guild_id: i64,
+    pub role_key: String,
+    pub allow_view: bool,
+    pub allow_post: bool,
+    pub allow_manage: bool,
+}
+
+/// guild_member_roles_v2 由来の割当行を表現する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuildMemberRoleRow {
+    pub guild_id: i64,
+    pub user_id: i64,
+    pub role_key: String,
+}
+
+/// channel_role_permission_overrides_v2 由来の行を表現する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelRoleOverrideRow {
+    pub channel_id: i64,
+    pub guild_id: i64,
+    pub role_key: String,
+    pub can_view: Option<bool>,
+    pub can_post: Option<bool>,
+}
+
+/// channel_user_permission_overrides_v2 由来の行を表現する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelUserOverrideRow {
+    pub channel_id: i64,
+    pub guild_id: i64,
+    pub user_id: i64,
+    pub can_view: Option<bool>,
+    pub can_post: Option<bool>,
+}
+
+/// backfillに必要なソースデータ集合を表現する。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TupleBackfillInput {
+    pub guild_roles: Vec<GuildRolePermissionRow>,
+    pub guild_member_roles: Vec<GuildMemberRoleRow>,
+    pub channel_role_overrides: Vec<ChannelRoleOverrideRow>,
+    pub channel_user_overrides: Vec<ChannelUserOverrideRow>,
+}
+
+/// backfill実行結果を表現する。
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct TupleBackfillReport {
+    pub guild_role_rows: u64,
+    pub guild_member_role_rows: u64,
+    pub channel_role_override_rows: u64,
+    pub channel_user_override_rows: u64,
+    pub generated_tuple_count: u64,
+    pub applied_mutation_count: u64,
+}
+
+/// tuple差分レポートを表現する。
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct TupleDriftReport {
+    pub missing_tuples: Vec<SpiceDbTuple>,
+    pub unexpected_tuples: Vec<SpiceDbTuple>,
+}
+
+impl TupleDriftReport {
+    /// 差分が存在するかを判定する。
+    /// @param なし
+    /// @returns 差分有無
+    /// @throws なし
+    pub fn has_drift(&self) -> bool {
+        !self.missing_tuples.is_empty() || !self.unexpected_tuples.is_empty()
+    }
+}
+
+/// tuple同期の更新操作を表現する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpiceDbTupleMutation {
+    Upsert(SpiceDbTuple),
+    Delete(SpiceDbTuple),
+}
+
+/// outboxイベントを表現する。
+#[derive(Debug, Clone, PartialEq)]
+pub struct TupleSyncOutboxEvent {
+    pub id: i64,
+    pub event_type: String,
+    pub aggregate_id: String,
+    pub payload: Value,
+}
+
+/// outboxイベントから解釈した同期コマンドを表現する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TupleSyncCommand {
+    Mutations(Vec<SpiceDbTupleMutation>),
+    FullResync { reason: Option<String> },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct TupleSyncRunReport {
+    pub claimed_events: u64,
+    pub succeeded_events: u64,
+    pub failed_events: u64,
+    pub applied_mutations: u64,
+    pub full_resync_events: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum TupleSyncOperation {
+    Upsert,
+    Delete,
+}
+
+#[derive(Debug, Deserialize)]
+struct GuildRoleOutboxPayload {
+    op: TupleSyncOperation,
+    guild_id: i64,
+    role_key: String,
+    allow_view: Option<bool>,
+    allow_post: Option<bool>,
+    allow_manage: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GuildMemberRoleOutboxPayload {
+    op: TupleSyncOperation,
+    guild_id: i64,
+    user_id: i64,
+    role_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChannelRoleOverrideOutboxPayload {
+    op: TupleSyncOperation,
+    channel_id: i64,
+    guild_id: i64,
+    role_key: String,
+    can_view: Option<bool>,
+    can_post: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChannelUserOverrideOutboxPayload {
+    op: TupleSyncOperation,
+    channel_id: i64,
+    guild_id: i64,
+    user_id: i64,
+    can_view: Option<bool>,
+    can_post: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct FullResyncOutboxPayload {
+    reason: Option<String>,
+}
+
+/// guild_member_roles_v2 の1行を tuple へ写像する。
+/// @param row guild member role 行
+/// @returns `role:{guild}/{role_key}#member@user:{user}` tuple
+/// @throws なし
+pub fn map_guild_member_role_to_tuple(row: &GuildMemberRoleRow) -> SpiceDbTuple {
+    SpiceDbTuple::new(
+        role_object(row.guild_id, &row.role_key),
+        ROLE_MEMBER_RELATION,
+        user_subject(row.user_id),
+    )
+}
+
+/// guild_roles_v2 の1行を tuple 群へ写像する。
+/// @param row guild role 行
+/// @returns guild role baseline tuple 群
+/// @throws なし
+pub fn map_guild_role_permissions_to_tuples(row: &GuildRolePermissionRow) -> Vec<SpiceDbTuple> {
+    let object = guild_object(row.guild_id);
+    let role_subject = role_member_subject(row.guild_id, &row.role_key);
+    let mut tuples = Vec::new();
+
+    if row.allow_manage {
+        tuples.push(SpiceDbTuple::new(
+            object.clone(),
+            GUILD_MANAGER_RELATION,
+            role_subject.clone(),
+        ));
+    }
+    if row.allow_view {
+        tuples.push(SpiceDbTuple::new(
+            object.clone(),
+            GUILD_VIEWER_RELATION,
+            role_subject.clone(),
+        ));
+    }
+    if row.allow_post {
+        tuples.push(SpiceDbTuple::new(
+            object,
+            GUILD_POSTER_RELATION,
+            role_subject,
+        ));
+    }
+
+    tuples
+}
+
+/// channel_role_permission_overrides_v2 の1行を tuple 群へ写像する。
+/// @param row channel role override 行
+/// @returns channel role override tuple 群
+/// @throws なし
+pub fn map_channel_role_override_to_tuples(row: &ChannelRoleOverrideRow) -> Vec<SpiceDbTuple> {
+    let object = channel_object(row.channel_id);
+    let role_subject = role_member_subject(row.guild_id, &row.role_key);
+    let mut tuples = Vec::new();
+
+    match row.can_view {
+        Some(true) => tuples.push(SpiceDbTuple::new(
+            object.clone(),
+            CHANNEL_VIEWER_ROLE_RELATION,
+            role_subject.clone(),
+        )),
+        Some(false) => tuples.push(SpiceDbTuple::new(
+            object.clone(),
+            CHANNEL_VIEW_DENY_ROLE_RELATION,
+            role_subject.clone(),
+        )),
+        None => {}
+    }
+
+    match row.can_post {
+        Some(true) => tuples.push(SpiceDbTuple::new(
+            object,
+            CHANNEL_POSTER_ROLE_RELATION,
+            role_subject,
+        )),
+        Some(false) => tuples.push(SpiceDbTuple::new(
+            channel_object(row.channel_id),
+            CHANNEL_POST_DENY_ROLE_RELATION,
+            role_member_subject(row.guild_id, &row.role_key),
+        )),
+        None => {}
+    }
+
+    tuples
+}
+
+/// channel_user_permission_overrides_v2 の1行を tuple 群へ写像する。
+/// @param row channel user override 行
+/// @returns channel user override tuple 群
+/// @throws なし
+pub fn map_channel_user_override_to_tuples(row: &ChannelUserOverrideRow) -> Vec<SpiceDbTuple> {
+    let object = channel_object(row.channel_id);
+    let subject = user_subject(row.user_id);
+    let mut tuples = Vec::new();
+
+    match row.can_view {
+        Some(true) => tuples.push(SpiceDbTuple::new(
+            object.clone(),
+            CHANNEL_VIEWER_USER_RELATION,
+            subject.clone(),
+        )),
+        Some(false) => tuples.push(SpiceDbTuple::new(
+            object.clone(),
+            CHANNEL_VIEW_DENY_USER_RELATION,
+            subject.clone(),
+        )),
+        None => {}
+    }
+
+    match row.can_post {
+        Some(true) => tuples.push(SpiceDbTuple::new(
+            object,
+            CHANNEL_POSTER_USER_RELATION,
+            subject,
+        )),
+        Some(false) => tuples.push(SpiceDbTuple::new(
+            channel_object(row.channel_id),
+            CHANNEL_POST_DENY_USER_RELATION,
+            user_subject(row.user_id),
+        )),
+        None => {}
+    }
+
+    tuples
+}
+
+/// backfill入力から最終tuple集合を生成する。
+/// @param input backfill入力
+/// @returns 重複除去済みtuple一覧
+/// @throws なし
+pub fn build_backfill_tuples(input: &TupleBackfillInput) -> Vec<SpiceDbTuple> {
+    let mut tuples = BTreeSet::new();
+
+    for row in &input.guild_member_roles {
+        tuples.insert(map_guild_member_role_to_tuple(row));
+    }
+
+    for row in &input.guild_roles {
+        tuples.extend(map_guild_role_permissions_to_tuples(row));
+    }
+
+    for row in &input.channel_role_overrides {
+        tuples.extend(map_channel_role_override_to_tuples(row));
+    }
+
+    for row in &input.channel_user_overrides {
+        tuples.extend(map_channel_user_override_to_tuples(row));
+    }
+
+    tuples.into_iter().collect()
+}
+
+/// 期待tuple集合と観測tuple集合の差分を検知する。
+/// @param expected 期待tuple集合
+/// @param observed 観測tuple集合
+/// @returns 差分レポート
+/// @throws なし
+pub fn detect_tuple_drift(
+    expected: &[SpiceDbTuple],
+    observed: &[SpiceDbTuple],
+) -> TupleDriftReport {
+    let expected_set: BTreeSet<SpiceDbTuple> = expected.iter().cloned().collect();
+    let observed_set: BTreeSet<SpiceDbTuple> = observed.iter().cloned().collect();
+
+    let missing_tuples = expected_set.difference(&observed_set).cloned().collect();
+    let unexpected_tuples = observed_set.difference(&expected_set).cloned().collect();
+
+    TupleDriftReport {
+        missing_tuples,
+        unexpected_tuples,
+    }
+}
+
+/// 差分レポートから再同期用 mutation を生成する。
+/// @param report 差分レポート
+/// @returns 再同期mutation一覧
+/// @throws なし
+pub fn build_resync_mutations(report: &TupleDriftReport) -> Vec<SpiceDbTupleMutation> {
+    let mut mutations = Vec::new();
+
+    for tuple in &report.unexpected_tuples {
+        mutations.push(SpiceDbTupleMutation::Delete(tuple.clone()));
+    }
+
+    for tuple in &report.missing_tuples {
+        mutations.push(SpiceDbTupleMutation::Upsert(tuple.clone()));
+    }
+
+    mutations
+}
+
+/// outboxイベントから tuple 同期コマンドへ変換する。
+/// @param event outboxイベント
+/// @returns 同期コマンド
+/// @throws String 不正event type/payload時
+pub fn build_tuple_sync_command(event: &TupleSyncOutboxEvent) -> Result<TupleSyncCommand, String> {
+    match event.event_type.as_str() {
+        AUTHZ_TUPLE_EVENT_GUILD_ROLE => {
+            let payload: GuildRoleOutboxPayload = parse_json_payload(event)?;
+            Ok(TupleSyncCommand::Mutations(build_guild_role_mutations(
+                payload,
+            )?))
+        }
+        AUTHZ_TUPLE_EVENT_GUILD_MEMBER_ROLE => {
+            let payload: GuildMemberRoleOutboxPayload = parse_json_payload(event)?;
+            Ok(TupleSyncCommand::Mutations(
+                build_guild_member_role_mutations(payload),
+            ))
+        }
+        AUTHZ_TUPLE_EVENT_CHANNEL_ROLE_OVERRIDE => {
+            let payload: ChannelRoleOverrideOutboxPayload = parse_json_payload(event)?;
+            Ok(TupleSyncCommand::Mutations(
+                build_channel_role_override_mutations(payload),
+            ))
+        }
+        AUTHZ_TUPLE_EVENT_CHANNEL_USER_OVERRIDE => {
+            let payload: ChannelUserOverrideOutboxPayload = parse_json_payload(event)?;
+            Ok(TupleSyncCommand::Mutations(
+                build_channel_user_override_mutations(payload),
+            ))
+        }
+        AUTHZ_TUPLE_EVENT_FULL_RESYNC => {
+            let payload: FullResyncOutboxPayload = parse_optional_json_payload(event)?;
+            Ok(TupleSyncCommand::FullResync {
+                reason: payload.reason,
+            })
+        }
+        _ => Err(format!(
+            "unsupported tuple sync event_type: {}",
+            event.event_type
+        )),
+    }
+}
+
+#[async_trait]
+pub trait TupleBackfillSource: Send + Sync {
+    async fn list_guild_roles(&self) -> Result<Vec<GuildRolePermissionRow>, String>;
+    async fn list_guild_member_roles(&self) -> Result<Vec<GuildMemberRoleRow>, String>;
+    async fn list_channel_role_overrides(&self) -> Result<Vec<ChannelRoleOverrideRow>, String>;
+    async fn list_channel_user_overrides(&self) -> Result<Vec<ChannelUserOverrideRow>, String>;
+}
+
+#[async_trait]
+pub trait TupleSyncOutboxStore: Send + Sync {
+    async fn claim_outbox_events(
+        &self,
+        limit: u32,
+        lease_seconds: u32,
+    ) -> Result<Vec<TupleSyncOutboxEvent>, String>;
+    async fn mark_outbox_event_sent(&self, event_id: i64) -> Result<(), String>;
+    async fn mark_outbox_event_failed(
+        &self,
+        event_id: i64,
+        retry_seconds: u32,
+    ) -> Result<(), String>;
+}
+
+#[async_trait]
+pub trait TupleMutationSink: Send + Sync {
+    async fn apply_mutations(&self, mutations: Vec<SpiceDbTupleMutation>) -> Result<(), String>;
+}
+
+/// Postgresからbackfillソースを読み取る実装を表現する。
+#[derive(Clone)]
+pub struct PostgresTupleBackfillSource {
+    client: Arc<Client>,
+}
+
+impl PostgresTupleBackfillSource {
+    /// Postgres backfill ソースを生成する。
+    /// @param client Postgresクライアント
+    /// @returns backfillソース
+    /// @throws なし
+    pub fn new(client: Arc<Client>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl TupleBackfillSource for PostgresTupleBackfillSource {
+    async fn list_guild_roles(&self) -> Result<Vec<GuildRolePermissionRow>, String> {
+        let rows = self
+            .client
+            .query(
+                "SELECT guild_id, role_key, allow_view, allow_post, allow_manage
+                 FROM guild_roles_v2
+                 ORDER BY guild_id, role_key",
+                &[],
+            )
+            .await
+            .map_err(|error| format!("tuple_backfill_list_guild_roles_failed:{error}"))?;
+
+        Ok(rows
+            .iter()
+            .map(|row| GuildRolePermissionRow {
+                guild_id: row.get::<usize, i64>(0),
+                role_key: row.get::<usize, String>(1),
+                allow_view: row.get::<usize, bool>(2),
+                allow_post: row.get::<usize, bool>(3),
+                allow_manage: row.get::<usize, bool>(4),
+            })
+            .collect())
+    }
+
+    async fn list_guild_member_roles(&self) -> Result<Vec<GuildMemberRoleRow>, String> {
+        let rows = self
+            .client
+            .query(
+                "SELECT guild_id, user_id, role_key
+                 FROM guild_member_roles_v2
+                 ORDER BY guild_id, user_id, role_key",
+                &[],
+            )
+            .await
+            .map_err(|error| format!("tuple_backfill_list_guild_member_roles_failed:{error}"))?;
+
+        Ok(rows
+            .iter()
+            .map(|row| GuildMemberRoleRow {
+                guild_id: row.get::<usize, i64>(0),
+                user_id: row.get::<usize, i64>(1),
+                role_key: row.get::<usize, String>(2),
+            })
+            .collect())
+    }
+
+    async fn list_channel_role_overrides(&self) -> Result<Vec<ChannelRoleOverrideRow>, String> {
+        let rows = self
+            .client
+            .query(
+                "SELECT channel_id, guild_id, role_key, can_view, can_post
+                 FROM channel_role_permission_overrides_v2
+                 ORDER BY channel_id, role_key",
+                &[],
+            )
+            .await
+            .map_err(|error| {
+                format!("tuple_backfill_list_channel_role_overrides_failed:{error}")
+            })?;
+
+        Ok(rows
+            .iter()
+            .map(|row| ChannelRoleOverrideRow {
+                channel_id: row.get::<usize, i64>(0),
+                guild_id: row.get::<usize, i64>(1),
+                role_key: row.get::<usize, String>(2),
+                can_view: row.get::<usize, Option<bool>>(3),
+                can_post: row.get::<usize, Option<bool>>(4),
+            })
+            .collect())
+    }
+
+    async fn list_channel_user_overrides(&self) -> Result<Vec<ChannelUserOverrideRow>, String> {
+        let rows = self
+            .client
+            .query(
+                "SELECT channel_id, guild_id, user_id, can_view, can_post
+                 FROM channel_user_permission_overrides_v2
+                 ORDER BY channel_id, user_id",
+                &[],
+            )
+            .await
+            .map_err(|error| {
+                format!("tuple_backfill_list_channel_user_overrides_failed:{error}")
+            })?;
+
+        Ok(rows
+            .iter()
+            .map(|row| ChannelUserOverrideRow {
+                channel_id: row.get::<usize, i64>(0),
+                guild_id: row.get::<usize, i64>(1),
+                user_id: row.get::<usize, i64>(2),
+                can_view: row.get::<usize, Option<bool>>(3),
+                can_post: row.get::<usize, Option<bool>>(4),
+            })
+            .collect())
+    }
+}
+
+/// Postgres outboxを用いたtuple同期ストア実装を表現する。
+#[derive(Clone)]
+pub struct PostgresTupleSyncOutboxStore {
+    client: Arc<Client>,
+}
+
+impl PostgresTupleSyncOutboxStore {
+    /// Postgres outbox ストアを生成する。
+    /// @param client Postgresクライアント
+    /// @returns outboxストア
+    /// @throws なし
+    pub fn new(client: Arc<Client>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl TupleSyncOutboxStore for PostgresTupleSyncOutboxStore {
+    async fn claim_outbox_events(
+        &self,
+        limit: u32,
+        lease_seconds: u32,
+    ) -> Result<Vec<TupleSyncOutboxEvent>, String> {
+        let limit_i32 = i32::try_from(limit)
+            .map_err(|_| format!("tuple_sync_claim_limit_out_of_range:{limit}"))?;
+        let lease_i32 = i32::try_from(lease_seconds)
+            .map_err(|_| format!("tuple_sync_lease_seconds_out_of_range:{lease_seconds}"))?;
+
+        let rows = self
+            .client
+            .query(
+                "SELECT id, event_type, aggregate_id, payload::text
+                 FROM claim_outbox_events($1, $2)",
+                &[&limit_i32, &lease_i32],
+            )
+            .await
+            .map_err(|error| format!("tuple_sync_claim_outbox_failed:{error}"))?;
+
+        rows.iter()
+            .map(|row| {
+                let payload_text = row.get::<usize, String>(3);
+                let payload = serde_json::from_str::<Value>(&payload_text).map_err(|error| {
+                    format!(
+                        "tuple_sync_claim_outbox_payload_parse_failed:event_id={} reason={}",
+                        row.get::<usize, i64>(0),
+                        error
+                    )
+                })?;
+
+                Ok(TupleSyncOutboxEvent {
+                    id: row.get::<usize, i64>(0),
+                    event_type: row.get::<usize, String>(1),
+                    aggregate_id: row.get::<usize, String>(2),
+                    payload,
+                })
+            })
+            .collect()
+    }
+
+    async fn mark_outbox_event_sent(&self, event_id: i64) -> Result<(), String> {
+        self.client
+            .execute("SELECT mark_outbox_event_sent($1)", &[&event_id])
+            .await
+            .map_err(|error| format!("tuple_sync_mark_sent_failed:{error}"))?;
+        Ok(())
+    }
+
+    async fn mark_outbox_event_failed(
+        &self,
+        event_id: i64,
+        retry_seconds: u32,
+    ) -> Result<(), String> {
+        let retry_i32 = i32::try_from(retry_seconds)
+            .map_err(|_| format!("tuple_sync_retry_seconds_out_of_range:{retry_seconds}"))?;
+        self.client
+            .execute(
+                "SELECT mark_outbox_event_failed($1, $2)",
+                &[&event_id, &retry_i32],
+            )
+            .await
+            .map_err(|error| format!("tuple_sync_mark_failed_failed:{error}"))?;
+        Ok(())
+    }
+}
+
+/// tuple mutation を no-op で受ける実装を表現する。
+#[derive(Default)]
+pub struct NoopTupleMutationSink;
+
+#[async_trait]
+impl TupleMutationSink for NoopTupleMutationSink {
+    async fn apply_mutations(&self, mutations: Vec<SpiceDbTupleMutation>) -> Result<(), String> {
+        tracing::info!(
+            mutation_count = mutations.len(),
+            "noop tuple mutation sink accepted mutations"
+        );
+        Ok(())
+    }
+}
+
+/// テスト/検証用のインメモリtuple sinkを表現する。
+#[derive(Default)]
+pub struct InMemoryTupleMutationSink {
+    tuples: RwLock<BTreeSet<SpiceDbTuple>>,
+    failure_reason: RwLock<Option<String>>,
+}
+
+impl InMemoryTupleMutationSink {
+    /// 保存中tupleのスナップショットを返す。
+    /// @param なし
+    /// @returns tuple一覧
+    /// @throws なし
+    pub async fn snapshot(&self) -> Vec<SpiceDbTuple> {
+        self.tuples.read().await.iter().cloned().collect()
+    }
+
+    /// mutation適用時に返す失敗理由を設定する。
+    /// @param reason 失敗理由（Noneで解除）
+    /// @returns なし
+    /// @throws なし
+    pub async fn set_failure_reason(&self, reason: Option<String>) {
+        *self.failure_reason.write().await = reason;
+    }
+}
+
+#[async_trait]
+impl TupleMutationSink for InMemoryTupleMutationSink {
+    async fn apply_mutations(&self, mutations: Vec<SpiceDbTupleMutation>) -> Result<(), String> {
+        if let Some(reason) = self.failure_reason.read().await.clone() {
+            return Err(reason);
+        }
+
+        let mut tuples = self.tuples.write().await;
+        for mutation in mutations {
+            match mutation {
+                SpiceDbTupleMutation::Upsert(tuple) => {
+                    tuples.insert(tuple);
+                }
+                SpiceDbTupleMutation::Delete(tuple) => {
+                    tuples.remove(&tuple);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// tuple同期メトリクスを保持する。
+#[derive(Default)]
+pub struct AuthzTupleSyncMetrics {
+    outbox_claimed_total: AtomicU64,
+    outbox_succeeded_total: AtomicU64,
+    outbox_failed_total: AtomicU64,
+    outbox_full_resync_total: AtomicU64,
+    backfill_runs_total: AtomicU64,
+    backfill_generated_tuples_total: AtomicU64,
+    tuple_mutations_applied_total: AtomicU64,
+    sync_apply_failure_total: AtomicU64,
+}
+
+/// tuple同期メトリクスのスナップショットを保持する。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AuthzTupleSyncMetricsSnapshot {
+    pub outbox_claimed_total: u64,
+    pub outbox_succeeded_total: u64,
+    pub outbox_failed_total: u64,
+    pub outbox_full_resync_total: u64,
+    pub backfill_runs_total: u64,
+    pub backfill_generated_tuples_total: u64,
+    pub tuple_mutations_applied_total: u64,
+    pub sync_apply_failure_total: u64,
+}
+
+impl AuthzTupleSyncMetrics {
+    /// outbox claim 件数を記録する。
+    /// @param count claim 件数
+    /// @returns なし
+    /// @throws なし
+    pub fn record_outbox_claimed(&self, count: u64) {
+        self.outbox_claimed_total
+            .fetch_add(count, Ordering::Relaxed);
+    }
+
+    /// outboxイベント成功を記録する。
+    /// @param applied_mutations 適用したmutation件数
+    /// @param full_resync フル再同期イベントかどうか
+    /// @returns なし
+    /// @throws なし
+    pub fn record_outbox_success(&self, applied_mutations: u64, full_resync: bool) {
+        self.outbox_succeeded_total.fetch_add(1, Ordering::Relaxed);
+        if full_resync {
+            self.outbox_full_resync_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.tuple_mutations_applied_total
+            .fetch_add(applied_mutations, Ordering::Relaxed);
+    }
+
+    /// outboxイベント失敗を記録する。
+    /// @param なし
+    /// @returns なし
+    /// @throws なし
+    pub fn record_outbox_failed(&self) {
+        self.outbox_failed_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// backfill結果を記録する。
+    /// @param generated_tuples 生成したtuple件数
+    /// @param applied_mutations 適用したmutation件数
+    /// @returns なし
+    /// @throws なし
+    pub fn record_backfill(&self, generated_tuples: u64, applied_mutations: u64) {
+        self.backfill_runs_total.fetch_add(1, Ordering::Relaxed);
+        self.backfill_generated_tuples_total
+            .fetch_add(generated_tuples, Ordering::Relaxed);
+        self.tuple_mutations_applied_total
+            .fetch_add(applied_mutations, Ordering::Relaxed);
+    }
+
+    /// 同期適用失敗を記録する。
+    /// @param なし
+    /// @returns なし
+    /// @throws なし
+    pub fn record_sync_apply_failure(&self) {
+        self.sync_apply_failure_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// メトリクスの現在値を返す。
+    /// @param なし
+    /// @returns スナップショット
+    /// @throws なし
+    pub fn snapshot(&self) -> AuthzTupleSyncMetricsSnapshot {
+        AuthzTupleSyncMetricsSnapshot {
+            outbox_claimed_total: self.outbox_claimed_total.load(Ordering::Relaxed),
+            outbox_succeeded_total: self.outbox_succeeded_total.load(Ordering::Relaxed),
+            outbox_failed_total: self.outbox_failed_total.load(Ordering::Relaxed),
+            outbox_full_resync_total: self.outbox_full_resync_total.load(Ordering::Relaxed),
+            backfill_runs_total: self.backfill_runs_total.load(Ordering::Relaxed),
+            backfill_generated_tuples_total: self
+                .backfill_generated_tuples_total
+                .load(Ordering::Relaxed),
+            tuple_mutations_applied_total: self
+                .tuple_mutations_applied_total
+                .load(Ordering::Relaxed),
+            sync_apply_failure_total: self.sync_apply_failure_total.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// tuple同期のユースケース実装を表現する。
+pub struct AuthzTupleSyncService {
+    outbox_store: Arc<dyn TupleSyncOutboxStore>,
+    backfill_source: Arc<dyn TupleBackfillSource>,
+    sink: Arc<dyn TupleMutationSink>,
+    metrics: Arc<AuthzTupleSyncMetrics>,
+    config: SpiceDbTupleSyncRuntimeConfig,
+}
+
+impl AuthzTupleSyncService {
+    /// tuple同期サービスを生成する。
+    /// @param outbox_store outboxストア
+    /// @param backfill_source backfillソース
+    /// @param sink mutation適用先
+    /// @param metrics メトリクス集計器
+    /// @param config 同期設定
+    /// @returns tuple同期サービス
+    /// @throws なし
+    pub fn new(
+        outbox_store: Arc<dyn TupleSyncOutboxStore>,
+        backfill_source: Arc<dyn TupleBackfillSource>,
+        sink: Arc<dyn TupleMutationSink>,
+        metrics: Arc<AuthzTupleSyncMetrics>,
+        config: SpiceDbTupleSyncRuntimeConfig,
+    ) -> Self {
+        Self {
+            outbox_store,
+            backfill_source,
+            sink,
+            metrics,
+            config,
+        }
+    }
+
+    /// メトリクス参照を返す。
+    /// @param なし
+    /// @returns メトリクス参照
+    /// @throws なし
+    pub fn metrics(&self) -> Arc<AuthzTupleSyncMetrics> {
+        Arc::clone(&self.metrics)
+    }
+
+    /// 現在のPostgres状態をフルbackfillとして同期する。
+    /// @param なし
+    /// @returns backfill実行結果
+    /// @throws String 読み取り/適用失敗時
+    pub async fn run_backfill_once(&self) -> Result<TupleBackfillReport, String> {
+        let guild_roles = self.backfill_source.list_guild_roles().await?;
+        let guild_member_roles = self.backfill_source.list_guild_member_roles().await?;
+        let channel_role_overrides = self.backfill_source.list_channel_role_overrides().await?;
+        let channel_user_overrides = self.backfill_source.list_channel_user_overrides().await?;
+
+        let input = TupleBackfillInput {
+            guild_roles,
+            guild_member_roles,
+            channel_role_overrides,
+            channel_user_overrides,
+        };
+
+        let tuples = build_backfill_tuples(&input);
+        let generated_tuple_count = tuples.len() as u64;
+        let mutations: Vec<SpiceDbTupleMutation> = tuples
+            .into_iter()
+            .map(SpiceDbTupleMutation::Upsert)
+            .collect();
+
+        let applied_mutation_count = mutations.len() as u64;
+        if let Err(error) = self.sink.apply_mutations(mutations).await {
+            self.metrics.record_sync_apply_failure();
+            return Err(format!("tuple_backfill_apply_failed:{error}"));
+        }
+
+        self.metrics
+            .record_backfill(generated_tuple_count, applied_mutation_count);
+
+        tracing::info!(
+            guild_role_rows = input.guild_roles.len(),
+            guild_member_role_rows = input.guild_member_roles.len(),
+            channel_role_override_rows = input.channel_role_overrides.len(),
+            channel_user_override_rows = input.channel_user_overrides.len(),
+            generated_tuple_count,
+            applied_mutation_count,
+            "authz tuple backfill completed"
+        );
+
+        Ok(TupleBackfillReport {
+            guild_role_rows: input.guild_roles.len() as u64,
+            guild_member_role_rows: input.guild_member_roles.len() as u64,
+            channel_role_override_rows: input.channel_role_overrides.len() as u64,
+            channel_user_override_rows: input.channel_user_overrides.len() as u64,
+            generated_tuple_count,
+            applied_mutation_count,
+        })
+    }
+
+    /// outboxを1回処理して差分同期を実行する。
+    /// @param なし
+    /// @returns 同期実行結果
+    /// @throws String outbox操作失敗時
+    pub async fn run_sync_once(&self) -> Result<TupleSyncRunReport, String> {
+        let claimed = self
+            .outbox_store
+            .claim_outbox_events(
+                self.config.outbox_claim_limit,
+                self.config.outbox_lease_seconds,
+            )
+            .await?;
+
+        self.metrics.record_outbox_claimed(claimed.len() as u64);
+
+        let mut report = TupleSyncRunReport {
+            claimed_events: claimed.len() as u64,
+            ..TupleSyncRunReport::default()
+        };
+
+        for event in claimed {
+            match self.process_claimed_event(&event).await {
+                Ok(result) => {
+                    if let Err(error) = self.outbox_store.mark_outbox_event_sent(event.id).await {
+                        return Err(format!(
+                            "tuple_sync_mark_sent_failed:event_id={} reason={}",
+                            event.id, error
+                        ));
+                    }
+
+                    report.succeeded_events += 1;
+                    report.applied_mutations += result.applied_mutations;
+                    if result.full_resync {
+                        report.full_resync_events += 1;
+                    }
+
+                    let metrics_applied_mutations = if result.full_resync {
+                        0
+                    } else {
+                        result.applied_mutations
+                    };
+                    self.metrics
+                        .record_outbox_success(metrics_applied_mutations, result.full_resync);
+                }
+                Err(reason) => {
+                    self.metrics.record_outbox_failed();
+                    report.failed_events += 1;
+                    tracing::warn!(
+                        event_id = event.id,
+                        event_type = %event.event_type,
+                        aggregate_id = %event.aggregate_id,
+                        reason = %reason,
+                        "authz tuple sync event failed"
+                    );
+                    if let Err(mark_error) = self
+                        .outbox_store
+                        .mark_outbox_event_failed(event.id, self.config.outbox_retry_seconds)
+                        .await
+                    {
+                        return Err(format!(
+                            "tuple_sync_mark_failed_failed:event_id={} reason={} mark_error={}",
+                            event.id, reason, mark_error
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(report)
+    }
+
+    async fn process_claimed_event(
+        &self,
+        event: &TupleSyncOutboxEvent,
+    ) -> Result<ProcessedEventResult, String> {
+        let command = build_tuple_sync_command(event)?;
+        match command {
+            TupleSyncCommand::Mutations(mutations) => {
+                let mutation_count = mutations.len() as u64;
+                if let Err(error) = self.sink.apply_mutations(mutations).await {
+                    self.metrics.record_sync_apply_failure();
+                    return Err(format!("tuple_sync_apply_failed:{error}"));
+                }
+
+                Ok(ProcessedEventResult {
+                    applied_mutations: mutation_count,
+                    full_resync: false,
+                })
+            }
+            TupleSyncCommand::FullResync { reason } => {
+                tracing::warn!(
+                    reason = ?reason,
+                    event_type = %event.event_type,
+                    aggregate_id = %event.aggregate_id,
+                    "authz tuple full resync requested"
+                );
+                let backfill_report = self.run_backfill_once().await?;
+                Ok(ProcessedEventResult {
+                    applied_mutations: backfill_report.applied_mutation_count,
+                    full_resync: true,
+                })
+            }
+        }
+    }
+}
+
+struct ProcessedEventResult {
+    applied_mutations: u64,
+    full_resync: bool,
+}
+
+fn build_guild_role_mutations(
+    payload: GuildRoleOutboxPayload,
+) -> Result<Vec<SpiceDbTupleMutation>, String> {
+    let candidates = guild_role_candidate_tuples(payload.guild_id, &payload.role_key);
+
+    match payload.op {
+        TupleSyncOperation::Delete => Ok(build_delete_mutations(candidates)),
+        TupleSyncOperation::Upsert => {
+            let row = GuildRolePermissionRow {
+                guild_id: payload.guild_id,
+                role_key: payload.role_key,
+                allow_view: require_payload_bool(
+                    payload.allow_view,
+                    "allow_view",
+                    AUTHZ_TUPLE_EVENT_GUILD_ROLE,
+                )?,
+                allow_post: require_payload_bool(
+                    payload.allow_post,
+                    "allow_post",
+                    AUTHZ_TUPLE_EVENT_GUILD_ROLE,
+                )?,
+                allow_manage: require_payload_bool(
+                    payload.allow_manage,
+                    "allow_manage",
+                    AUTHZ_TUPLE_EVENT_GUILD_ROLE,
+                )?,
+            };
+            let desired = map_guild_role_permissions_to_tuples(&row);
+            Ok(build_replace_mutations(candidates, desired))
+        }
+    }
+}
+
+fn build_guild_member_role_mutations(
+    payload: GuildMemberRoleOutboxPayload,
+) -> Vec<SpiceDbTupleMutation> {
+    let tuple = map_guild_member_role_to_tuple(&GuildMemberRoleRow {
+        guild_id: payload.guild_id,
+        user_id: payload.user_id,
+        role_key: payload.role_key,
+    });
+
+    match payload.op {
+        TupleSyncOperation::Delete => vec![SpiceDbTupleMutation::Delete(tuple)],
+        TupleSyncOperation::Upsert => vec![
+            SpiceDbTupleMutation::Delete(tuple.clone()),
+            SpiceDbTupleMutation::Upsert(tuple),
+        ],
+    }
+}
+
+fn build_channel_role_override_mutations(
+    payload: ChannelRoleOverrideOutboxPayload,
+) -> Vec<SpiceDbTupleMutation> {
+    let candidates = channel_role_override_candidate_tuples(
+        payload.channel_id,
+        payload.guild_id,
+        &payload.role_key,
+    );
+
+    match payload.op {
+        TupleSyncOperation::Delete => build_delete_mutations(candidates),
+        TupleSyncOperation::Upsert => {
+            let desired = map_channel_role_override_to_tuples(&ChannelRoleOverrideRow {
+                channel_id: payload.channel_id,
+                guild_id: payload.guild_id,
+                role_key: payload.role_key,
+                can_view: payload.can_view,
+                can_post: payload.can_post,
+            });
+            build_replace_mutations(candidates, desired)
+        }
+    }
+}
+
+fn build_channel_user_override_mutations(
+    payload: ChannelUserOverrideOutboxPayload,
+) -> Vec<SpiceDbTupleMutation> {
+    let candidates = channel_user_override_candidate_tuples(payload.channel_id, payload.user_id);
+
+    match payload.op {
+        TupleSyncOperation::Delete => build_delete_mutations(candidates),
+        TupleSyncOperation::Upsert => {
+            let desired = map_channel_user_override_to_tuples(&ChannelUserOverrideRow {
+                channel_id: payload.channel_id,
+                guild_id: payload.guild_id,
+                user_id: payload.user_id,
+                can_view: payload.can_view,
+                can_post: payload.can_post,
+            });
+            build_replace_mutations(candidates, desired)
+        }
+    }
+}
+
+fn parse_optional_u32_env(name: &str, default: u32) -> Result<u32, String> {
+    match env::var(name) {
+        Ok(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Err(format!("{name} must not be empty when set"));
+            }
+            trimmed
+                .parse::<u32>()
+                .map_err(|error| format!("{name} must be a valid u32 (reason: {error})"))
+        }
+        Err(_) => Ok(default),
+    }
+}
+
+fn parse_json_payload<T>(event: &TupleSyncOutboxEvent) -> Result<T, String>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_value(event.payload.clone()).map_err(|error| {
+        format!(
+            "invalid payload for {} (event_id={}, reason={})",
+            event.event_type, event.id, error
+        )
+    })
+}
+
+fn parse_optional_json_payload<T>(event: &TupleSyncOutboxEvent) -> Result<T, String>
+where
+    T: DeserializeOwned + Default,
+{
+    if event.payload.is_null() {
+        return Ok(T::default());
+    }
+
+    parse_json_payload(event)
+}
+
+fn require_payload_bool(
+    value: Option<bool>,
+    field: &str,
+    event_type: &str,
+) -> Result<bool, String> {
+    value.ok_or_else(|| format!("{event_type} requires bool field: {field}"))
+}
+
+fn build_replace_mutations(
+    candidates: Vec<SpiceDbTuple>,
+    desired: Vec<SpiceDbTuple>,
+) -> Vec<SpiceDbTupleMutation> {
+    let mut mutations = Vec::new();
+
+    for tuple in BTreeSet::<SpiceDbTuple>::from_iter(candidates) {
+        mutations.push(SpiceDbTupleMutation::Delete(tuple));
+    }
+
+    for tuple in BTreeSet::<SpiceDbTuple>::from_iter(desired) {
+        mutations.push(SpiceDbTupleMutation::Upsert(tuple));
+    }
+
+    mutations
+}
+
+fn build_delete_mutations(candidates: Vec<SpiceDbTuple>) -> Vec<SpiceDbTupleMutation> {
+    BTreeSet::<SpiceDbTuple>::from_iter(candidates)
+        .into_iter()
+        .map(SpiceDbTupleMutation::Delete)
+        .collect()
+}
+
+fn guild_role_candidate_tuples(guild_id: i64, role_key: &str) -> Vec<SpiceDbTuple> {
+    let object = guild_object(guild_id);
+    let subject = role_member_subject(guild_id, role_key);
+    vec![
+        SpiceDbTuple::new(object.clone(), GUILD_MANAGER_RELATION, subject.clone()),
+        SpiceDbTuple::new(object.clone(), GUILD_VIEWER_RELATION, subject.clone()),
+        SpiceDbTuple::new(object, GUILD_POSTER_RELATION, subject),
+    ]
+}
+
+fn channel_role_override_candidate_tuples(
+    channel_id: i64,
+    guild_id: i64,
+    role_key: &str,
+) -> Vec<SpiceDbTuple> {
+    let object = channel_object(channel_id);
+    let subject = role_member_subject(guild_id, role_key);
+    vec![
+        SpiceDbTuple::new(
+            object.clone(),
+            CHANNEL_VIEWER_ROLE_RELATION,
+            subject.clone(),
+        ),
+        SpiceDbTuple::new(
+            object.clone(),
+            CHANNEL_VIEW_DENY_ROLE_RELATION,
+            subject.clone(),
+        ),
+        SpiceDbTuple::new(
+            object.clone(),
+            CHANNEL_POSTER_ROLE_RELATION,
+            subject.clone(),
+        ),
+        SpiceDbTuple::new(object, CHANNEL_POST_DENY_ROLE_RELATION, subject),
+    ]
+}
+
+fn channel_user_override_candidate_tuples(channel_id: i64, user_id: i64) -> Vec<SpiceDbTuple> {
+    let object = channel_object(channel_id);
+    let subject = user_subject(user_id);
+    vec![
+        SpiceDbTuple::new(
+            object.clone(),
+            CHANNEL_VIEWER_USER_RELATION,
+            subject.clone(),
+        ),
+        SpiceDbTuple::new(
+            object.clone(),
+            CHANNEL_VIEW_DENY_USER_RELATION,
+            subject.clone(),
+        ),
+        SpiceDbTuple::new(
+            object.clone(),
+            CHANNEL_POSTER_USER_RELATION,
+            subject.clone(),
+        ),
+        SpiceDbTuple::new(object, CHANNEL_POST_DENY_USER_RELATION, subject),
+    ]
+}
+
+fn role_object(guild_id: i64, role_key: &str) -> String {
+    format!("role:{guild_id}/{role_key}")
+}
+
+fn guild_object(guild_id: i64) -> String {
+    format!("guild:{guild_id}")
+}
+
+fn channel_object(channel_id: i64) -> String {
+    format!("channel:{channel_id}")
+}
+
+fn role_member_subject(guild_id: i64, role_key: &str) -> String {
+    format!("{}#member", role_object(guild_id, role_key))
+}
+
+fn user_subject(user_id: i64) -> String {
+    format!("user:{user_id}")
+}


### PR DESCRIPTION
## 概要

LIN-864 として、Postgres `*_v2` 権限データから SpiceDB canonical relation への tuple 写像、および backfill / outbox差分同期の実装基盤を追加しました。

## 変更内容

- Rust (`rust/apps/api/src/authz/tuple_sync.rs`)
  - canonical relation tuple mapping
  - backfill入力/出力生成
  - outbox event -> mutation 変換（upsert/delete/full_resync）
  - `claim_outbox_events` / `mark_outbox_event_sent` / `mark_outbox_event_failed` による同期ループ
  - 同期メトリクスと drift 再同期フック
- Rust runtime (`rust/apps/api/src/authz/runtime.rs`)
  - `AUTHZ_PROVIDER=spicedb` 時の tuple sync env 検証ログ追加
- Rust tests (`rust/apps/api/src/authz/tests.rs`)
  - tuple mapping/backfill/delta sync/failure/full resync ケース追加
- 契約/ドキュメント
  - `database/contracts/lin864_postgres_spicedb_tuple_sync_contract.md` 追加
  - `docs/runbooks/authz-spicedb-tuple-sync-operations-runbook.md` 追加
  - `docs/AUTHZ.md` / `docs/DATABASE.md` / `docs/runbooks/README.md` / `.env.example` 更新

## 受け入れ条件との対応

- 主要ロール/overrideケースの Tuple 変換:
  - Rustテストで canonical relation への写像を固定
- backfill 実行後の主要権限再現:
  - backfill生成と重複除去、full resync 経路をテストで固定
- 同期失敗時の検知:
  - sync failure 時の `mark_outbox_event_failed` と metrics 増分をテストで固定

## テスト

- `make rust-lint` : ✅ pass
- `make validate` : ❌ fail (`typescript` 側で `prettier: command not found` / `node_modules` 未導入)

## 互換性・スコープ

- additive only（既存AuthZ I/Fの破壊的変更なし）
- SpiceDB Authorizer への実運用切替は LIN-865 へ継続

## ADR-001 チェック

- 本PRは event schema/stream contract 変更を含まないため、ADR-001 互換性チェックは **N/A**。
- 互換性判断: AuthZ tuple sync 基盤の追加のみで既存公開契約に影響なし。

## Review outcome

- `reviewer_simple`: 環境制約により利用不可（manual self-review fallback）
- blocking findings (`P1+`): none
- non-blocking suggestions (`P2/P3`): none

## UI check

- `reviewer_ui_guard`: 環境制約により利用不可
- UI変更なしのため `reviewer_ui` は skipped

## Linear

- https://linear.app/linklynx-ai/issue/LIN-864/v1authz-spicedb-04-postgresspicedb-tuple写像と同期実装
