### PR TITLE
LIN-807 設定プロフィールを実API接続し保存導線を実装

### DIFF
--- a/docs/agent_runs/LIN-807/Documentation.md
+++ b/docs/agent_runs/LIN-807/Documentation.md
@@ -1,0 +1,30 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now: LIN-807 実装 + reviewer指摘反映 + 品質ゲート/レビューゲート完了。
+- Next: PR作成。
+
+## Decisions
+- LIN-807では display_name / status_text の永続化を対象にする。
+- avatar はUIプレビューのみで、API更新対象から外す。
+- status_text は設定画面の自己紹介とユーザーパネル customStatus に反映する。
+- `myProfile` queryはアカウント切替時の誤再利用を防ぐため userId スコープ key を採用する。
+- プロフィール同期は初回hydrationのみとし、未保存フォーム上書きを禁止する。
+- no-data/mock でも空payload更新を `VALIDATION_ERROR` として拒否し、実APIと契約を揃える。
+
+## How to run / demo
+- 1. `pnpm -C typescript install --frozen-lockfile`
+- 2. `cd typescript && npm run test -- src/shared/api/guild-channel-api-client.test.ts src/features/settings/ui/user/user-profile.test.tsx`
+- 3. `cd typescript && npm run typecheck`
+- 4. `make rust-lint`
+- 5. `make validate`
+- 6. UIデモ:
+  - ユーザー設定 > プロフィールを開く。
+  - 表示名/自己紹介を変更して「変更を保存」を押す。
+  - 成功メッセージ表示と、左下ユーザーパネル表示（displayName/customStatus）が更新されることを確認する。
+  - API失敗時にエラー表示と「再試行」導線が表示されることを確認する。
+  - 入力中にプロフィール再取得が起きても、未保存の入力値が維持されることを確認する。
+
+## Known issues / follow-ups
+- `user-profile.test.tsx` 実行時に React `act(...)` 警告は出るが、テスト結果自体は pass。
+- avatar_key の永続化（画像アップロード経路）は LIN-807 スコープ外。

--- a/docs/agent_runs/LIN-807/Implement.md
+++ b/docs/agent_runs/LIN-807/Implement.md
@@ -1,0 +1,89 @@
+# Implement.md (Runbook)
+
+- Follow Plan.md as the single execution order. If order changes are needed, document the reason in Documentation.md and update it.
+- Keep diffs small and do not mix in out-of-scope improvements.
+- Run validation after each milestone and fix failures immediately before continuing.
+- Continuously update Documentation.md with decisions, progress, demo steps, and known issues.
+
+## Execution log
+
+1. Branch baseline sync
+- `git merge --no-edit origin/main` を実行し、LIN-804を含む最新 `origin/main` を fast-forward で取り込み。
+
+2. API profile contract integration
+- `typescript/src/shared/api/api-client.ts`
+  - `MyProfile` / `UpdateMyProfileInput` 型を追加。
+  - `getMyProfile` / `updateMyProfile` 契約を追加。
+- `typescript/src/shared/api/guild-channel-api-client.ts`
+  - `/users/me/profile` GET/PATCH 実装を追加。
+  - Zod 境界検証 (`MY_PROFILE_RESPONSE_SCHEMA`) を追加。
+  - PATCH の partial payload（変更キーのみ送信）を追加。
+- `typescript/src/shared/api/no-data-api-client.ts`
+  - no-data fallback 向け `getMyProfile` / `updateMyProfile` を追加。
+- `typescript/src/shared/api/mock/mock-api-client.ts`
+  - mock 実装へ `getMyProfile` / `updateMyProfile` を追加。
+
+3. Query/Mutation + UI wiring
+- `typescript/src/shared/api/queries/use-my-profile.ts` を追加し、`queries/index.ts` へ公開。
+- `typescript/src/shared/api/mutations/use-my-profile.ts` を追加し、`mutations/index.ts` へ公開。
+- `typescript/src/features/settings/ui/user/user-profile.tsx`
+  - `useMyProfile` で初期値同期。
+  - `useUpdateMyProfile` で保存処理を実装。
+  - 成功表示/エラー表示（再試行）を実装。
+  - 更新成功時に `auth-store` の `currentUser.displayName` と `customStatus` を同期。
+  - avatar は既存どおり UI プレビューのみ（API更新対象外）を維持。
+
+4. Tests
+- `typescript/src/shared/api/guild-channel-api-client.test.ts`
+  - `getMyProfile` mapping テストを追加。
+  - `updateMyProfile` partial PATCH body テストを追加。
+  - 空 payload の `VALIDATION_ERROR` テストを追加。
+- `typescript/src/features/settings/ui/user/user-profile.test.tsx`
+  - 更新成功時の store 同期テストを追加。
+  - 更新失敗時の再試行導線テストを追加。
+
+5. Validation
+- 初回失敗:
+  - `cd typescript && npm run test -- ...` は `vitest: command not found`。
+  - `npm -C typescript ci` は lock 不整合で失敗。
+  - `pnpm -C typescript install --frozen-lockfile` は sandbox DNS 制限で失敗。
+- 対応:
+  - 権限昇格で `pnpm -C typescript install --frozen-lockfile` を再実行し成功。
+  - `typescript/tsconfig.tsbuildinfo` は差分が出たため `git show HEAD:... > ...` で復元。
+- 成功:
+  - `cd typescript && npm run test -- src/shared/api/guild-channel-api-client.test.ts src/features/settings/ui/user/user-profile.test.tsx`
+  - `cd typescript && npm run typecheck`
+  - `make rust-lint`
+  - `make validate`
+
+6. Review feedback fixes (blocker disposition)
+- `typescript/src/features/settings/ui/user/user-profile.tsx`
+  - `myProfile` の再取得で未保存入力が上書きされないよう、フォーム初期化を「ユーザー切替時 + 初回profile hydration時」に限定。
+  - deep import を排除し、`@/shared/api/queries` / `@/shared/api/mutations` の Public API 経由に変更。
+- `typescript/src/shared/api/queries/use-my-profile.ts`
+  - query key を `["myProfile", userId]` に変更し、アカウントスコープ化。
+  - public hook に日本語JSDocを追加。
+- `typescript/src/shared/api/mutations/use-my-profile.ts`
+  - mutation成功時の cache write key を `["myProfile", userId]` に一致させた。
+  - public hook に日本語JSDocを追加。
+- `typescript/src/shared/api/my-profile-validation.ts`（新規）
+  - update payload 空判定を共通化し、validation error shape を補助するユーティリティを追加。
+- `typescript/src/shared/api/no-data-api-client.ts` / `mock/mock-api-client.ts`
+  - 空payload更新時に validation error を返すようにして、実APIクライアントとの契約差を解消。
+- `typescript/src/shared/api/guild-channel-api-client.test.ts`
+  - `statusText` のみ変更時に PATCH body が最小化されるテストを追加。
+- `typescript/src/features/settings/ui/user/user-profile.test.tsx`
+  - profile再取得で未保存bioが保持される回帰テストを追加。
+  - profile取得失敗時の「再試行」導線テストを追加。
+
+7. Final validation rerun after fixes
+- `cd typescript && npm run test -- src/shared/api/guild-channel-api-client.test.ts src/features/settings/ui/user/user-profile.test.tsx`
+- `cd typescript && npm run typecheck`
+- `make rust-lint`
+- `make validate`
+- `typescript/tsconfig.tsbuildinfo` は生成差分を出さないために `git show HEAD:typescript/tsconfig.tsbuildinfo > typescript/tsconfig.tsbuildinfo` で復元。
+
+8. Review gate rerun
+- `reviewer_ui_guard`: `run_ui_checks: true`
+- `reviewer`（full stack）: ブロッカーなし（pass相当）。
+- UI gate: `cd typescript && pnpm lint` / `pnpm typecheck` / `pnpm test` を実行し、failure なし（pass）。

--- a/docs/agent_runs/LIN-807/Plan.md
+++ b/docs/agent_runs/LIN-807/Plan.md
@@ -1,0 +1,29 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: if validation fails, repair it before moving to the next step.
+
+## Milestones
+### M1: API層にプロフィールGET/PATCHを追加
+- Acceptance criteria:
+  - [x] `APIClient` に `getMyProfile` / `updateMyProfile` が追加される。
+  - [x] `GuildChannelAPIClient` で `/users/me/profile` を実装し、境界検証する。
+- Validation:
+  - `cd typescript && npm run test -- src/shared/api/guild-channel-api-client.test.ts`
+
+### M2: Query/Mutation hooksとUI接続
+- Acceptance criteria:
+  - [x] `useMyProfile` / `useUpdateMyProfile` を追加する。
+  - [x] `UserProfile` で読み込み・更新・成功/失敗・再試行を実装する。
+  - [x] 更新結果を `auth-store` に反映してユーザーパネル表示を同期する。
+- Validation:
+  - `cd typescript && npm run typecheck`
+
+### M3: テスト・品質ゲート
+- Acceptance criteria:
+  - [x] UI連携の主要ケースをテストで固定する。
+  - [x] required quality commands の結果を記録する。
+- Validation:
+  - `make validate`
+  - `make rust-lint`
+  - `cd typescript && npm run typecheck`

--- a/docs/agent_runs/LIN-807/Prompt.md
+++ b/docs/agent_runs/LIN-807/Prompt.md
@@ -1,0 +1,27 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- LIN-807として、設定画面プロフィール（表示名/自己紹介）を実APIへ接続する。
+- 更新成功/失敗（再試行可能）をUI上で明示する。
+- 更新結果を設定画面プレビューとユーザーパネル表示へ反映する。
+
+## Non-goals
+- 新規設定項目の追加。
+- avatar画像アップロード経路の新規実装。
+- テーマ切替導線の実装完了。
+
+## Deliverables
+- `/users/me/profile`（GET/PATCH）を呼び出す frontend API 実装。
+- `useMyProfile` / `useUpdateMyProfile` hooks 実装。
+- 設定画面 `UserProfile` からの更新導線実装（成功/失敗/再試行）。
+- LIN-807 スコープのテスト追加と検証結果の記録。
+
+## Done when
+- [x] 設定画面からプロフィール更新ができる。
+- [x] エラー表示に再試行導線がある。
+- [x] 更新結果が画面（プロフィール設定・ユーザーパネル）へ反映される。
+
+## Constraints
+- Perf: 既存導線の不要な再描画/再フェッチを増やさない。
+- Security: 既存の認証付き API 呼び出し経路を踏襲する。
+- Compatibility: LIN-804のAPI契約（display_name/status_text/avatar_key）に準拠する。

--- a/typescript/src/features/settings/ui/user/user-profile.test.tsx
+++ b/typescript/src/features/settings/ui/user/user-profile.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { GuildChannelApiError } from "@/shared/api/guild-channel-api-client";
+import { useAuthStore } from "@/shared/model/stores/auth-store";
+
+type MyProfile = {
+  displayName: string;
+  statusText: string | null;
+  avatarKey: string | null;
+};
+
+type MyProfileQueryResult = {
+  data: MyProfile | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  refetch: () => Promise<unknown>;
+};
+
+type UpdateMyProfileMutationResult = {
+  isPending: boolean;
+  mutateAsync: (input: unknown) => Promise<unknown>;
+};
+
+const mutateAsyncMock = vi.hoisted(() => vi.fn<(input: unknown) => Promise<unknown>>());
+const useMyProfileMock = vi.hoisted(() => vi.fn<(userId: string | null) => MyProfileQueryResult>());
+const useUpdateMyProfileMock = vi.hoisted(() =>
+  vi.fn<(userId: string | null) => UpdateMyProfileMutationResult>(),
+);
+
+vi.mock("@/shared/api/mutations", () => ({
+  useUpdateMyProfile: useUpdateMyProfileMock,
+}));
+
+vi.mock("@/shared/api/queries", () => ({
+  useMyProfile: useMyProfileMock,
+}));
+
+import { UserProfile } from "./user-profile";
+
+describe("UserProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({
+      currentUser: {
+        id: "u-1",
+        username: "alice",
+        displayName: "old-name",
+        avatar: null,
+        status: "online",
+        customStatus: "old-status",
+        bot: false,
+      },
+      status: "online",
+      customStatus: "old-status",
+    });
+    useUpdateMyProfileMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: mutateAsyncMock,
+    });
+    useMyProfileMock.mockReturnValue({
+      data: {
+        displayName: "old-name",
+        statusText: "old-status",
+        avatarKey: null,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    useAuthStore.setState({
+      currentUser: null,
+      status: "online",
+      customStatus: null,
+    });
+  });
+
+  test("saves profile and syncs auth-store on success", async () => {
+    mutateAsyncMock.mockResolvedValueOnce({
+      displayName: "new-name",
+      statusText: "new-status",
+      avatarKey: null,
+    });
+
+    render(<UserProfile />);
+
+    const displayNameInput = screen.getByDisplayValue("old-name");
+    await userEvent.clear(displayNameInput);
+    await userEvent.type(displayNameInput, "new-name");
+
+    const bioInput = screen.getByPlaceholderText("あなたについて教えてください");
+    await userEvent.clear(bioInput);
+    await userEvent.type(bioInput, "new-status");
+
+    await userEvent.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledWith({
+        displayName: "new-name",
+        statusText: "new-status",
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByText("プロフィールを更新しました。")).not.toBeNull();
+      expect(useAuthStore.getState().currentUser?.displayName).toBe("new-name");
+      expect(useAuthStore.getState().customStatus).toBe("new-status");
+    });
+    expect(useMyProfileMock).toHaveBeenCalledWith("u-1");
+    expect(useUpdateMyProfileMock).toHaveBeenCalledWith("u-1");
+  });
+
+  test("shows retry action when update fails and can retry", async () => {
+    mutateAsyncMock
+      .mockRejectedValueOnce(
+        new GuildChannelApiError("profile update failed", {
+          requestId: "req-807",
+        }),
+      )
+      .mockResolvedValueOnce({
+        displayName: "retry-name",
+        statusText: "retry-status",
+        avatarKey: null,
+      });
+
+    render(<UserProfile />);
+
+    const bioInput = screen.getByPlaceholderText("あなたについて教えてください");
+    await userEvent.clear(bioInput);
+    await userEvent.type(bioInput, "retry-status");
+
+    await userEvent.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/request_id: req-807/)).not.toBeNull();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "再試行" }));
+
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("プロフィールを更新しました。")).not.toBeNull();
+    });
+  });
+
+  test("keeps unsaved bio when profile query data is refreshed", async () => {
+    const queryResult: MyProfileQueryResult = {
+      data: {
+        displayName: "old-name",
+        statusText: "old-status",
+        avatarKey: null,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    useMyProfileMock.mockImplementation(() => queryResult);
+
+    const { rerender } = render(<UserProfile />);
+
+    const bioInput = screen.getByPlaceholderText("あなたについて教えてください");
+    await userEvent.clear(bioInput);
+    await userEvent.type(bioInput, "draft-status");
+
+    queryResult.data = {
+      displayName: "old-name",
+      statusText: "server-updated-status",
+      avatarKey: null,
+    };
+    rerender(<UserProfile />);
+
+    await waitFor(() => {
+      const latestBioInput = screen.getByPlaceholderText("あなたについて教えてください");
+      if (!(latestBioInput instanceof HTMLTextAreaElement)) {
+        throw new Error("bio input is not a textarea element");
+      }
+      expect(latestBioInput.value).toBe("draft-status");
+    });
+  });
+
+  test("calls refetch when profile fetch fails and retry is clicked", async () => {
+    const refetchMock = vi.fn<() => Promise<unknown>>().mockResolvedValue(undefined);
+    useMyProfileMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("failed to fetch profile"),
+      refetch: refetchMock,
+    });
+
+    render(<UserProfile />);
+
+    await userEvent.click(screen.getByRole("button", { name: "再試行" }));
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/typescript/src/features/settings/ui/user/user-profile.tsx
+++ b/typescript/src/features/settings/ui/user/user-profile.tsx
@@ -1,19 +1,41 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { toApiErrorText } from "@/shared/api/guild-channel-api-client";
+import { useUpdateMyProfile } from "@/shared/api/mutations";
+import { useMyProfile } from "@/shared/api/queries";
 import { Avatar } from "@/shared/ui/avatar";
+import { Button } from "@/shared/ui/button";
+import { ImageCropModal } from "@/shared/ui/image-crop-modal";
 import { Input } from "@/shared/ui/input";
 import { Textarea } from "@/shared/ui/textarea";
-import { Button } from "@/shared/ui/button";
 import { useAuthStore } from "@/shared/model/stores/auth-store";
-import { ImageCropModal } from "@/shared/ui/image-crop-modal";
 import { cn } from "@/shared/lib/cn";
+
+const BIO_MAX = 190;
+const BIO_WARN = 180;
 
 export function UserProfile() {
   const currentUser = useAuthStore((s) => s.currentUser);
+  const setCurrentUser = useAuthStore((s) => s.setCurrentUser);
+  const setCustomStatus = useAuthStore((s) => s.setCustomStatus);
+  const currentUserId = currentUser?.id ?? null;
+  const {
+    data: myProfile,
+    isLoading: isProfileLoading,
+    isError: isProfileError,
+    error: profileError,
+    refetch: refetchProfile,
+  } = useMyProfile(currentUserId);
+  const updateMyProfile = useUpdateMyProfile(currentUserId);
+
   const [displayName, setDisplayName] = useState(currentUser?.displayName ?? "");
   const [bio, setBio] = useState("");
   const [themeColor, setThemeColor] = useState("#5865F2");
+  const [saveMessage, setSaveMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
 
   const [cropImage, setCropImage] = useState<{
     url: string;
@@ -24,9 +46,31 @@ export function UserProfile() {
 
   const avatarInputRef = useRef<HTMLInputElement>(null);
   const bannerInputRef = useRef<HTMLInputElement>(null);
+  const hydratedUserIdRef = useRef<string | null>(null);
+  const hasHydratedProfileRef = useRef(false);
 
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [bannerUrl, setBannerUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (hydratedUserIdRef.current === currentUserId) {
+      return;
+    }
+    hydratedUserIdRef.current = currentUserId;
+    hasHydratedProfileRef.current = false;
+    setDisplayName(currentUser?.displayName ?? "");
+    setBio(currentUser?.customStatus ?? "");
+    setSaveMessage(null);
+  }, [currentUser?.customStatus, currentUser?.displayName, currentUserId]);
+
+  useEffect(() => {
+    if (!myProfile || hasHydratedProfileRef.current) {
+      return;
+    }
+    hasHydratedProfileRef.current = true;
+    setDisplayName(myProfile.displayName);
+    setBio(myProfile.statusText ?? "");
+  }, [myProfile]);
 
   const handleFileSelect = (file: File, target: "avatar" | "banner") => {
     const url = URL.createObjectURL(file);
@@ -47,12 +91,80 @@ export function UserProfile() {
     setCropImage(null);
   };
 
-  const BIO_MAX = 190;
-  const BIO_WARN = 180;
+  const persistedDisplayName = myProfile?.displayName ?? currentUser?.displayName ?? "";
+  const persistedStatusText = myProfile?.statusText ?? "";
+  const normalizedPersistedDisplayName = persistedDisplayName.trim();
+  const normalizedPersistedStatusText = persistedStatusText.trim();
+  const normalizedDisplayName = displayName.trim();
+  const normalizedBio = bio.trim();
+  const hasPendingChanges =
+    normalizedDisplayName !== normalizedPersistedDisplayName ||
+    normalizedBio !== normalizedPersistedStatusText;
+  const canSave =
+    isProfileLoading === false && hasPendingChanges && updateMyProfile.isPending === false;
+
+  const handleSave = async () => {
+    const input: {
+      displayName?: string;
+      statusText?: string | null;
+    } = {};
+
+    if (normalizedDisplayName !== normalizedPersistedDisplayName) {
+      input.displayName = normalizedDisplayName;
+    }
+    if (normalizedBio !== normalizedPersistedStatusText) {
+      input.statusText = normalizedBio.length === 0 ? null : normalizedBio;
+    }
+    if (Object.keys(input).length === 0) {
+      return;
+    }
+
+    setSaveMessage(null);
+    try {
+      const updatedProfile = await updateMyProfile.mutateAsync(input);
+      if (currentUser !== null) {
+        setCurrentUser({
+          ...currentUser,
+          displayName: updatedProfile.displayName,
+          customStatus: updatedProfile.statusText,
+        });
+      }
+      setCustomStatus(updatedProfile.statusText);
+      setDisplayName(updatedProfile.displayName);
+      setBio(updatedProfile.statusText ?? "");
+      setSaveMessage({
+        type: "success",
+        text: "プロフィールを更新しました。",
+      });
+    } catch (error) {
+      setSaveMessage({
+        type: "error",
+        text: toApiErrorText(error, "プロフィールの更新に失敗しました。"),
+      });
+    }
+  };
 
   return (
     <div>
       <h2 className="mb-5 text-xl font-bold text-discord-header-primary">プロフィール</h2>
+
+      {isProfileError && (
+        <div className="mb-4 rounded bg-discord-bg-tertiary px-3 py-2" role="alert">
+          <p className="text-sm text-discord-status-dnd">
+            {toApiErrorText(profileError, "プロフィール情報の取得に失敗しました。")}
+          </p>
+          <Button
+            className="mt-2"
+            variant="link"
+            size="sm"
+            onClick={() => {
+              void refetchProfile();
+            }}
+          >
+            再試行
+          </Button>
+        </div>
+      )}
 
       <div className="flex gap-8">
         {/* Form */}
@@ -135,6 +247,37 @@ export function UserProfile() {
               onChange={(e) => setThemeColor(e.target.value)}
               className="h-10 w-16 cursor-pointer rounded border-none bg-transparent"
             />
+          </div>
+
+          <div className="space-y-2">
+            <Button
+              onClick={() => {
+                void handleSave();
+              }}
+              disabled={!canSave}
+            >
+              {updateMyProfile.isPending ? "保存中..." : "変更を保存"}
+            </Button>
+            {saveMessage?.type === "success" && (
+              <p role="status" className="text-sm text-discord-status-online">
+                {saveMessage.text}
+              </p>
+            )}
+            {saveMessage?.type === "error" && (
+              <div role="alert" className="flex items-center gap-3">
+                <p className="text-sm text-discord-status-dnd">{saveMessage.text}</p>
+                <Button
+                  variant="link"
+                  size="sm"
+                  onClick={() => {
+                    void handleSave();
+                  }}
+                  disabled={updateMyProfile.isPending}
+                >
+                  再試行
+                </Button>
+              </div>
+            )}
           </div>
         </div>
 

--- a/typescript/src/shared/api/api-client.ts
+++ b/typescript/src/shared/api/api-client.ts
@@ -25,6 +25,18 @@ export type SearchResult = {
   totalResults: number;
 };
 
+export type MyProfile = {
+  displayName: string;
+  statusText: string | null;
+  avatarKey: string | null;
+};
+
+export type UpdateMyProfileInput = {
+  displayName?: string;
+  statusText?: string | null;
+  avatarKey?: string | null;
+};
+
 export type CreateGuildData = {
   name: string;
   icon?: string;
@@ -129,6 +141,8 @@ export type APIClient = {
   // Users
   getUser(userId: string): Promise<User>;
   getUserProfile(userId: string): Promise<UserProfile>;
+  getMyProfile(): Promise<MyProfile>;
+  updateMyProfile(input: UpdateMyProfileInput): Promise<MyProfile>;
 
   // Relationships (Friends)
   getFriends(): Promise<Relationship[]>;

--- a/typescript/src/shared/api/guild-channel-api-client.test.ts
+++ b/typescript/src/shared/api/guild-channel-api-client.test.ts
@@ -346,6 +346,112 @@ describe("GuildChannelAPIClient", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  test("getMyProfile maps profile response", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          profile: {
+            display_name: "alice",
+            status_text: "busy coding",
+            avatar_key: "avatar/alice.png",
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const client = new GuildChannelAPIClient();
+    const profile = await client.getMyProfile();
+
+    expect(profile).toEqual({
+      displayName: "alice",
+      statusText: "busy coding",
+      avatarKey: "avatar/alice.png",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:8080/users/me/profile");
+    expect(init.method).toBe("GET");
+    expect(new Headers(init.headers).get("Authorization")).toBe("Bearer token-1");
+  });
+
+  test("updateMyProfile sends partial patch body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          profile: {
+            display_name: "new-name",
+            status_text: null,
+            avatar_key: null,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const client = new GuildChannelAPIClient();
+    const profile = await client.updateMyProfile({
+      displayName: "new-name",
+      statusText: null,
+    });
+
+    expect(profile).toEqual({
+      displayName: "new-name",
+      statusText: null,
+      avatarKey: null,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:8080/users/me/profile");
+    expect(init.method).toBe("PATCH");
+    expect(new Headers(init.headers).get("Authorization")).toBe("Bearer token-1");
+    expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
+    expect(init.body).toBe(JSON.stringify({ display_name: "new-name", status_text: null }));
+  });
+
+  test("updateMyProfile sends status-only patch body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          profile: {
+            display_name: "old-name",
+            status_text: "focus mode",
+            avatar_key: null,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const client = new GuildChannelAPIClient();
+    const profile = await client.updateMyProfile({
+      statusText: "focus mode",
+    });
+
+    expect(profile).toEqual({
+      displayName: "old-name",
+      statusText: "focus mode",
+      avatarKey: null,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:8080/users/me/profile");
+    expect(init.method).toBe("PATCH");
+    expect(new Headers(init.headers).get("Authorization")).toBe("Bearer token-1");
+    expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
+    expect(init.body).toBe(JSON.stringify({ status_text: "focus mode" }));
+  });
+
+  test("updateMyProfile rejects empty payload", async () => {
+    const client = new GuildChannelAPIClient();
+
+    await expect(client.updateMyProfile({})).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      status: 400,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test("returns typed error with request_id when backend error contract is returned", async () => {
     fetchMock.mockResolvedValue(
       new Response(

--- a/typescript/src/shared/api/guild-channel-api-client.ts
+++ b/typescript/src/shared/api/guild-channel-api-client.ts
@@ -1,7 +1,13 @@
 import { z } from "zod";
 import { getFirebaseAuth } from "@/shared/lib";
 import type { Channel, Guild } from "@/shared/model/types";
-import type { CreateChannelData, CreateGuildData } from "./api-client";
+import type {
+  CreateChannelData,
+  CreateGuildData,
+  MyProfile,
+  UpdateMyProfileInput,
+} from "./api-client";
+import { hasMyProfileUpdateFields } from "./my-profile-validation";
 import { NoDataAPIClient } from "./no-data-api-client";
 
 const API_BASE_URL_SCHEMA = z.string().url();
@@ -33,6 +39,14 @@ const CHANNEL_LIST_RESPONSE_SCHEMA = z.object({
 });
 const CHANNEL_CREATE_RESPONSE_SCHEMA = z.object({
   channel: CHANNEL_SUMMARY_SCHEMA,
+});
+const MY_PROFILE_SCHEMA = z.object({
+  display_name: z.string(),
+  status_text: z.string().nullable(),
+  avatar_key: z.string().nullable(),
+});
+const MY_PROFILE_RESPONSE_SCHEMA = z.object({
+  profile: MY_PROFILE_SCHEMA,
 });
 const BACKEND_ERROR_RESPONSE_SCHEMA = z.object({
   code: z.string().trim().min(1),
@@ -70,6 +84,7 @@ const CREATE_ERROR_MESSAGES = {
 type GuildListResponse = z.infer<typeof GUILD_LIST_RESPONSE_SCHEMA>;
 type GuildCreateResponse = z.infer<typeof GUILD_CREATE_RESPONSE_SCHEMA>;
 type ChannelListResponse = z.infer<typeof CHANNEL_LIST_RESPONSE_SCHEMA>;
+type MyProfileResponse = z.infer<typeof MY_PROFILE_RESPONSE_SCHEMA>;
 type SupportedChannelType = (typeof SUPPORTED_CHANNEL_TYPES)[number];
 
 type GuildChannelApiErrorParams = {
@@ -283,6 +298,14 @@ function mapChannel(summary: ChannelListResponse["channels"][number], position: 
   };
 }
 
+function mapMyProfile(response: MyProfileResponse): MyProfile {
+  return {
+    displayName: response.profile.display_name,
+    statusText: response.profile.status_text,
+    avatarKey: response.profile.avatar_key,
+  };
+}
+
 function isSupportedChannelType(type: CreateChannelData["type"]): type is SupportedChannelType {
   return SUPPORTED_CHANNEL_TYPES.some((supportedType) => supportedType === type);
 }
@@ -338,7 +361,7 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
 
   private async requestJson<T>(params: {
     path: string;
-    method: "GET" | "POST";
+    method: "GET" | "POST" | "PATCH";
     schema: z.ZodType<T>;
     expectedStatus: number;
     body?: Record<string, unknown>;
@@ -413,6 +436,20 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
       body,
       schema,
       expectedStatus: 201,
+    });
+  }
+
+  private async patchJson<T>(
+    path: string,
+    body: Record<string, unknown>,
+    schema: z.ZodType<T>,
+  ): Promise<T> {
+    return this.requestJson({
+      path,
+      method: "PATCH",
+      body,
+      schema,
+      expectedStatus: 200,
     });
   }
 
@@ -577,6 +614,34 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
       status: 404,
       code: "CHANNEL_NOT_FOUND",
     });
+  }
+
+  async getMyProfile(): Promise<MyProfile> {
+    const response = await this.getJson("/users/me/profile", MY_PROFILE_RESPONSE_SCHEMA);
+    return mapMyProfile(response);
+  }
+
+  async updateMyProfile(input: UpdateMyProfileInput): Promise<MyProfile> {
+    if (!hasMyProfileUpdateFields(input)) {
+      throw new GuildChannelApiError("No profile fields provided.", {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    const body: Record<string, unknown> = {};
+    if (input.displayName !== undefined) {
+      body.display_name = input.displayName;
+    }
+    if (input.statusText !== undefined) {
+      body.status_text = input.statusText;
+    }
+    if (input.avatarKey !== undefined) {
+      body.avatar_key = input.avatarKey;
+    }
+
+    const response = await this.patchJson("/users/me/profile", body, MY_PROFILE_RESPONSE_SCHEMA);
+    return mapMyProfile(response);
   }
 
   async createServer(data: CreateGuildData): Promise<Guild> {

--- a/typescript/src/shared/api/mock/mock-api-client.ts
+++ b/typescript/src/shared/api/mock/mock-api-client.ts
@@ -4,13 +4,16 @@ import type {
   CreateChannelData,
   CreateInviteData,
   Invite,
+  MyProfile,
   Role,
+  UpdateMyProfileInput,
   Webhook,
   AuditLogEntry,
   Relationship,
   SearchParams,
   SearchResult,
 } from "../api-client";
+import { createMyProfileValidationError, hasMyProfileUpdateFields } from "../my-profile-validation";
 import type {
   User,
   UserProfile,
@@ -280,6 +283,60 @@ export class MockAPIClient implements APIClient {
       };
     }
     return profile;
+  }
+
+  async getMyProfile(): Promise<MyProfile> {
+    await this.simulateDelay();
+    if (!mockCurrentUser.id) {
+      throw new Error("User not found");
+    }
+
+    const profile = mockUserProfiles[mockCurrentUser.id];
+    return {
+      displayName: profile?.displayName ?? mockCurrentUser.displayName,
+      statusText: profile?.bio ?? mockCurrentUser.customStatus,
+      avatarKey: null,
+    };
+  }
+
+  async updateMyProfile(input: UpdateMyProfileInput): Promise<MyProfile> {
+    await this.simulateDelay();
+    if (!hasMyProfileUpdateFields(input)) {
+      throw createMyProfileValidationError();
+    }
+
+    if (!mockCurrentUser.id) {
+      throw new Error("User not found");
+    }
+
+    const displayName =
+      input.displayName !== undefined ? input.displayName.trim() : mockCurrentUser.displayName;
+    const statusText =
+      input.statusText !== undefined
+        ? (input.statusText?.trim() ?? null)
+        : mockCurrentUser.customStatus;
+    mockCurrentUser.displayName = displayName;
+    mockCurrentUser.customStatus = statusText;
+
+    const existingProfile = mockUserProfiles[mockCurrentUser.id];
+    mockUserProfiles[mockCurrentUser.id] = {
+      ...(existingProfile ?? {
+        ...mockCurrentUser,
+        banner: null,
+        bio: null,
+        accentColor: null,
+        badges: [],
+        createdAt: "2022-01-01T00:00:00.000Z",
+      }),
+      displayName,
+      bio: statusText,
+    };
+
+    return {
+      displayName,
+      statusText,
+      avatarKey: null,
+    };
   }
 
   // Relationships

--- a/typescript/src/shared/api/mutations/index.ts
+++ b/typescript/src/shared/api/mutations/index.ts
@@ -24,3 +24,4 @@ export {
 export { useCreateRole, useUpdateRole, useDeleteRole, useReorderRoles } from "./use-role-actions";
 export { useCreateInvite, useRevokeInvite } from "./use-invite-actions";
 export { useUpdateChannel } from "./use-channel-update";
+export { useUpdateMyProfile } from "./use-my-profile";

--- a/typescript/src/shared/api/mutations/use-my-profile.ts
+++ b/typescript/src/shared/api/mutations/use-my-profile.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getAPIClient } from "@/shared/api/api-client";
+import type { UpdateMyProfileInput } from "@/shared/api/api-client";
+
+/**
+ * ログインユーザーのプロフィールを更新する。
+ */
+export function useUpdateMyProfile(userId: string | null) {
+  const queryClient = useQueryClient();
+  const api = getAPIClient();
+
+  return useMutation({
+    mutationFn: (input: UpdateMyProfileInput) => api.updateMyProfile(input),
+    onSuccess: (updatedProfile) => {
+      if (userId !== null) {
+        queryClient.setQueryData(["myProfile", userId], updatedProfile);
+      }
+    },
+  });
+}

--- a/typescript/src/shared/api/my-profile-validation.ts
+++ b/typescript/src/shared/api/my-profile-validation.ts
@@ -1,0 +1,27 @@
+import type { UpdateMyProfileInput } from "./api-client";
+
+type MyProfileValidationError = Error & {
+  code: "VALIDATION_ERROR";
+  status: 400;
+};
+
+export function hasMyProfileUpdateFields(input: UpdateMyProfileInput): boolean {
+  return (
+    input.displayName !== undefined ||
+    input.statusText !== undefined ||
+    input.avatarKey !== undefined
+  );
+}
+
+/**
+ * プロフィール更新入力の検証エラーを生成する。
+ */
+export function createMyProfileValidationError(
+  message = "No profile fields provided.",
+): MyProfileValidationError {
+  const error = new Error(message) as MyProfileValidationError;
+  error.name = "GuildChannelApiError";
+  error.code = "VALIDATION_ERROR";
+  error.status = 400;
+  return error;
+}

--- a/typescript/src/shared/api/no-data-api-client.ts
+++ b/typescript/src/shared/api/no-data-api-client.ts
@@ -6,12 +6,15 @@ import type {
   CreateGuildData,
   CreateInviteData,
   Invite,
+  MyProfile,
   Relationship,
   Role,
   SearchParams,
   SearchResult,
+  UpdateMyProfileInput,
   Webhook,
 } from "./api-client";
+import { createMyProfileValidationError, hasMyProfileUpdateFields } from "./my-profile-validation";
 import type {
   Channel,
   Guild,
@@ -51,6 +54,14 @@ function buildProfile(user: User): UserProfile {
     accentColor: null,
     badges: [],
     createdAt: new Date(0).toISOString(),
+  };
+}
+
+function buildMyProfile(user: User): MyProfile {
+  return {
+    displayName: user.displayName,
+    statusText: user.customStatus,
+    avatarKey: null,
   };
 }
 
@@ -168,6 +179,49 @@ export class NoDataAPIClient implements APIClient {
 
   getUserProfile(userId: string): Promise<UserProfile> {
     return this.getUser(userId).then((user) => buildProfile(user));
+  }
+
+  getMyProfile(): Promise<MyProfile> {
+    try {
+      return Promise.resolve(buildMyProfile(resolveCurrentUserOrThrow()));
+    } catch (error) {
+      return Promise.reject(
+        error instanceof Error ? error : new Error("Unknown profile fetch error."),
+      );
+    }
+  }
+
+  updateMyProfile(input: UpdateMyProfileInput): Promise<MyProfile> {
+    if (!hasMyProfileUpdateFields(input)) {
+      return Promise.reject(createMyProfileValidationError());
+    }
+
+    try {
+      const currentUser = resolveCurrentUserOrThrow();
+      const displayName =
+        input.displayName !== undefined ? input.displayName.trim() : currentUser.displayName;
+      const statusText =
+        input.statusText !== undefined
+          ? (input.statusText?.trim() ?? null)
+          : currentUser.customStatus;
+
+      const updatedUser: User = {
+        ...currentUser,
+        displayName,
+        customStatus: statusText,
+      };
+      useAuthStore.setState({ currentUser: updatedUser, customStatus: statusText });
+
+      return Promise.resolve({
+        displayName,
+        statusText,
+        avatarKey: null,
+      });
+    } catch (error) {
+      return Promise.reject(
+        error instanceof Error ? error : new Error("Unknown profile update error."),
+      );
+    }
   }
 
   getFriends(): Promise<Relationship[]> {

--- a/typescript/src/shared/api/queries/index.ts
+++ b/typescript/src/shared/api/queries/index.ts
@@ -3,6 +3,7 @@ export { useChannels, useChannel, useDMChannels } from "./use-channels";
 export { useMessages, usePinnedMessages } from "./use-messages";
 export { useMembers } from "./use-members";
 export { useUserProfile } from "./use-user-profile";
+export { useMyProfile } from "./use-my-profile";
 export { useFriends } from "./use-friends";
 export { useRoles } from "./use-roles";
 export { useInvites } from "./use-invites";

--- a/typescript/src/shared/api/queries/use-my-profile.ts
+++ b/typescript/src/shared/api/queries/use-my-profile.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getAPIClient } from "@/shared/api/api-client";
+
+/**
+ * ログインユーザーのプロフィールを取得する。
+ */
+export function useMyProfile(userId: string | null) {
+  const api = getAPIClient();
+  return useQuery({
+    queryKey: ["myProfile", userId],
+    queryFn: () => api.getMyProfile(),
+    enabled: userId !== null,
+  });
+}


### PR DESCRIPTION
## 概要
- LIN-807として、ユーザー設定のプロフィール編集（表示名/自己紹介）を実APIへ接続しました。
- 保存成功/失敗（再試行）をUIで明示し、更新結果を設定画面とユーザーパネルへ反映します。

## 変更内容
- `APIClient` に `getMyProfile` / `updateMyProfile` 契約を追加。
- `GuildChannelAPIClient` に `/users/me/profile` の GET/PATCH 実装を追加。
- `useMyProfile` / `useUpdateMyProfile` hooks を追加。
- `UserProfile` UIをAPI連携し、保存・エラーメッセージ・再試行導線を実装。
- 未保存編集中に profile 再取得が発生しても入力が上書きされないよう同期ロジックを修正。
- `myProfile` query key を `userId` スコープ化して、アカウント切替時のキャッシュ誤利用を防止。
- no-data/mock クライアントでも空payload更新を `VALIDATION_ERROR` に統一。

## 変更の意図
- LIN-804で追加された backend profile API を frontend 設定画面に正しく接続し、プロフィール更新体験を完成させるため。
- 再取得やアカウント切替時の状態不整合（未保存入力の消失・キャッシュ混線）を防ぐため。
- 本番/モック/no-data 間の挙動差異を縮小し、検証と運用の再現性を上げるため。

## 受け入れ基準の対応
- [x] 設定画面からプロフィール更新ができる。
- [x] エラー表示に再試行導線がある。
- [x] 更新結果が画面（プロフィール設定・ユーザーパネル）へ反映される。

## テスト
- [x] `cd typescript && npm run test -- src/shared/api/guild-channel-api-client.test.ts src/features/settings/ui/user/user-profile.test.tsx`
- [x] `cd typescript && npm run typecheck`
- [x] `make rust-lint`
- [x] `make validate`

## レビューゲート結果
- `reviewer_ui_guard`: `run_ui_checks: true`
- `reviewer` (full stack): pass（blocking findings なし）
- `reviewer_ui`: pass

## 互換性・移行
- Event contract 変更: なし（ADR-001チェック対象外）
- DB migration: なし
- Breaking change: なし

## ランタイムスモーク
- 今回は既存設定画面内のAPI接続/状態同期改善と単体テスト追加が中心のため、`make validate`・`pnpm test`を主要確認とし、追加の手動スモークは未実施。

## 関連Issue
- LIN-807
