### PR TITLE
[v1/AuthZ-SpiceDB-06] 既存REST API権限適用（Guild/Channel/Message）

### DIFF
--- a/docs/AUTHZ_API_MATRIX.md
+++ b/docs/AUTHZ_API_MATRIX.md
@@ -26,6 +26,11 @@
 | GET | `/health` | Public | なし | なし | ヘルスチェック |
 | GET | `/internal/auth/metrics` | Public | なし | なし | 認証メトリクス取得 |
 | GET | `/v1/protected/ping` | Protected | 必須 | 必須 | `rest_auth_middleware` を経由 |
+| GET | `/v1/guilds/:guild_id` | Protected | 必須 | 必須 | Guild参照 |
+| PATCH | `/v1/guilds/:guild_id` | Protected | 必須 | 必須 | Guild管理 |
+| GET | `/v1/guilds/:guild_id/channels/:channel_id` | Protected | 必須 | 必須 | Channel参照 |
+| GET | `/v1/guilds/:guild_id/channels/:channel_id/messages` | Protected | 必須 | 必須 | Message一覧参照 |
+| POST | `/v1/guilds/:guild_id/channels/:channel_id/messages` | Protected | 必須 | 必須 | Message投稿 |
 
 ### 2.2 WebSocket endpoint
 
@@ -42,6 +47,11 @@
 
 ### Protected (AuthZ required)
 - `GET /v1/protected/ping`
+- `GET /v1/guilds/:guild_id`
+- `PATCH /v1/guilds/:guild_id`
+- `GET /v1/guilds/:guild_id/channels/:channel_id`
+- `GET /v1/guilds/:guild_id/channels/:channel_id/messages`
+- `POST /v1/guilds/:guild_id/channels/:channel_id/messages`
 - `GET /ws`（upgrade handshake）
 - `auth.reauthenticate` 処理時の再認証 AuthZ
 
@@ -52,6 +62,11 @@
 | Surface | Operation | Principal | Resource | Action | Expected decision handling |
 | --- | --- | --- | --- | --- | --- |
 | REST | `GET /v1/protected/ping` | AuthN済み `principal_id` | `AuthzResource::RestPath { path: "/v1/protected/ping" }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `GET /v1/guilds/:guild_id` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `PATCH /v1/guilds/:guild_id` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `GET /v1/guilds/:guild_id/channels/:channel_id` | AuthN済み `principal_id` | `AuthzResource::GuildChannel { guild_id, channel_id }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `GET /v1/guilds/:guild_id/channels/:channel_id/messages` | AuthN済み `principal_id` | `AuthzResource::GuildChannel { guild_id, channel_id }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `POST /v1/guilds/:guild_id/channels/:channel_id/messages` | AuthN済み `principal_id` | `AuthzResource::GuildChannel { guild_id, channel_id }` | `Post` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
 | WS | `/ws` handshake | AuthN済み `principal_id` | `AuthzResource::Session` | `Connect` | deny=`1008`, unavailable=`1011` |
 | WS | `auth.reauthenticate` | AuthN済み `principal_id` | `AuthzResource::Session` | `Connect` | deny=`1008`, unavailable=`1011` |
 
@@ -78,4 +93,4 @@
 ## 6. Notes for downstream issues
 
 - `LIN-862` 以降は本マトリクスを入力に SpiceDB スキーマ・Tuple写像を設計する。
-- `LIN-866` / `LIN-867` で新規ドメインAPIを適用する際は、本ファイルに endpoint を追加する。
+- `LIN-867` で Invite/DM/Moderation/WS の追加適用時は、本ファイルに endpoint を追加する。

--- a/docs/agent_runs/LIN-860/Documentation.md
+++ b/docs/agent_runs/LIN-860/Documentation.md
@@ -2,7 +2,7 @@
 
 ## Status
 - In progress.
-- Current child issue: `LIN-865`.
+- Current child issue: `LIN-866`.
 
 ## Decisions
 - Parent/child execution order follows LIN-860 definition (`861 -> 868`).
@@ -212,6 +212,61 @@
 ## Per-child evidence (LIN-865)
 - issue: `LIN-865`
 - branch: `codex/LIN-865-authz-provider-spicedb-fail-close`
+- validation commands and results:
+  - `make rust-lint`: passed
+  - `make validate`: failed（environment dependency missing）
+- reviewer gate (`reviewer_simple`): unavailable -> manual self-review fallback (no blocking findings)
+- UI gate (`reviewer_ui_guard` / `reviewer_ui`): unavailable -> UI changesなしで `reviewer_ui` skipped
+- PR URL: https://github.com/LinkLynx-AI/LinkLynx-AI/pull/1033
+- PR base branch: `codex/lin-860`
+- merge/auto-merge status: merged (`2026-03-04T07:25:16Z`)
+
+## LIN-866 progress
+- branch: `codex/LIN-866-authz-rest-guild-channel-message`
+- objective: Guild/Channel/Message 系 REST API へ AuthZ 適用（resource/action 写像の固定）と fail-close 境界維持
+- delivered:
+  - `rust/apps/api/src/main/http_routes.rs`
+    - 最小 REST endpoint を追加
+      - `GET /v1/guilds/{guild_id}`
+      - `PATCH /v1/guilds/{guild_id}`
+      - `GET /v1/guilds/{guild_id}/channels/{channel_id}`
+      - `GET/POST /v1/guilds/{guild_id}/channels/{channel_id}/messages`
+    - `rest_auth_middleware` の resource/action 写像を拡張
+      - Guild path -> `AuthzResource::Guild`
+      - Channel/Message path -> `AuthzResource::GuildChannel`
+      - method -> `View/Post/Manage`
+  - `rust/apps/api/src/authz/service.rs`
+    - `AuthzResource` に `Guild` / `GuildChannel` を追加
+    - SpiceDB check mapping を追加
+      - `Guild + View/Manage` -> `guild:{id}#can_view/can_manage`
+      - `GuildChannel + View/Post/Manage` -> `channel:{id}#can_view/can_post/can_manage`
+  - `rust/apps/api/src/main/tests.rs`
+    - owner/admin/member 相当の allow/deny テスト追加
+    - unavailable (`503`) 維持テストを Guild endpoint で追加
+  - `rust/apps/api/src/authz/tests.rs`
+    - SpiceDB request body を捕捉し、Guild/Channel mapping を検証するテスト追加
+  - `docs/AUTHZ_API_MATRIX.md`
+    - LIN-866 対象 endpoint と `principal/resource/action` マトリクスを追記
+
+## Validation results (LIN-866)
+- `make rust-lint`: passed
+- `make validate`: failed（`typescript` の `node_modules` 未導入により `prettier: command not found`）
+
+## Review results (LIN-866)
+- `reviewer_simple`: unavailable in current execution environment（agent type unavailable）
+- Manual self-review fallback:
+  - 追加 endpoint がすべて `rest_auth_middleware` を経由することを確認
+  - Guild/Channel resource mapping と method action mapping をテストで固定
+  - SpiceDB provider request mapping（objectType/objectId/permission）をテストで固定
+  - blocking findings: none
+- `reviewer_ui_guard`: unavailable in current execution environment（agent type unavailable）
+- UI gate fallback:
+  - changed files are backend/docs only, no frontend/UI files
+  - `reviewer_ui`: skipped（UI changesなし）
+
+## Per-child evidence (LIN-866)
+- issue: `LIN-866`
+- branch: `codex/LIN-866-authz-rest-guild-channel-message`
 - validation commands and results:
   - `make rust-lint`: passed
   - `make validate`: failed（environment dependency missing）

--- a/rust/apps/api/src/authz/service.rs
+++ b/rust/apps/api/src/authz/service.rs
@@ -18,6 +18,8 @@ pub struct AuthzCheckInput {
 #[derive(Debug, Clone)]
 pub enum AuthzResource {
     Session,
+    Guild { guild_id: i64 },
+    GuildChannel { guild_id: i64, channel_id: i64 },
     RestPath { path: String },
 }
 
@@ -306,6 +308,65 @@ impl SpiceDbHttpAuthorizer {
             (AuthzResource::Session, _) => {
                 return Err(AuthzError::denied("session_action_not_supported"));
             }
+            (AuthzResource::Guild { guild_id }, AuthzAction::View) => (
+                SpiceDbObjectReference {
+                    object_type: "guild".to_owned(),
+                    object_id: guild_id.to_string(),
+                },
+                "can_view".to_owned(),
+            ),
+            (AuthzResource::Guild { guild_id }, AuthzAction::Manage) => (
+                SpiceDbObjectReference {
+                    object_type: "guild".to_owned(),
+                    object_id: guild_id.to_string(),
+                },
+                "can_manage".to_owned(),
+            ),
+            (AuthzResource::Guild { .. }, _) => {
+                return Err(AuthzError::denied("guild_action_not_supported"));
+            }
+            (
+                AuthzResource::GuildChannel {
+                    guild_id: _,
+                    channel_id,
+                },
+                AuthzAction::View,
+            ) => (
+                SpiceDbObjectReference {
+                    object_type: "channel".to_owned(),
+                    object_id: channel_id.to_string(),
+                },
+                "can_view".to_owned(),
+            ),
+            (
+                AuthzResource::GuildChannel {
+                    guild_id: _,
+                    channel_id,
+                },
+                AuthzAction::Post,
+            ) => (
+                SpiceDbObjectReference {
+                    object_type: "channel".to_owned(),
+                    object_id: channel_id.to_string(),
+                },
+                "can_post".to_owned(),
+            ),
+            (
+                AuthzResource::GuildChannel {
+                    guild_id: _,
+                    channel_id,
+                },
+                AuthzAction::Manage,
+            ) => (
+                SpiceDbObjectReference {
+                    object_type: "channel".to_owned(),
+                    object_id: channel_id.to_string(),
+                },
+                "can_manage".to_owned(),
+            ),
+            (AuthzResource::GuildChannel { .. }, _) => {
+                return Err(AuthzError::denied("guild_channel_action_not_supported"));
+            }
             (AuthzResource::RestPath { path }, AuthzAction::View) => (
                 SpiceDbObjectReference {
                     object_type: "api_path".to_owned(),
@@ -460,6 +521,11 @@ fn authz_action_label(action: AuthzAction) -> &'static str {
 fn authz_resource_label(resource: &AuthzResource) -> String {
     match resource {
         AuthzResource::Session => "session".to_owned(),
+        AuthzResource::Guild { guild_id } => format!("guild:{guild_id}"),
+        AuthzResource::GuildChannel {
+            guild_id,
+            channel_id,
+        } => format!("guild:{guild_id}/channel:{channel_id}"),
         AuthzResource::RestPath { path } => path.clone(),
     }
 }
@@ -467,6 +533,11 @@ fn authz_resource_label(resource: &AuthzResource) -> String {
 fn authz_resource_cache_key(resource: &AuthzResource) -> String {
     match resource {
         AuthzResource::Session => "session:global".to_owned(),
+        AuthzResource::Guild { guild_id } => format!("guild:{guild_id}"),
+        AuthzResource::GuildChannel {
+            guild_id,
+            channel_id,
+        } => format!("guild:{guild_id}/channel:{channel_id}"),
         AuthzResource::RestPath { path } => format!("api_path:{path}"),
     }
 }

--- a/rust/apps/api/src/authz/tests.rs
+++ b/rust/apps/api/src/authz/tests.rs
@@ -276,6 +276,73 @@ mod tests {
         assert_eq!(mock.request_count(), 1);
     }
 
+    #[tokio::test]
+    async fn runtime_provider_spicedb_maps_guild_manage_to_can_manage() {
+        let _guard = env_lock().lock().await;
+        let mock = MockSpiceDbServer::start(
+            vec![MockSpiceDbResponse::ok("PERMISSIONSHIP_HAS_PERMISSION")],
+            false,
+        )
+        .await;
+        let mut scoped = ScopedEnv::new();
+        scoped.set("AUTHZ_PROVIDER", "spicedb");
+        scoped.set("SPICEDB_ENDPOINT", "http://spicedb:50051");
+        scoped.set("SPICEDB_CHECK_ENDPOINT", &mock.endpoint());
+        scoped.set("SPICEDB_PRESHARED_KEY", "test-key");
+        scoped.set("SPICEDB_REQUEST_TIMEOUT_MS", "100");
+        scoped.set("SPICEDB_CHECK_MAX_RETRIES", "0");
+
+        let authorizer = build_runtime_authorizer();
+        let input = AuthzCheckInput {
+            principal_id: PrincipalId(4001),
+            resource: AuthzResource::Guild { guild_id: 99 },
+            action: AuthzAction::Manage,
+        };
+
+        assert!(authorizer.check(&input).await.is_ok());
+        assert_eq!(mock.request_count(), 1);
+        let requests = mock.requests().await;
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["resource"]["objectType"], "guild");
+        assert_eq!(requests[0]["resource"]["objectId"], "99");
+        assert_eq!(requests[0]["permission"], "can_manage");
+    }
+
+    #[tokio::test]
+    async fn runtime_provider_spicedb_maps_channel_post_to_can_post() {
+        let _guard = env_lock().lock().await;
+        let mock = MockSpiceDbServer::start(
+            vec![MockSpiceDbResponse::ok("PERMISSIONSHIP_HAS_PERMISSION")],
+            false,
+        )
+        .await;
+        let mut scoped = ScopedEnv::new();
+        scoped.set("AUTHZ_PROVIDER", "spicedb");
+        scoped.set("SPICEDB_ENDPOINT", "http://spicedb:50051");
+        scoped.set("SPICEDB_CHECK_ENDPOINT", &mock.endpoint());
+        scoped.set("SPICEDB_PRESHARED_KEY", "test-key");
+        scoped.set("SPICEDB_REQUEST_TIMEOUT_MS", "100");
+        scoped.set("SPICEDB_CHECK_MAX_RETRIES", "0");
+
+        let authorizer = build_runtime_authorizer();
+        let input = AuthzCheckInput {
+            principal_id: PrincipalId(4002),
+            resource: AuthzResource::GuildChannel {
+                guild_id: 10,
+                channel_id: 77,
+            },
+            action: AuthzAction::Post,
+        };
+
+        assert!(authorizer.check(&input).await.is_ok());
+        assert_eq!(mock.request_count(), 1);
+        let requests = mock.requests().await;
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["resource"]["objectType"], "channel");
+        assert_eq!(requests[0]["resource"]["objectId"], "77");
+        assert_eq!(requests[0]["permission"], "can_post");
+    }
+
     #[test]
     fn tuple_mapping_uses_canonical_relations() {
         let role_row = GuildRolePermissionRow {
@@ -579,6 +646,7 @@ mod tests {
     struct MockSpiceDbState {
         responses: Arc<tokio::sync::Mutex<Vec<MockSpiceDbResponse>>>,
         request_count: Arc<AtomicU64>,
+        requests: Arc<tokio::sync::Mutex<Vec<serde_json::Value>>>,
         require_auth: bool,
     }
 
@@ -592,6 +660,7 @@ mod tests {
             let state = MockSpiceDbState {
                 responses: Arc::new(tokio::sync::Mutex::new(responses)),
                 request_count: Arc::new(AtomicU64::new(0)),
+                requests: Arc::new(tokio::sync::Mutex::new(Vec::new())),
                 require_auth,
             };
 
@@ -618,16 +687,21 @@ mod tests {
                 .request_count
                 .load(Ordering::Relaxed)
         }
+
+        async fn requests(&self) -> Vec<serde_json::Value> {
+            self.state.requests.lock().await.clone()
+        }
     }
 
     async fn mock_spicedb_check_handler(
         State(state): State<MockSpiceDbState>,
         headers: axum::http::HeaderMap,
-        Json(_request): Json<serde_json::Value>,
+        Json(request): Json<serde_json::Value>,
     ) -> (axum::http::StatusCode, Json<serde_json::Value>) {
         state
             .request_count
             .fetch_add(1, Ordering::Relaxed);
+        state.requests.lock().await.push(request);
 
         if state.require_auth {
             let has_header = headers

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -10,6 +10,20 @@ fn app_with_state(state: AppState) -> Router {
 
     let protected_routes = Router::new()
         .route("/v1/protected/ping", get(protected_ping))
+        .route("/v1/guilds/{guild_id}", get(get_guild))
+        .route("/v1/guilds/{guild_id}", axum::routing::patch(update_guild))
+        .route(
+            "/v1/guilds/{guild_id}/channels/{channel_id}",
+            get(get_guild_channel),
+        )
+        .route(
+            "/v1/guilds/{guild_id}/channels/{channel_id}/messages",
+            get(list_channel_messages),
+        )
+        .route(
+            "/v1/guilds/{guild_id}/channels/{channel_id}/messages",
+            axum::routing::post(create_channel_message),
+        )
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             rest_auth_middleware,
@@ -49,6 +63,43 @@ struct ProtectedPingResponse {
     firebase_uid: String,
 }
 
+#[derive(Debug, Serialize)]
+struct GuildResponse {
+    ok: bool,
+    request_id: String,
+    principal_id: i64,
+    guild_id: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct GuildChannelResponse {
+    ok: bool,
+    request_id: String,
+    principal_id: i64,
+    guild_id: i64,
+    channel_id: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct GuildChannelMessagesResponse {
+    ok: bool,
+    request_id: String,
+    principal_id: i64,
+    guild_id: i64,
+    channel_id: i64,
+    messages: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct GuildChannelMessageCreateResponse {
+    ok: bool,
+    request_id: String,
+    principal_id: i64,
+    guild_id: i64,
+    channel_id: i64,
+    message_id: String,
+}
+
 /// 認証済みエンドポイントの疎通応答を返す。
 /// @param auth_context 認証文脈
 /// @returns 認証済み応答
@@ -61,6 +112,96 @@ async fn protected_ping(
         request_id: auth_context.request_id,
         principal_id: auth_context.principal_id.0,
         firebase_uid: auth_context.firebase_uid,
+    })
+}
+
+/// ギルド情報の最小応答を返す。
+/// @param path guild_id を含むパス
+/// @param auth_context 認証文脈
+/// @returns ギルド最小応答
+/// @throws なし
+async fn get_guild(
+    axum::extract::Path(guild_id): axum::extract::Path<i64>,
+    Extension(auth_context): Extension<AuthContext>,
+) -> Json<GuildResponse> {
+    Json(GuildResponse {
+        ok: true,
+        request_id: auth_context.request_id,
+        principal_id: auth_context.principal_id.0,
+        guild_id,
+    })
+}
+
+/// ギルド更新の最小応答を返す。
+/// @param path guild_id を含むパス
+/// @param auth_context 認証文脈
+/// @returns ギルド更新最小応答
+/// @throws なし
+async fn update_guild(
+    axum::extract::Path(guild_id): axum::extract::Path<i64>,
+    Extension(auth_context): Extension<AuthContext>,
+) -> Json<GuildResponse> {
+    Json(GuildResponse {
+        ok: true,
+        request_id: auth_context.request_id,
+        principal_id: auth_context.principal_id.0,
+        guild_id,
+    })
+}
+
+/// ギルドチャンネル情報の最小応答を返す。
+/// @param path guild_id と channel_id を含むパス
+/// @param auth_context 認証文脈
+/// @returns チャンネル最小応答
+/// @throws なし
+async fn get_guild_channel(
+    axum::extract::Path((guild_id, channel_id)): axum::extract::Path<(i64, i64)>,
+    Extension(auth_context): Extension<AuthContext>,
+) -> Json<GuildChannelResponse> {
+    Json(GuildChannelResponse {
+        ok: true,
+        request_id: auth_context.request_id,
+        principal_id: auth_context.principal_id.0,
+        guild_id,
+        channel_id,
+    })
+}
+
+/// チャンネルメッセージ一覧の最小応答を返す。
+/// @param path guild_id と channel_id を含むパス
+/// @param auth_context 認証文脈
+/// @returns メッセージ一覧最小応答
+/// @throws なし
+async fn list_channel_messages(
+    axum::extract::Path((guild_id, channel_id)): axum::extract::Path<(i64, i64)>,
+    Extension(auth_context): Extension<AuthContext>,
+) -> Json<GuildChannelMessagesResponse> {
+    Json(GuildChannelMessagesResponse {
+        ok: true,
+        request_id: auth_context.request_id,
+        principal_id: auth_context.principal_id.0,
+        guild_id,
+        channel_id,
+        messages: Vec::new(),
+    })
+}
+
+/// チャンネルメッセージ作成の最小応答を返す。
+/// @param path guild_id と channel_id を含むパス
+/// @param auth_context 認証文脈
+/// @returns メッセージ作成最小応答
+/// @throws なし
+async fn create_channel_message(
+    axum::extract::Path((guild_id, channel_id)): axum::extract::Path<(i64, i64)>,
+    Extension(auth_context): Extension<AuthContext>,
+) -> Json<GuildChannelMessageCreateResponse> {
+    Json(GuildChannelMessageCreateResponse {
+        ok: true,
+        request_id: auth_context.request_id,
+        principal_id: auth_context.principal_id.0,
+        guild_id,
+        channel_id,
+        message_id: format!("msg-{guild_id}-{channel_id}"),
     })
 }
 
@@ -124,11 +265,7 @@ async fn rest_auth_middleware(
         "REST auth accepted"
     );
 
-    let action = match request_method {
-        axum::http::Method::GET | axum::http::Method::HEAD => AuthzAction::View,
-        axum::http::Method::POST => AuthzAction::Post,
-        _ => AuthzAction::Manage,
-    };
+    let action = rest_authz_action_from_method(&request_method);
     let action_label = match action {
         AuthzAction::Connect => "connect",
         AuthzAction::View => "view",
@@ -137,9 +274,7 @@ async fn rest_auth_middleware(
     };
     let authz_input = AuthzCheckInput {
         principal_id: authenticated.principal_id,
-        resource: AuthzResource::RestPath {
-            path: request_path.clone(),
-        },
+        resource: rest_authz_resource_from_path(&request_path),
         action,
     };
     if let Err(error) = state.authorizer.check(&authz_input).await {
@@ -164,4 +299,73 @@ async fn rest_auth_middleware(
     });
 
     next.run(request).await
+}
+
+/// RESTメソッドから AuthZ action を決定する。
+/// @param method HTTP メソッド
+/// @returns AuthZ action
+/// @throws なし
+fn rest_authz_action_from_method(method: &axum::http::Method) -> AuthzAction {
+    match method {
+        &axum::http::Method::GET | &axum::http::Method::HEAD => AuthzAction::View,
+        &axum::http::Method::POST => AuthzAction::Post,
+        _ => AuthzAction::Manage,
+    }
+}
+
+/// RESTパスから AuthZ resource を決定する。
+/// @param path リクエストパス
+/// @returns AuthZ resource
+/// @throws なし
+fn rest_authz_resource_from_path(path: &str) -> AuthzResource {
+    if let Some((guild_id, channel_id)) = parse_guild_channel_path(path) {
+        return AuthzResource::GuildChannel {
+            guild_id,
+            channel_id,
+        };
+    }
+    if let Some(guild_id) = parse_guild_path(path) {
+        return AuthzResource::Guild { guild_id };
+    }
+    AuthzResource::RestPath {
+        path: path.to_owned(),
+    }
+}
+
+/// ギルドパスから guild_id を抽出する。
+/// @param path リクエストパス
+/// @returns guild_id
+/// @throws なし
+fn parse_guild_path(path: &str) -> Option<i64> {
+    let segments = path
+        .trim_matches('/')
+        .split('/')
+        .collect::<Vec<_>>();
+    if segments.len() != 3 {
+        return None;
+    }
+    if segments[0] != "v1" || segments[1] != "guilds" {
+        return None;
+    }
+    segments[2].parse::<i64>().ok()
+}
+
+/// ギルドチャンネルパスから guild_id/channel_id を抽出する。
+/// @param path リクエストパス
+/// @returns guild_id と channel_id
+/// @throws なし
+fn parse_guild_channel_path(path: &str) -> Option<(i64, i64)> {
+    let segments = path
+        .trim_matches('/')
+        .split('/')
+        .collect::<Vec<_>>();
+    if segments.len() < 5 {
+        return None;
+    }
+    if segments[0] != "v1" || segments[1] != "guilds" || segments[3] != "channels" {
+        return None;
+    }
+    let guild_id = segments[2].parse::<i64>().ok()?;
+    let channel_id = segments[4].parse::<i64>().ok()?;
+    Some((guild_id, channel_id))
 }

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -7,7 +7,7 @@ mod tests {
         PrincipalProvisioner, PrincipalResolver, PrincipalStore, TokenVerifier, TokenVerifyError,
         VerifiedToken,
     };
-    use authz::{Authorizer, AuthzCheckInput, AuthzError};
+    use authz::{Authorizer, AuthzAction, AuthzCheckInput, AuthzError, AuthzResource};
     use axum::{body::to_bytes, http::StatusCode};
     use linklynx_shared::PrincipalId;
     use tower::ServiceExt;
@@ -18,6 +18,7 @@ mod tests {
     struct StaticAllowAllAuthorizer;
     struct StaticDenyAuthorizer;
     struct StaticUnavailableAuthorizer;
+    struct RoleScenarioAuthorizer;
 
     #[async_trait]
     impl TokenVerifier for StaticTokenVerifier {
@@ -65,6 +66,42 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl Authorizer for RoleScenarioAuthorizer {
+        async fn check(&self, input: &AuthzCheckInput) -> Result<(), AuthzError> {
+            match (&input.resource, input.action) {
+                (AuthzResource::Guild { .. }, AuthzAction::Manage) => {
+                    if input.principal_id.0 == 9001 || input.principal_id.0 == 9002 {
+                        Ok(())
+                    } else {
+                        Err(AuthzError::denied("guild_manage_denied"))
+                    }
+                }
+                (AuthzResource::Guild { .. }, AuthzAction::View) => {
+                    if input.principal_id.0 == 9001
+                        || input.principal_id.0 == 9002
+                        || input.principal_id.0 == 9003
+                    {
+                        Ok(())
+                    } else {
+                        Err(AuthzError::denied("guild_view_denied"))
+                    }
+                }
+                (AuthzResource::GuildChannel { .. }, AuthzAction::View | AuthzAction::Post) => {
+                    if input.principal_id.0 == 9001
+                        || input.principal_id.0 == 9002
+                        || input.principal_id.0 == 9003
+                    {
+                        Ok(())
+                    } else {
+                        Err(AuthzError::denied("guild_channel_access_denied"))
+                    }
+                }
+                _ => Ok(()),
+            }
+        }
+    }
+
     async fn app_for_test() -> Router {
         app_for_test_with_authorizer(Arc::new(StaticAllowAllAuthorizer)).await
     }
@@ -75,6 +112,9 @@ mod tests {
 
         let store = Arc::new(InMemoryPrincipalStore::default());
         store.insert("firebase", "u-1", PrincipalId(1001)).await;
+        store.insert("firebase", "u-owner", PrincipalId(9001)).await;
+        store.insert("firebase", "u-admin", PrincipalId(9002)).await;
+        store.insert("firebase", "u-member", PrincipalId(9003)).await;
         let store_resolver: Arc<dyn PrincipalStore> = store.clone();
         let provisioner: Arc<dyn PrincipalProvisioner> = store.clone();
 
@@ -242,6 +282,106 @@ mod tests {
         let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
         assert_eq!(json["code"], "AUTHZ_UNAVAILABLE");
         assert_eq!(json["request_id"], "authz-unavailable-test");
+    }
+
+    #[tokio::test]
+    async fn guild_channel_message_endpoints_apply_role_based_allow_and_deny() {
+        let app = app_for_test_with_authorizer(Arc::new(RoleScenarioAuthorizer)).await;
+
+        let owner_token = format!("u-owner:{}", unix_timestamp_seconds() + 300);
+        let owner_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/guilds/10")
+                    .header("authorization", format!("Bearer {owner_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(owner_response.status(), StatusCode::OK);
+
+        let admin_token = format!("u-admin:{}", unix_timestamp_seconds() + 300);
+        let admin_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/v1/guilds/10")
+                    .header("authorization", format!("Bearer {admin_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(admin_response.status(), StatusCode::OK);
+
+        let member_token = format!("u-member:{}", unix_timestamp_seconds() + 300);
+        let member_manage_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/v1/guilds/10")
+                    .header("authorization", format!("Bearer {member_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(member_manage_response.status(), StatusCode::FORBIDDEN);
+
+        let member_channel_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/guilds/10/channels/20")
+                    .header("authorization", format!("Bearer {member_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(member_channel_response.status(), StatusCode::OK);
+
+        let member_message_response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/guilds/10/channels/20/messages")
+                    .header("authorization", format!("Bearer {member_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(member_message_response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn guild_endpoint_returns_unavailable_when_authz_unavailable() {
+        let app = app_for_test_with_authorizer(Arc::new(StaticUnavailableAuthorizer)).await;
+        let token = format!("u-owner:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/guilds/10")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("x-request-id", "guild-authz-unavailable-test")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "AUTHZ_UNAVAILABLE");
+        assert_eq!(json["request_id"], "guild-authz-unavailable-test");
     }
 
     #[test]


### PR DESCRIPTION
## 概要
- LIN-866 として Guild/Channel/Message 系の最小RESTエンドポイントを Rust API に追加し、`rest_auth_middleware` 経由で AuthZ 適用を固定しました。
- `AuthzResource` を `Guild` / `GuildChannel` に拡張し、SpiceDB provider 側の object/permission 写像を LIN-862 契約に合わせて追加しました。
- deny/unavailable 境界（403/503）を既存契約のまま維持し、role相当シナリオのテストを追加しました。

## 変更内容
- `rust/apps/api/src/main/http_routes.rs`
  - 追加 endpoint
    - `GET /v1/guilds/{guild_id}`
    - `PATCH /v1/guilds/{guild_id}`
    - `GET /v1/guilds/{guild_id}/channels/{channel_id}`
    - `GET /v1/guilds/{guild_id}/channels/{channel_id}/messages`
    - `POST /v1/guilds/{guild_id}/channels/{channel_id}/messages`
  - `rest_auth_middleware` の resource/action 写像を拡張
- `rust/apps/api/src/authz/service.rs`
  - `AuthzResource::Guild` / `AuthzResource::GuildChannel` を追加
  - SpiceDB check mapping を拡張
    - `Guild + View/Manage` -> `guild:{id}` + `can_view/can_manage`
    - `GuildChannel + View/Post/Manage` -> `channel:{id}` + `can_view/can_post/can_manage`
- `rust/apps/api/src/main/tests.rs`
  - owner/admin/member 相当の allow/deny テストを追加
  - dependency unavailable の 503 維持テストを Guild endpoint で追加
- `rust/apps/api/src/authz/tests.rs`
  - SpiceDB request body を捕捉し、Guild/Channel mapping の object/permission を検証するテストを追加
- `docs/AUTHZ_API_MATRIX.md`
  - LIN-866 対象 endpoint と `principal/resource/action` マトリクスを追加
- `docs/agent_runs/LIN-860/Documentation.md`
  - LIN-866 実行証跡を追記

## 受け入れ条件との対応
- 対象REST APIで権限不足が正しく拒否される
  - `guild_channel_message_endpoints_apply_role_based_allow_and_deny` で member の guild manage を `403` で固定
- dependency unavailable 時の fail-close（503）維持
  - `guild_endpoint_returns_unavailable_when_authz_unavailable` で `503/AUTHZ_UNAVAILABLE` を固定
- 既存成功ケースの退行なし
  - 既存 `protected_ping` 系テストを含め `make rust-lint` で全通過

## 検証結果
- `make rust-lint`: passed
- `make validate`: failed（`typescript` の `node_modules` 未導入により `prettier: command not found`）

## レビュー結果
- `reviewer_simple`: unavailable（agent type unavailable）
- manual self-review fallback: blocking findings なし
- `reviewer_ui_guard`: unavailable（agent type unavailable）
- UI変更なしのため `reviewer_ui` は skip

## ADR-001 チェック
- 結果: 対象外
- 理由: event schema / event contract の変更は含まない

## 互換性判断
- additive / backward-compatible
- 既存エンドポイント契約を壊さずに AuthZ 適用対象を拡張

## Linear
- LIN-866
