### PR TITLE
LIN-868 AuthZ統合の観測性強化とSpiceDB回帰CI追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,25 @@ jobs:
           workspaces: rust
       - run: make validate
 
+  authz-spicedb-regression:
+    name: AuthZ SpiceDB Regression
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+      - name: Run SpiceDB provider and REST/WS authz regressions
+        run: |
+          cargo test -p linklynx_backend runtime_provider_spicedb_
+          cargo test -p linklynx_backend guild_channel_message_endpoints_apply_role_based_allow_and_deny
+          cargo test -p linklynx_backend invite_dm_moderation_endpoints_apply_role_based_allow_and_deny
+          cargo test -p linklynx_backend moderation_endpoint_returns_unavailable_when_authz_unavailable
+
   python-validate:
     name: Python Validate
     runs-on: ubuntu-latest

--- a/docs/AUTHZ.md
+++ b/docs/AUTHZ.md
@@ -226,3 +226,4 @@ v0 での認可関連 SoR:
 - WS は handshake/reauth（`Session + Connect`）に加えて、接続後メッセージ処理（`/ws/stream`）でも AuthZ を評価する。
   - deny: close `1008`（`AUTHZ_DENIED`）
   - unavailable: close `1011`（`AUTHZ_UNAVAILABLE`）
+- 最小観測基盤として `GET /internal/authz/metrics` を追加し、`allow_total` / `deny_total` / `unavailable_total` を公開する。

--- a/docs/AUTHZ_API_MATRIX.md
+++ b/docs/AUTHZ_API_MATRIX.md
@@ -13,7 +13,7 @@
 - 実装済みの AuthN/AuthZ 適用境界
 
 ### Out of scope
-- 未実装ドメインAPI（Guild/Channel/Message/Invite/DM/Moderation本体）の将来仕様
+- 各ドメインAPIの業務ロジック詳細仕様（本書はAuthZ境界と写像のみを扱う）
 - SpiceDBクライアント実装詳細
 
 ## 2. Endpoint inventory
@@ -25,6 +25,7 @@
 | GET | `/` | Public | なし | なし | ルート疎通 |
 | GET | `/health` | Public | なし | なし | ヘルスチェック |
 | GET | `/internal/auth/metrics` | Public | なし | なし | 認証メトリクス取得 |
+| GET | `/internal/authz/metrics` | Public | なし | なし | 認可メトリクス取得 |
 | GET | `/v1/protected/ping` | Protected | 必須 | 必須 | `rest_auth_middleware` を経由 |
 | GET | `/v1/guilds/:guild_id` | Protected | 必須 | 必須 | Guild参照 |
 | PATCH | `/v1/guilds/:guild_id` | Protected | 必須 | 必須 | Guild管理 |
@@ -49,6 +50,7 @@
 - `GET /`
 - `GET /health`
 - `GET /internal/auth/metrics`
+- `GET /internal/authz/metrics`
 
 ### Protected (AuthZ required)
 - `GET /v1/protected/ping`
@@ -111,4 +113,4 @@
 ## 6. Notes for downstream issues
 
 - `LIN-862` 以降は本マトリクスを入力に SpiceDB スキーマ・Tuple写像を設計する。
-- `LIN-867` で Invite/DM/Moderation/WS の追加適用時は、本ファイルに endpoint を追加する。
+- `LIN-868` では本マトリクスの allow/deny/unavailable 回帰をCIで検知できるよう統合テストを維持する。

--- a/docs/agent_runs/LIN-860/Documentation.md
+++ b/docs/agent_runs/LIN-860/Documentation.md
@@ -2,7 +2,7 @@
 
 ## Status
 - In progress.
-- Current child issue: `LIN-867`.
+- Current child issue: `LIN-868`.
 
 ## Decisions
 - Parent/child execution order follows LIN-860 definition (`861 -> 868`).
@@ -325,6 +325,58 @@
 - validation commands and results:
   - `make rust-lint`: passed
   - `make validate`: failed（environment dependency missing）
+- reviewer gate (`reviewer_simple`): unavailable -> manual self-review fallback (no blocking findings)
+- UI gate (`reviewer_ui_guard` / `reviewer_ui`): unavailable -> UI changesなしで `reviewer_ui` skipped
+- PR URL: https://github.com/LinkLynx-AI/LinkLynx-AI/pull/1035
+- PR base branch: `codex/lin-860`
+- merge/auto-merge status: merged (`2026-03-04T07:44:34Z`)
+
+## LIN-868 progress
+- branch: `codex/LIN-868-authz-integration-observability-cutover`
+- objective: SpiceDB経路の統合回帰固定、最小観測基盤、cutover/rollback runbook の実運用化
+- delivered:
+  - `rust/apps/api/src/authz/service.rs`
+    - `AuthzMetrics` / `AuthzMetricsSnapshot` を追加（`allow_total` / `deny_total` / `unavailable_total`）
+  - `rust/apps/api/src/main.rs`
+    - `AppState` に `authz_metrics` を追加
+  - `rust/apps/api/src/main/http_routes.rs`
+    - `GET /internal/authz/metrics` を追加
+    - REST authz 判定で allow/deny/unavailable をメトリクス記録
+  - `rust/apps/api/src/main/ws_routes.rs`
+    - handshake/reauth/stream operation のAuthZ判定結果をメトリクス記録
+  - `rust/apps/api/src/main/tests.rs`
+    - `authz_metrics` endpoint の allow/deny/unavailable カウント回帰テスト追加
+  - `.github/workflows/ci.yml`
+    - `AuthZ SpiceDB Regression` job を追加し、provider/REST-WS回帰テストを明示実行
+  - `docs/runbooks/authz-noop-allow-all-spicedb-handoff-runbook.md`
+    - cutover dry-run 手順、rollback 手順、観測/アラート観点を更新
+  - `docs/AUTHZ.md` / `docs/AUTHZ_API_MATRIX.md`
+    - metrics endpoint と LIN-868 downstream note を反映
+
+## Validation results (LIN-868)
+- `make rust-lint`: passed
+- `make validate`: failed（`typescript` の `node_modules` 未導入により `prettier: command not found`）
+- `cd typescript && npm run typecheck`: failed（`tsc: command not found`）
+
+## Review results (LIN-868)
+- `reviewer_simple`: unavailable in current execution environment（agent type unavailable）
+- Manual self-review fallback:
+  - REST/WSのAuthZ判定境界を維持したまま、観測メトリクスを additive に追加
+  - CI job で SpiceDB provider 経路の主要回帰が明示検知されることを確認
+  - handoff runbook の cutover/rollback 手順が staging dry-run 前提で再現可能な記述に更新
+  - blocking findings: none
+- `reviewer_ui_guard`: unavailable in current execution environment（agent type unavailable）
+- UI gate fallback:
+  - changed files are backend/docs/ci only, no frontend/UI files
+  - `reviewer_ui`: skipped（UI changesなし）
+
+## Per-child evidence (LIN-868)
+- issue: `LIN-868`
+- branch: `codex/LIN-868-authz-integration-observability-cutover`
+- validation commands and results:
+  - `make rust-lint`: passed
+  - `make validate`: failed（environment dependency missing）
+  - `cd typescript && npm run typecheck`: failed（environment dependency missing）
 - reviewer gate (`reviewer_simple`): unavailable -> manual self-review fallback (no blocking findings)
 - UI gate (`reviewer_ui_guard` / `reviewer_ui`): unavailable -> UI changesなしで `reviewer_ui` skipped
 - PR URL: pending（to be created）

--- a/docs/runbooks/authz-noop-allow-all-spicedb-handoff-runbook.md
+++ b/docs/runbooks/authz-noop-allow-all-spicedb-handoff-runbook.md
@@ -1,7 +1,7 @@
 # AuthZ noop allow-all Exception and SpiceDB Handoff Runbook
 
 - Status: Draft
-- Last updated: 2026-02-28
+- Last updated: 2026-03-04
 - Owner scope: v1 pre-release AuthZ exception management and SpiceDB cutover handoff
 - References:
   - [ADR-004 AuthZ Fail-Close Policy and Cache Strategy](../adr/ADR-004-authz-fail-close-and-cache-strategy.md)
@@ -29,7 +29,8 @@ Out of scope:
 
 - `AUTHZ_PROVIDER=noop` (default)
 - `AUTHZ_ALLOW_ALL_UNTIL=2026-06-30` (UTC date baseline)
-- `AUTHZ_PROVIDER=spicedb` is currently mapped to noop fallback until SpiceDB implementation is delivered.
+- `AUTHZ_PROVIDER=spicedb` uses active SpiceDB authorizer path and fail-close semantics.
+- implicit fallback from `spicedb` to `noop allow-all` is prohibited.
 
 ### 2.2 Risk statement
 
@@ -54,7 +55,7 @@ Out of scope:
 1. Confirm runtime logs include:
 - `AUTHZ_PROVIDER`
 - `AUTHZ_ALLOW_ALL_UNTIL`
-- fallback warning when `AUTHZ_PROVIDER=spicedb`
+- decision logs on deny/unavailable paths (`request_id`, `principal_id`, `resource`, `action`, `decision`, `error_class`)
 
 2. Confirm release gate check (required before release):
 - Run `printenv AUTHZ_PROVIDER` on release environment and confirm value is **not** `noop`.
@@ -85,8 +86,12 @@ Out of scope:
 Cutover readiness requires all items:
 - `AUTHZ_PROVIDER=spicedb` path returns deterministic deny/unavailable mapping per ADR-004.
 - Noop allow-all path is disabled in release configuration.
+- CI can detect SpiceDB path regressions via Rust tests (`make rust-lint`).
+- CI job `AuthZ SpiceDB Regression` runs focused provider/REST-path regressions.
 - Observability fields exist on AuthZ deny/unavailable paths:
   - `request_id`, `principal_id`, `resource`, `action`, `decision`, `decision_source`, `error_class`
+- Metrics endpoint exposes decision counters:
+  - `GET /internal/authz/metrics` -> `allow_total`, `deny_total`, `unavailable_total`
 - Validation gates pass:
   - `cd rust && cargo test -p linklynx_backend --locked`
   - `make rust-lint`
@@ -97,8 +102,13 @@ Cutover readiness requires all items:
 1. Freeze AuthZ-related config changes.
 2. Deploy SpiceDB-capable build to staging.
 3. Switch staging `AUTHZ_PROVIDER` from `noop` to `spicedb`.
-4. Run deny/unavailable scenario checks (REST + WS).
-5. Verify metrics and logs for decision quality.
+4. Execute dry-run checks:
+  - allow path: protected REST endpoint returns `2xx`
+  - deny path: protected REST endpoint returns `403` (`AUTHZ_DENIED`)
+  - unavailable path: stop SpiceDB and confirm REST `503` / WS `1011`
+5. Verify observability:
+  - logs include required decision fields
+  - `GET /internal/authz/metrics` counters increase in expected buckets
 6. Roll forward to production only after staged acceptance pass.
 
 ## 6. Rollback procedure
@@ -110,18 +120,24 @@ Rollback trigger examples:
 
 Rollback steps:
 1. Switch `AUTHZ_PROVIDER` back to `noop`.
-2. Confirm service stability and expected response mappings.
-3. Record incident, owner, and follow-up action with target date.
+2. Re-run smoke checks:
+  - protected REST baseline succeeds for known test principal
+  - WS handshake/reauth baseline succeeds
+3. Confirm `unavailable_total` increase has stopped and error logs stabilized.
+4. Record incident, owner, and follow-up action with target date.
 
 ## 7. Observability minimum
 
 During exception and cutover windows, monitor at minimum:
 - request-level authz reject logs with required fields
-- ratio of unavailable decisions
+- decision counters from `GET /internal/authz/metrics`
+  - `allow_total`
+  - `deny_total`
+  - `unavailable_total`
 - ws close code distribution (`1008`, `1011`)
 
 Alert viewpoints:
-1. sudden increase of unavailable decisions
+1. sudden increase of `unavailable_total` growth rate
 2. mismatch between expected deny and observed unavailable
 3. handshake/reauth close-code mismatch in WS logs
 

--- a/rust/apps/api/src/authz/service.rs
+++ b/rust/apps/api/src/authz/service.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    sync::atomic::{AtomicU64, Ordering},
     time::{Duration, Instant},
 };
 
@@ -41,6 +42,59 @@ pub trait Authorizer: Send + Sync {
     /// @returns 許可時は `Ok(())`
     /// @throws AuthzError 拒否または依存障害時
     async fn check(&self, input: &AuthzCheckInput) -> Result<(), AuthzError>;
+}
+
+/// 認可判定メトリクスを表現する。
+#[derive(Debug, Default)]
+pub struct AuthzMetrics {
+    allow_total: AtomicU64,
+    deny_total: AtomicU64,
+    unavailable_total: AtomicU64,
+}
+
+/// 認可判定メトリクスのスナップショットを表現する。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AuthzMetricsSnapshot {
+    allow_total: u64,
+    deny_total: u64,
+    unavailable_total: u64,
+}
+
+impl AuthzMetrics {
+    /// 認可許可メトリクスを記録する。
+    /// @param なし
+    /// @returns なし
+    /// @throws なし
+    pub fn record_allow(&self) {
+        self.allow_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// 認可拒否/判定不能メトリクスを記録する。
+    /// @param error 認可エラー
+    /// @returns なし
+    /// @throws なし
+    pub fn record_error(&self, error: &AuthzError) {
+        match error.kind {
+            AuthzErrorKind::Denied => {
+                self.deny_total.fetch_add(1, Ordering::Relaxed);
+            }
+            AuthzErrorKind::DependencyUnavailable => {
+                self.unavailable_total.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// 現在の認可判定メトリクスを取得する。
+    /// @param なし
+    /// @returns メトリクススナップショット
+    /// @throws なし
+    pub fn snapshot(&self) -> AuthzMetricsSnapshot {
+        AuthzMetricsSnapshot {
+            allow_total: self.allow_total.load(Ordering::Relaxed),
+            deny_total: self.deny_total.load(Ordering::Relaxed),
+            unavailable_total: self.unavailable_total.load(Ordering::Relaxed),
+        }
+    }
 }
 
 /// 暫定の allow-all 認可実装を表現する。

--- a/rust/apps/api/src/main.rs
+++ b/rust/apps/api/src/main.rs
@@ -15,7 +15,7 @@ use auth::{
 };
 use authz::{
     authz_error_response, build_runtime_authorizer, Authorizer, AuthzAction, AuthzCheckInput,
-    AuthzResource,
+    AuthzMetrics, AuthzMetricsSnapshot, AuthzResource,
 };
 use axum::{
     body::Body,
@@ -37,6 +37,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 pub(crate) struct AppState {
     auth_service: Arc<AuthService>,
     authorizer: Arc<dyn Authorizer>,
+    authz_metrics: Arc<AuthzMetrics>,
     ws_reauth_grace: Duration,
 }
 
@@ -83,6 +84,7 @@ fn build_runtime_state() -> AppState {
     let metrics = Arc::new(AuthMetrics::default());
     let auth_service = Arc::new(build_runtime_auth_service(Arc::clone(&metrics)));
     let authorizer = build_runtime_authorizer();
+    let authz_metrics = Arc::new(AuthzMetrics::default());
     let ws_reauth_grace = Duration::from_secs(
         env::var("WS_REAUTH_GRACE_SECONDS")
             .ok()
@@ -93,6 +95,7 @@ fn build_runtime_state() -> AppState {
     AppState {
         auth_service,
         authorizer,
+        authz_metrics,
         ws_reauth_grace,
     }
 }

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -48,6 +48,7 @@ fn app_with_state(state: AppState) -> Router {
         .route("/health", get(health_check))
         .route("/ws", get(ws_handler))
         .route("/internal/auth/metrics", get(auth_metrics_handler))
+        .route("/internal/authz/metrics", get(authz_metrics_handler))
         .merge(protected_routes)
         .with_state(state)
         .layer(cors)
@@ -362,6 +363,14 @@ async fn auth_metrics_handler(State(state): State<AppState>) -> Json<AuthMetrics
     Json(state.auth_service.metrics().snapshot())
 }
 
+/// 認可メトリクスを返す。
+/// @param state アプリケーション状態
+/// @returns 認可メトリクス
+/// @throws なし
+async fn authz_metrics_handler(State(state): State<AppState>) -> Json<AuthzMetricsSnapshot> {
+    Json(state.authz_metrics.snapshot())
+}
+
 /// REST認証ミドルウェアを実行する。
 /// @param state アプリケーション状態
 /// @param request HTTPリクエスト
@@ -427,6 +436,7 @@ async fn rest_auth_middleware(
         action,
     };
     if let Err(error) = state.authorizer.check(&authz_input).await {
+        state.authz_metrics.record_error(&error);
         tracing::warn!(
             decision = %error.decision(),
             request_id = %request_id,
@@ -440,6 +450,7 @@ async fn rest_auth_middleware(
         );
         return authz_error_response(&error, request_id);
     }
+    state.authz_metrics.record_allow();
 
     request.extensions_mut().insert(AuthContext {
         request_id,

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -141,6 +141,7 @@ mod tests {
         let state = AppState {
             auth_service,
             authorizer,
+            authz_metrics: Arc::new(AuthzMetrics::default()),
             ws_reauth_grace: Duration::from_secs(30),
         };
 
@@ -292,6 +293,117 @@ mod tests {
         let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
         assert_eq!(json["code"], "AUTHZ_UNAVAILABLE");
         assert_eq!(json["request_id"], "authz-unavailable-test");
+    }
+
+    #[tokio::test]
+    async fn authz_metrics_endpoint_counts_allow_decisions() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+
+        let _ = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/protected/ping")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/internal/authz/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["allow_total"], 1);
+        assert_eq!(json["deny_total"], 0);
+        assert_eq!(json["unavailable_total"], 0);
+    }
+
+    #[tokio::test]
+    async fn authz_metrics_endpoint_counts_deny_decisions() {
+        let app = app_for_test_with_authorizer(Arc::new(StaticDenyAuthorizer)).await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+
+        let _ = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/protected/ping")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/internal/authz/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["allow_total"], 0);
+        assert_eq!(json["deny_total"], 1);
+        assert_eq!(json["unavailable_total"], 0);
+    }
+
+    #[tokio::test]
+    async fn authz_metrics_endpoint_counts_unavailable_decisions() {
+        let app = app_for_test_with_authorizer(Arc::new(StaticUnavailableAuthorizer)).await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+
+        let _ = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/protected/ping")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/internal/authz/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["allow_total"], 0);
+        assert_eq!(json["deny_total"], 0);
+        assert_eq!(json["unavailable_total"], 1);
     }
 
     #[tokio::test]

--- a/rust/apps/api/src/main/ws_routes.rs
+++ b/rust/apps/api/src/main/ws_routes.rs
@@ -53,6 +53,7 @@ async fn ws_handler(
         action: AuthzAction::Connect,
     };
     if let Err(error) = state.authorizer.check(&authz_input).await {
+        state.authz_metrics.record_error(&error);
         tracing::warn!(
             decision = %error.decision(),
             request_id = %request_id,
@@ -72,6 +73,7 @@ async fn ws_handler(
             })
             .into_response();
     }
+    state.authz_metrics.record_allow();
 
     ws.on_upgrade(move |socket| handle_socket(socket, state, authenticated, request_id))
         .into_response()
@@ -243,6 +245,7 @@ async fn handle_socket_message(
                             action: AuthzAction::Connect,
                         };
                         if let Err(error) = state.authorizer.check(&authz_input).await {
+                            state.authz_metrics.record_error(&error);
                             state.auth_service.metrics().record_ws_reauth(false);
                             tracing::warn!(
                                 decision = %error.decision(),
@@ -259,6 +262,7 @@ async fn handle_socket_message(
                                 close_socket(socket, error.ws_close_code(), error.app_code()).await;
                             return false;
                         }
+                        state.authz_metrics.record_allow();
 
                         if next_principal.principal_id != authenticated.principal_id {
                             state.auth_service.metrics().record_ws_reauth(false);
@@ -388,6 +392,7 @@ async fn authorize_ws_stream_operation(
         action: AuthzAction::View,
     };
     if let Err(error) = state.authorizer.check(&authz_input).await {
+        state.authz_metrics.record_error(&error);
         tracing::warn!(
             decision = %error.decision(),
             request_id = %request_id,
@@ -402,5 +407,6 @@ async fn authorize_ws_stream_operation(
         let _ = close_socket(socket, error.ws_close_code(), error.app_code()).await;
         return false;
     }
+    state.authz_metrics.record_allow();
     true
 }


### PR DESCRIPTION
## 概要
- LIN-868 のスコープとして、AuthZ 判定の最小観測基盤を追加しました。
- `GET /internal/authz/metrics` を追加し、`allow_total` / `deny_total` / `unavailable_total` を公開しました。
- REST/WS の AuthZ 判定経路でメトリクスを記録するようにしました。
- CI に `AuthZ SpiceDB Regression` ジョブを追加し、SpiceDB provider と主要エンドポイント回帰を明示実行するようにしました。
- cutover/rollback 手順と観測要件を runbook に反映しました。

## 変更理由
- SpiceDB cutover 前に、deny/unavailable を早期に検知できる観測面と回帰検知面を固定するためです。

## 受け入れ条件との対応
- 最小観測基盤: `GET /internal/authz/metrics` を追加し decision カウンタを提供。
- 回帰固定: CI ジョブで provider/REST 回帰を明示実行。
- 運用手順: runbook を cutover dry-run / rollback / observability 観点で更新。

## テスト
- `make rust-lint` : ✅ pass
- `make validate` : ⚠️ fail（`typescript` の `node_modules` 未導入のため `prettier: command not found`）
- `cd typescript && npm run typecheck` : ⚠️ fail（`tsc: command not found`）

## 破壊的変更・移行
- 破壊的変更なし（additive change のみ）

## Linear
- LIN-868

## レビュー結果
- `reviewer_simple`: 実行環境で利用不可のため manual self-review を実施（blocking finding なし）
- `reviewer_ui_guard`: 実行環境で利用不可
- `reviewer_ui`: UI 変更なしのため skip
