### PR TITLE
[v1/AuthZ-SpiceDB-07] 既存REST/WS API権限適用（Invite/DM/Moderation/WS）

### DIFF
--- a/docs/AUTHZ.md
+++ b/docs/AUTHZ.md
@@ -215,3 +215,14 @@ v0 での認可関連 SoR:
   - allow TTL: `AUTHZ_CACHE_ALLOW_TTL_MS=5000`
   - deny TTL: `AUTHZ_CACHE_DENY_TTL_MS=1000`
   - retry/backoff: `SPICEDB_CHECK_MAX_RETRIES` / `SPICEDB_CHECK_RETRY_BACKOFF_MS`
+
+## 14. LIN-867 Invite/DM/Moderation/WS apply baseline
+
+- Invite/DM/Moderation 系 REST を `rest_auth_middleware` 保護配下に追加し、既存の `error.code/message/details/requestId` 契約を維持する。
+- path->resource の追加写像（current baseline）は以下で固定する。
+  - `/v1/guilds/{guild_id}/invites/{invite_code}` -> `AuthzResource::Guild { guild_id }`
+  - `/v1/dms/{channel_id}` / `/v1/dms/{channel_id}/messages` -> `AuthzResource::Channel { channel_id }`
+  - `/v1/moderation/guilds/{guild_id}/...` -> `AuthzResource::Guild { guild_id }`
+- WS は handshake/reauth（`Session + Connect`）に加えて、接続後メッセージ処理（`/ws/stream`）でも AuthZ を評価する。
+  - deny: close `1008`（`AUTHZ_DENIED`）
+  - unavailable: close `1011`（`AUTHZ_UNAVAILABLE`）

--- a/docs/AUTHZ_API_MATRIX.md
+++ b/docs/AUTHZ_API_MATRIX.md
@@ -31,6 +31,11 @@
 | GET | `/v1/guilds/:guild_id/channels/:channel_id` | Protected | 必須 | 必須 | Channel参照 |
 | GET | `/v1/guilds/:guild_id/channels/:channel_id/messages` | Protected | 必須 | 必須 | Message一覧参照 |
 | POST | `/v1/guilds/:guild_id/channels/:channel_id/messages` | Protected | 必須 | 必須 | Message投稿 |
+| GET | `/v1/guilds/:guild_id/invites/:invite_code` | Protected | 必須 | 必須 | Invite参照 |
+| GET | `/v1/dms/:channel_id` | Protected | 必須 | 必須 | DM channel参照 |
+| GET | `/v1/dms/:channel_id/messages` | Protected | 必須 | 必須 | DM message一覧参照 |
+| POST | `/v1/dms/:channel_id/messages` | Protected | 必須 | 必須 | DM message投稿 |
+| PATCH | `/v1/moderation/guilds/:guild_id/members/:member_id` | Protected | 必須 | 必須 | Moderation操作 |
 
 ### 2.2 WebSocket endpoint
 
@@ -52,8 +57,14 @@
 - `GET /v1/guilds/:guild_id/channels/:channel_id`
 - `GET /v1/guilds/:guild_id/channels/:channel_id/messages`
 - `POST /v1/guilds/:guild_id/channels/:channel_id/messages`
+- `GET /v1/guilds/:guild_id/invites/:invite_code`
+- `GET /v1/dms/:channel_id`
+- `GET /v1/dms/:channel_id/messages`
+- `POST /v1/dms/:channel_id/messages`
+- `PATCH /v1/moderation/guilds/:guild_id/members/:member_id`
 - `GET /ws`（upgrade handshake）
 - `auth.reauthenticate` 処理時の再認証 AuthZ
+- 再認証待機外のWSテキスト/バイナリメッセージ（`/ws/stream`）
 
 ## 4. Principal / Resource / Action matrix
 
@@ -67,8 +78,14 @@
 | REST | `GET /v1/guilds/:guild_id/channels/:channel_id` | AuthN済み `principal_id` | `AuthzResource::GuildChannel { guild_id, channel_id }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
 | REST | `GET /v1/guilds/:guild_id/channels/:channel_id/messages` | AuthN済み `principal_id` | `AuthzResource::GuildChannel { guild_id, channel_id }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
 | REST | `POST /v1/guilds/:guild_id/channels/:channel_id/messages` | AuthN済み `principal_id` | `AuthzResource::GuildChannel { guild_id, channel_id }` | `Post` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `GET /v1/guilds/:guild_id/invites/:invite_code` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `GET /v1/dms/:channel_id` | AuthN済み `principal_id` | `AuthzResource::Channel { channel_id }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `GET /v1/dms/:channel_id/messages` | AuthN済み `principal_id` | `AuthzResource::Channel { channel_id }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `POST /v1/dms/:channel_id/messages` | AuthN済み `principal_id` | `AuthzResource::Channel { channel_id }` | `Post` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `PATCH /v1/moderation/guilds/:guild_id/members/:member_id` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
 | WS | `/ws` handshake | AuthN済み `principal_id` | `AuthzResource::Session` | `Connect` | deny=`1008`, unavailable=`1011` |
 | WS | `auth.reauthenticate` | AuthN済み `principal_id` | `AuthzResource::Session` | `Connect` | deny=`1008`, unavailable=`1011` |
+| WS | stream text/binary message | AuthN済み `principal_id` | `AuthzResource::RestPath { path: "/ws/stream" }` | `View` | deny=`1008`, unavailable=`1011` |
 
 ### 4.2 REST action mapping rule
 
@@ -84,7 +101,8 @@
 
 ### Client -> Server
 - `auth.reauthenticate`（token付き）
-- その他テキスト（reauth要求中は拒否、通常時はecho）
+- その他テキスト（reauth要求中は拒否、通常時はAuthZ通過後にecho）
+- バイナリ（reauth要求中は拒否、通常時はAuthZ通過時のみ継続）
 
 ### Server -> Client
 - `auth.reauthenticate`（再認証要求）

--- a/docs/agent_runs/LIN-860/Documentation.md
+++ b/docs/agent_runs/LIN-860/Documentation.md
@@ -2,7 +2,7 @@
 
 ## Status
 - In progress.
-- Current child issue: `LIN-866`.
+- Current child issue: `LIN-867`.
 
 ## Decisions
 - Parent/child execution order follows LIN-860 definition (`861 -> 868`).
@@ -267,6 +267,61 @@
 ## Per-child evidence (LIN-866)
 - issue: `LIN-866`
 - branch: `codex/LIN-866-authz-rest-guild-channel-message`
+- validation commands and results:
+  - `make rust-lint`: passed
+  - `make validate`: failed（environment dependency missing）
+- reviewer gate (`reviewer_simple`): unavailable -> manual self-review fallback (no blocking findings)
+- UI gate (`reviewer_ui_guard` / `reviewer_ui`): unavailable -> UI changesなしで `reviewer_ui` skipped
+- PR URL: https://github.com/LinkLynx-AI/LinkLynx-AI/pull/1034
+- PR base branch: `codex/lin-860`
+- merge/auto-merge status: merged (`2026-03-04T07:36:03Z`)
+
+## LIN-867 progress
+- branch: `codex/LIN-867-authz-rest-ws-invite-dm-moderation`
+- objective: Invite/DM/Moderation 系 REST と WS 接続後操作へ AuthZ 適用し、deny/unavailable 境界（403/503, 1008/1011）を維持
+- delivered:
+  - `rust/apps/api/src/main/http_routes.rs`
+    - 最小 REST endpoint を追加
+      - `GET /v1/guilds/{guild_id}/invites/{invite_code}`
+      - `GET /v1/dms/{channel_id}`
+      - `GET/POST /v1/dms/{channel_id}/messages`
+      - `PATCH /v1/moderation/guilds/{guild_id}/members/{member_id}`
+    - path->resource 写像を拡張
+      - invite path -> `AuthzResource::Guild`
+      - dm path -> `AuthzResource::Channel`
+      - moderation path -> `AuthzResource::Guild`
+  - `rust/apps/api/src/authz/service.rs`
+    - `AuthzResource::Channel` を追加
+    - SpiceDB mapping を追加
+      - `Channel + View/Post/Manage` -> `channel:{id}#can_view/can_post/can_manage`
+  - `rust/apps/api/src/main/ws_routes.rs`
+    - reauth待機外のテキスト/バイナリ処理で `AuthzResource::RestPath { path: \"/ws/stream\" } + View` を追加検証
+    - deny/unavailable 時の close code を `1008/1011` で維持
+  - `rust/apps/api/src/main/tests.rs` / `rust/apps/api/src/authz/tests.rs`
+    - Invite/DM/Moderation allow/deny/unavailable テストを追加
+    - DM channel の SpiceDB request mapping テストを追加
+  - `docs/AUTHZ_API_MATRIX.md` / `docs/AUTHZ.md`
+    - LIN-867 対象 endpoint と WS stream operation のマトリクス・契約注記を追記
+
+## Validation results (LIN-867)
+- `make rust-lint`: passed
+- `make validate`: failed（`typescript` の `node_modules` 未導入により `prettier: command not found`）
+
+## Review results (LIN-867)
+- `reviewer_simple`: unavailable in current execution environment（agent type unavailable）
+- Manual self-review fallback:
+  - Invite/DM/Moderation endpoint が `rest_auth_middleware` を経由することを確認
+  - WS stream operation での AuthZ 拒否時 close code 境界（1008/1011）を確認
+  - `AuthzResource::Channel` の SpiceDB request mapping をテストで固定
+  - blocking findings: none
+- `reviewer_ui_guard`: unavailable in current execution environment（agent type unavailable）
+- UI gate fallback:
+  - changed files are backend/docs only, no frontend/UI files
+  - `reviewer_ui`: skipped（UI changesなし）
+
+## Per-child evidence (LIN-867)
+- issue: `LIN-867`
+- branch: `codex/LIN-867-authz-rest-ws-invite-dm-moderation`
 - validation commands and results:
   - `make rust-lint`: passed
   - `make validate`: failed（environment dependency missing）

--- a/rust/apps/api/src/authz/service.rs
+++ b/rust/apps/api/src/authz/service.rs
@@ -20,6 +20,7 @@ pub enum AuthzResource {
     Session,
     Guild { guild_id: i64 },
     GuildChannel { guild_id: i64, channel_id: i64 },
+    Channel { channel_id: i64 },
     RestPath { path: String },
 }
 
@@ -367,6 +368,30 @@ impl SpiceDbHttpAuthorizer {
             (AuthzResource::GuildChannel { .. }, _) => {
                 return Err(AuthzError::denied("guild_channel_action_not_supported"));
             }
+            (AuthzResource::Channel { channel_id }, AuthzAction::View) => (
+                SpiceDbObjectReference {
+                    object_type: "channel".to_owned(),
+                    object_id: channel_id.to_string(),
+                },
+                "can_view".to_owned(),
+            ),
+            (AuthzResource::Channel { channel_id }, AuthzAction::Post) => (
+                SpiceDbObjectReference {
+                    object_type: "channel".to_owned(),
+                    object_id: channel_id.to_string(),
+                },
+                "can_post".to_owned(),
+            ),
+            (AuthzResource::Channel { channel_id }, AuthzAction::Manage) => (
+                SpiceDbObjectReference {
+                    object_type: "channel".to_owned(),
+                    object_id: channel_id.to_string(),
+                },
+                "can_manage".to_owned(),
+            ),
+            (AuthzResource::Channel { .. }, _) => {
+                return Err(AuthzError::denied("channel_action_not_supported"));
+            }
             (AuthzResource::RestPath { path }, AuthzAction::View) => (
                 SpiceDbObjectReference {
                     object_type: "api_path".to_owned(),
@@ -526,6 +551,7 @@ fn authz_resource_label(resource: &AuthzResource) -> String {
             guild_id,
             channel_id,
         } => format!("guild:{guild_id}/channel:{channel_id}"),
+        AuthzResource::Channel { channel_id } => format!("channel:{channel_id}"),
         AuthzResource::RestPath { path } => path.clone(),
     }
 }
@@ -538,6 +564,7 @@ fn authz_resource_cache_key(resource: &AuthzResource) -> String {
             guild_id,
             channel_id,
         } => format!("guild:{guild_id}/channel:{channel_id}"),
+        AuthzResource::Channel { channel_id } => format!("channel:{channel_id}"),
         AuthzResource::RestPath { path } => format!("api_path:{path}"),
     }
 }

--- a/rust/apps/api/src/authz/tests.rs
+++ b/rust/apps/api/src/authz/tests.rs
@@ -343,6 +343,38 @@ mod tests {
         assert_eq!(requests[0]["permission"], "can_post");
     }
 
+    #[tokio::test]
+    async fn runtime_provider_spicedb_maps_dm_channel_post_to_can_post() {
+        let _guard = env_lock().lock().await;
+        let mock = MockSpiceDbServer::start(
+            vec![MockSpiceDbResponse::ok("PERMISSIONSHIP_HAS_PERMISSION")],
+            false,
+        )
+        .await;
+        let mut scoped = ScopedEnv::new();
+        scoped.set("AUTHZ_PROVIDER", "spicedb");
+        scoped.set("SPICEDB_ENDPOINT", "http://spicedb:50051");
+        scoped.set("SPICEDB_CHECK_ENDPOINT", &mock.endpoint());
+        scoped.set("SPICEDB_PRESHARED_KEY", "test-key");
+        scoped.set("SPICEDB_REQUEST_TIMEOUT_MS", "100");
+        scoped.set("SPICEDB_CHECK_MAX_RETRIES", "0");
+
+        let authorizer = build_runtime_authorizer();
+        let input = AuthzCheckInput {
+            principal_id: PrincipalId(4003),
+            resource: AuthzResource::Channel { channel_id: 88 },
+            action: AuthzAction::Post,
+        };
+
+        assert!(authorizer.check(&input).await.is_ok());
+        assert_eq!(mock.request_count(), 1);
+        let requests = mock.requests().await;
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["resource"]["objectType"], "channel");
+        assert_eq!(requests[0]["resource"]["objectId"], "88");
+        assert_eq!(requests[0]["permission"], "can_post");
+    }
+
     #[test]
     fn tuple_mapping_uses_canonical_relations() {
         let role_row = GuildRolePermissionRow {

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -13,6 +13,10 @@ fn app_with_state(state: AppState) -> Router {
         .route("/v1/guilds/{guild_id}", get(get_guild))
         .route("/v1/guilds/{guild_id}", axum::routing::patch(update_guild))
         .route(
+            "/v1/guilds/{guild_id}/invites/{invite_code}",
+            get(get_guild_invite),
+        )
+        .route(
             "/v1/guilds/{guild_id}/channels/{channel_id}",
             get(get_guild_channel),
         )
@@ -23,6 +27,16 @@ fn app_with_state(state: AppState) -> Router {
         .route(
             "/v1/guilds/{guild_id}/channels/{channel_id}/messages",
             axum::routing::post(create_channel_message),
+        )
+        .route("/v1/dms/{channel_id}", get(get_dm_channel))
+        .route("/v1/dms/{channel_id}/messages", get(list_dm_messages))
+        .route(
+            "/v1/dms/{channel_id}/messages",
+            axum::routing::post(create_dm_message),
+        )
+        .route(
+            "/v1/moderation/guilds/{guild_id}/members/{member_id}",
+            axum::routing::patch(moderate_guild_member),
         )
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
@@ -100,6 +114,51 @@ struct GuildChannelMessageCreateResponse {
     message_id: String,
 }
 
+#[derive(Debug, Serialize)]
+struct GuildInviteResponse {
+    ok: bool,
+    request_id: String,
+    principal_id: i64,
+    guild_id: i64,
+    invite_code: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DmChannelResponse {
+    ok: bool,
+    request_id: String,
+    principal_id: i64,
+    channel_id: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct DmMessagesResponse {
+    ok: bool,
+    request_id: String,
+    principal_id: i64,
+    channel_id: i64,
+    messages: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DmMessageCreateResponse {
+    ok: bool,
+    request_id: String,
+    principal_id: i64,
+    channel_id: i64,
+    message_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ModerationActionResponse {
+    ok: bool,
+    request_id: String,
+    principal_id: i64,
+    guild_id: i64,
+    member_id: i64,
+    action: String,
+}
+
 /// 認証済みエンドポイントの疎通応答を返す。
 /// @param auth_context 認証文脈
 /// @returns 認証済み応答
@@ -146,6 +205,24 @@ async fn update_guild(
         request_id: auth_context.request_id,
         principal_id: auth_context.principal_id.0,
         guild_id,
+    })
+}
+
+/// ギルド招待情報の最小応答を返す。
+/// @param path guild_id と invite_code を含むパス
+/// @param auth_context 認証文脈
+/// @returns 招待情報最小応答
+/// @throws なし
+async fn get_guild_invite(
+    axum::extract::Path((guild_id, invite_code)): axum::extract::Path<(i64, String)>,
+    Extension(auth_context): Extension<AuthContext>,
+) -> Json<GuildInviteResponse> {
+    Json(GuildInviteResponse {
+        ok: true,
+        request_id: auth_context.request_id,
+        principal_id: auth_context.principal_id.0,
+        guild_id,
+        invite_code,
     })
 }
 
@@ -202,6 +279,78 @@ async fn create_channel_message(
         guild_id,
         channel_id,
         message_id: format!("msg-{guild_id}-{channel_id}"),
+    })
+}
+
+/// DMチャンネル情報の最小応答を返す。
+/// @param path channel_id を含むパス
+/// @param auth_context 認証文脈
+/// @returns DMチャンネル最小応答
+/// @throws なし
+async fn get_dm_channel(
+    axum::extract::Path(channel_id): axum::extract::Path<i64>,
+    Extension(auth_context): Extension<AuthContext>,
+) -> Json<DmChannelResponse> {
+    Json(DmChannelResponse {
+        ok: true,
+        request_id: auth_context.request_id,
+        principal_id: auth_context.principal_id.0,
+        channel_id,
+    })
+}
+
+/// DMメッセージ一覧の最小応答を返す。
+/// @param path channel_id を含むパス
+/// @param auth_context 認証文脈
+/// @returns DMメッセージ一覧最小応答
+/// @throws なし
+async fn list_dm_messages(
+    axum::extract::Path(channel_id): axum::extract::Path<i64>,
+    Extension(auth_context): Extension<AuthContext>,
+) -> Json<DmMessagesResponse> {
+    Json(DmMessagesResponse {
+        ok: true,
+        request_id: auth_context.request_id,
+        principal_id: auth_context.principal_id.0,
+        channel_id,
+        messages: Vec::new(),
+    })
+}
+
+/// DMメッセージ作成の最小応答を返す。
+/// @param path channel_id を含むパス
+/// @param auth_context 認証文脈
+/// @returns DMメッセージ作成最小応答
+/// @throws なし
+async fn create_dm_message(
+    axum::extract::Path(channel_id): axum::extract::Path<i64>,
+    Extension(auth_context): Extension<AuthContext>,
+) -> Json<DmMessageCreateResponse> {
+    Json(DmMessageCreateResponse {
+        ok: true,
+        request_id: auth_context.request_id,
+        principal_id: auth_context.principal_id.0,
+        channel_id,
+        message_id: format!("dm-msg-{channel_id}"),
+    })
+}
+
+/// モデレーション操作の最小応答を返す。
+/// @param path guild_id と member_id を含むパス
+/// @param auth_context 認証文脈
+/// @returns モデレーション最小応答
+/// @throws なし
+async fn moderate_guild_member(
+    axum::extract::Path((guild_id, member_id)): axum::extract::Path<(i64, i64)>,
+    Extension(auth_context): Extension<AuthContext>,
+) -> Json<ModerationActionResponse> {
+    Json(ModerationActionResponse {
+        ok: true,
+        request_id: auth_context.request_id,
+        principal_id: auth_context.principal_id.0,
+        guild_id,
+        member_id,
+        action: "moderate_member".to_owned(),
     })
 }
 
@@ -324,6 +473,15 @@ fn rest_authz_resource_from_path(path: &str) -> AuthzResource {
             channel_id,
         };
     }
+    if let Some(channel_id) = parse_dm_channel_path(path) {
+        return AuthzResource::Channel { channel_id };
+    }
+    if let Some(guild_id) = parse_guild_invite_path(path) {
+        return AuthzResource::Guild { guild_id };
+    }
+    if let Some(guild_id) = parse_moderation_guild_path(path) {
+        return AuthzResource::Guild { guild_id };
+    }
     if let Some(guild_id) = parse_guild_path(path) {
         return AuthzResource::Guild { guild_id };
     }
@@ -368,4 +526,49 @@ fn parse_guild_channel_path(path: &str) -> Option<(i64, i64)> {
     let guild_id = segments[2].parse::<i64>().ok()?;
     let channel_id = segments[4].parse::<i64>().ok()?;
     Some((guild_id, channel_id))
+}
+
+/// ギルド招待パスから guild_id を抽出する。
+/// @param path リクエストパス
+/// @returns guild_id
+/// @throws なし
+fn parse_guild_invite_path(path: &str) -> Option<i64> {
+    let segments = path.trim_matches('/').split('/').collect::<Vec<_>>();
+    if segments.len() != 5 {
+        return None;
+    }
+    if segments[0] != "v1" || segments[1] != "guilds" || segments[3] != "invites" {
+        return None;
+    }
+    segments[2].parse::<i64>().ok()
+}
+
+/// DMパスから channel_id を抽出する。
+/// @param path リクエストパス
+/// @returns channel_id
+/// @throws なし
+fn parse_dm_channel_path(path: &str) -> Option<i64> {
+    let segments = path.trim_matches('/').split('/').collect::<Vec<_>>();
+    if segments.len() < 3 {
+        return None;
+    }
+    if segments[0] != "v1" || segments[1] != "dms" {
+        return None;
+    }
+    segments[2].parse::<i64>().ok()
+}
+
+/// モデレーションパスから guild_id を抽出する。
+/// @param path リクエストパス
+/// @returns guild_id
+/// @throws なし
+fn parse_moderation_guild_path(path: &str) -> Option<i64> {
+    let segments = path.trim_matches('/').split('/').collect::<Vec<_>>();
+    if segments.len() < 4 {
+        return None;
+    }
+    if segments[0] != "v1" || segments[1] != "moderation" || segments[2] != "guilds" {
+        return None;
+    }
+    segments[3].parse::<i64>().ok()
 }

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -97,7 +97,17 @@ mod tests {
                         Err(AuthzError::denied("guild_channel_access_denied"))
                     }
                 }
-                _ => Ok(()),
+                (AuthzResource::Channel { .. }, AuthzAction::View | AuthzAction::Post) => {
+                    if input.principal_id.0 == 9001
+                        || input.principal_id.0 == 9002
+                        || input.principal_id.0 == 9003
+                    {
+                        Ok(())
+                    } else {
+                        Err(AuthzError::denied("dm_channel_access_denied"))
+                    }
+                }
+                _ => Err(AuthzError::denied("unsupported_role_scenario")),
             }
         }
     }
@@ -382,6 +392,125 @@ mod tests {
         let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
         assert_eq!(json["code"], "AUTHZ_UNAVAILABLE");
         assert_eq!(json["request_id"], "guild-authz-unavailable-test");
+    }
+
+    #[tokio::test]
+    async fn invite_dm_moderation_endpoints_apply_role_based_allow_and_deny() {
+        let app = app_for_test_with_authorizer(Arc::new(RoleScenarioAuthorizer)).await;
+
+        let owner_token = format!("u-owner:{}", unix_timestamp_seconds() + 300);
+        let owner_invite_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/guilds/10/invites/invite-abc")
+                    .header("authorization", format!("Bearer {owner_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(owner_invite_response.status(), StatusCode::OK);
+
+        let member_token = format!("u-member:{}", unix_timestamp_seconds() + 300);
+        let member_dm_get_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/dms/55/messages")
+                    .header("authorization", format!("Bearer {member_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(member_dm_get_response.status(), StatusCode::OK);
+
+        let member_dm_post_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/dms/55/messages")
+                    .header("authorization", format!("Bearer {member_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(member_dm_post_response.status(), StatusCode::OK);
+
+        let member_moderation_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/v1/moderation/guilds/10/members/9003")
+                    .header("authorization", format!("Bearer {member_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(member_moderation_response.status(), StatusCode::FORBIDDEN);
+
+        let admin_token = format!("u-admin:{}", unix_timestamp_seconds() + 300);
+        let admin_moderation_response = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/v1/moderation/guilds/10/members/9003")
+                    .header("authorization", format!("Bearer {admin_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(admin_moderation_response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn moderation_endpoint_returns_unavailable_when_authz_unavailable() {
+        let app = app_for_test_with_authorizer(Arc::new(StaticUnavailableAuthorizer)).await;
+        let token = format!("u-owner:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/v1/moderation/guilds/10/members/9003")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("x-request-id", "moderation-authz-unavailable-test")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "AUTHZ_UNAVAILABLE");
+        assert_eq!(json["request_id"], "moderation-authz-unavailable-test");
+    }
+
+    #[test]
+    fn rest_authz_resource_maps_invite_dm_and_moderation_paths() {
+        match rest_authz_resource_from_path("/v1/guilds/10/invites/invite-abc") {
+            AuthzResource::Guild { guild_id } => assert_eq!(guild_id, 10),
+            _ => panic!("invite path should map to guild resource"),
+        }
+
+        match rest_authz_resource_from_path("/v1/dms/55/messages") {
+            AuthzResource::Channel { channel_id } => assert_eq!(channel_id, 55),
+            _ => panic!("dm path should map to channel resource"),
+        }
+
+        match rest_authz_resource_from_path("/v1/moderation/guilds/10/members/9003") {
+            AuthzResource::Guild { guild_id } => assert_eq!(guild_id, 10),
+            _ => panic!("moderation path should map to guild resource"),
+        }
     }
 
     #[test]

--- a/rust/apps/api/src/main/ws_routes.rs
+++ b/rust/apps/api/src/main/ws_routes.rs
@@ -314,12 +314,19 @@ async fn handle_socket_message(
                 return false;
             }
 
+            if !authorize_ws_stream_operation(state, authenticated, request_id, socket).await {
+                return false;
+            }
+
             socket.send(Message::Text(text.into())).await.is_ok()
         }
         Message::Binary(_) => {
             if reauth_deadline.is_some() {
                 state.auth_service.metrics().record_ws_reauth(false);
                 let _ = close_socket(socket, 1008, "reauth_required").await;
+                return false;
+            }
+            if !authorize_ws_stream_operation(state, authenticated, request_id, socket).await {
                 return false;
             }
             true
@@ -358,4 +365,42 @@ async fn close_socket(socket: &mut WebSocket, code: u16, reason: &str) -> Result
         .send(Message::Close(Some(frame)))
         .await
         .map_err(|_| ())
+}
+
+/// WS接続後メッセージ操作の認可を検証する。
+/// @param state アプリケーション状態
+/// @param authenticated 認証済み主体
+/// @param request_id 接続識別子
+/// @param socket WebSocket接続
+/// @returns 継続可否
+/// @throws なし
+async fn authorize_ws_stream_operation(
+    state: &AppState,
+    authenticated: &AuthenticatedPrincipal,
+    request_id: &str,
+    socket: &mut WebSocket,
+) -> bool {
+    let authz_input = AuthzCheckInput {
+        principal_id: authenticated.principal_id,
+        resource: AuthzResource::RestPath {
+            path: "/ws/stream".to_owned(),
+        },
+        action: AuthzAction::View,
+    };
+    if let Err(error) = state.authorizer.check(&authz_input).await {
+        tracing::warn!(
+            decision = %error.decision(),
+            request_id = %request_id,
+            principal_id = authenticated.principal_id.0,
+            error_class = %error.log_class(),
+            reason = %error.reason,
+            resource = "/ws/stream",
+            action = "view",
+            decision_source = "authorizer",
+            "WS authz rejected at stream operation"
+        );
+        let _ = close_socket(socket, error.ws_close_code(), error.app_code()).await;
+        return false;
+    }
+    true
 }


### PR DESCRIPTION
## 概要
- Invite/DM/Moderation 系 REST と WS 接続後メッセージ経路に AuthZ 適用を追加しました。
- LIN-866 で導入した Guild/Channel/Message 適用に続き、LIN-867 対象範囲で fail-close 境界（REST: 403/503, WS: 1008/1011）を維持しています。

## 変更内容
- `rust/apps/api/src/main/http_routes.rs`
  - 追加 endpoint
    - `GET /v1/guilds/{guild_id}/invites/{invite_code}`
    - `GET /v1/dms/{channel_id}`
    - `GET/POST /v1/dms/{channel_id}/messages`
    - `PATCH /v1/moderation/guilds/{guild_id}/members/{member_id}`
  - `rest_authz_resource_from_path` を拡張
    - invite path -> `AuthzResource::Guild`
    - dm path -> `AuthzResource::Channel`
    - moderation path -> `AuthzResource::Guild`
- `rust/apps/api/src/authz/service.rs`
  - `AuthzResource::Channel` を追加
  - SpiceDB mapping を追加
    - `Channel + View/Post/Manage` -> `channel:{id}` + `can_view/can_post/can_manage`
- `rust/apps/api/src/main/ws_routes.rs`
  - reauth待機外のWSテキスト/バイナリ処理に `/ws/stream` 向け AuthZ check を追加
  - deny/unavailable 時の close code を `1008/1011` で維持
- `rust/apps/api/src/main/tests.rs` / `rust/apps/api/src/authz/tests.rs`
  - Invite/DM/Moderation allow/deny/unavailable テスト追加
  - DM channel の SpiceDB request mapping テスト追加
- `docs/AUTHZ_API_MATRIX.md` / `docs/AUTHZ.md`
  - LIN-867 対象 endpoint と WS stream operation のマトリクス/契約を追記

## 受け入れ条件との対応
- 主要経路で権限境界が一貫
  - Invite/DM/Moderation は REST middleware の resource/action 写像で統一
  - WS stream operation でも AuthZ を実行
- 非許可ユーザーの拒否
  - `invite_dm_moderation_endpoints_apply_role_based_allow_and_deny` で deny ケースを固定
- 依存障害時 fail-close
  - `moderation_endpoint_returns_unavailable_when_authz_unavailable`
  - WS stream operation は `error.ws_close_code()` で `1008/1011` を維持

## 検証結果
- `make rust-lint`: passed
- `make validate`: failed（`typescript` の `node_modules` 未導入により `prettier: command not found`）

## レビュー結果
- `reviewer_simple`: unavailable（agent type unavailable）
- `reviewer_ui_guard`: unavailable（agent type unavailable）
- manual self-review fallback: blocking findings なし
- UI変更なしのため `reviewer_ui` は skip

## ADR-001 チェック
- 結果: 対象外
- 理由: event schema / event contract の変更は含みません

## 互換性判断
- additive / backward-compatible
- 既存 endpoint の契約は維持し、AuthZ 適用面を追加する変更のみ

## Linear
- LIN-867
