### PR TITLE
env.exampleのサンプル値とコメントを日本語で整理

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,17 @@
-# PostgreSQL
+# PostgreSQL（Docker Compose）
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 POSTGRES_DB=linklynx
 
-# Rust Backend (required for auth runtime startup)
+# Rust Backend（認証ランタイム起動に必須）
 FIREBASE_PROJECT_ID=your-firebase-project-id
 DATABASE_URL=postgres://postgres:password@localhost:5432/linklynx
 AUTH_ALLOW_POSTGRES_NOTLS=true
+
+# Rust Backend（推奨の任意設定）
+# - FIREBASE_AUDIENCE / FIREBASE_ISSUER は未設定時に
+#   FIREBASE_PROJECT_ID から自動導出されます。
+# - 特別な要件がない限り、未設定のまま運用してください。
 RUST_LOG=info
 WS_REAUTH_GRACE_SECONDS=30
 WS_TICKET_TTL_SECONDS=60
@@ -15,9 +20,7 @@ WS_TICKET_RATE_LIMIT_MAX_PER_MINUTE=20
 WS_IDENTIFY_RATE_LIMIT_MAX_PER_MINUTE=60
 WS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
-# Rust Backend (optional; if set, value must be valid)
-FIREBASE_AUDIENCE=your-firebase-project-id
-FIREBASE_ISSUER=https://securetoken.google.com/your-firebase-project-id
+# Rust Backend（詳細チューニング用の任意設定）
 FIREBASE_JWKS_URL=https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com
 FIREBASE_JWKS_TTL_SECONDS=300
 FIREBASE_HTTP_TIMEOUT_SECONDS=5
@@ -27,21 +30,17 @@ AUTH_PRINCIPAL_STORE_POOL_SIZE=4
 AUTH_PRINCIPAL_STORE_MAX_RETRIES=2
 AUTH_PRINCIPAL_STORE_RETRY_BASE_BACKOFF_MS=25
 
-# Next.js Frontend (required)
+# Next.js Frontend（Docker Compose 実行時に必須）
+# - NEXT_PUBLIC_FIREBASE_PROJECT_ID は FIREBASE_PROJECT_ID と同じ値を設定してください。
 NEXT_PUBLIC_API_URL=http://localhost:8080
 NEXT_PUBLIC_FIREBASE_API_KEY=replace-with-your-firebase-web-api-key
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-firebase-project-id.firebaseapp.com
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-firebase-project-id
 NEXT_PUBLIC_FIREBASE_APP_ID=replace-with-your-firebase-app-id
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=replace-with-your-messaging-sender-id
-NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-firebase-project-id.appspot.com
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=replace-with-your-firebase-storage-bucket
 
-# Next.js Frontend (optional)
-NODE_ENV=production
-PORT=3000
-HOSTNAME=0.0.0.0
-
-# DB Tooling (Makefile)
+# DB ツール（Makefile 用）
 POSTGRES_DB_NAME=linklynx
 SQLX_MIGRATIONS_DIR=../database/postgres/migrations
 SCHEMA_SNAPSHOT_PATH=database/postgres/schema.sql

--- a/typescript/.env.example
+++ b/typescript/.env.example
@@ -1,4 +1,4 @@
-# TypeScript (Next.js) デプロイ用環境変数
+# TypeScript（Next.js）用環境変数
 #
 # 必須:
 # - NEXT_PUBLIC_API_URL
@@ -9,28 +9,23 @@
 # - NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
 # - NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
 #
-# 起動時fail-fast契約:
+# 起動時 fail-fast 契約:
 # - 必須項目が欠落または不正値の場合、Next.js 起動時にエラーになります。
 
 # フロントエンドが参照する API ベースURL（必須）
 NEXT_PUBLIC_API_URL=http://localhost:8080
 
 # Firebase Web SDK 設定（必須）
+# - NEXT_PUBLIC_FIREBASE_PROJECT_ID は backend 側の FIREBASE_PROJECT_ID と同じ値を設定してください。
 NEXT_PUBLIC_FIREBASE_API_KEY=replace-with-your-firebase-web-api-key
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-firebase-project-id.firebaseapp.com
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-firebase-project-id
 NEXT_PUBLIC_FIREBASE_APP_ID=replace-with-your-firebase-app-id
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=replace-with-your-messaging-sender-id
-NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-firebase-project-id.appspot.com
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=replace-with-your-firebase-storage-bucket
 
 # Next.js 実行ポート（任意）
 PORT=3000
 
 # Next.js バインド先ホスト（任意）
 HOSTNAME=0.0.0.0
-
-# 実行環境（任意）
-NODE_ENV=production
-
-# UI gateway provider（任意、既定: mock）
-NEXT_PUBLIC_UI_GATEWAY_PROVIDER=mock


### PR DESCRIPTION
## 概要
root と TypeScript の env example を、現行実装の挙動に合わせて整理しました。

## 変更内容
- .env.example のコメントを日本語化
- FIREBASE_AUDIENCE / FIREBASE_ISSUER の固定例を削除（未設定時の自動導出をコメントで明記）
- NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET を汎用プレースホルダへ変更
- typescript/.env.example のコメントを日本語化
- typescript/.env.example から NODE_ENV と NEXT_PUBLIC_UI_GATEWAY_PROVIDER=mock の例を削除
- backend と frontend の FIREBASE_PROJECT_ID を一致させる注意書きを追加

## 影響範囲
- env テンプレートとコメントのみ（アプリコード変更なし）

## 確認
- 差分確認のみ（設定テンプレート更新のためテストは未実行）
