### PR TITLE
Update サブエージェントのGPTモデルを5.4に切り替え

### DIFF
--- a/.codex/agents/explorer.toml
+++ b/.codex/agents/explorer.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/monitor.toml
+++ b/.codex/agents/monitor.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4"
 model_reasoning_effort = "medium"
 developer_instructions = """
 Run the validation commands requested. Summarize failures and likely causes.

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/reviewer_coding_rules.toml
+++ b/.codex/agents/reviewer_coding_rules.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/reviewer_correctness.toml
+++ b/.codex/agents/reviewer_correctness.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/reviewer_performance.toml
+++ b/.codex/agents/reviewer_performance.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/reviewer_security.toml
+++ b/.codex/agents/reviewer_security.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/reviewer_simple.toml
+++ b/.codex/agents/reviewer_simple.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/reviewer_test_quality.toml
+++ b/.codex/agents/reviewer_test_quality.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/reviewer_ui.toml
+++ b/.codex/agents/reviewer_ui.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/reviewer_ui_guard.toml
+++ b/.codex/agents/reviewer_ui_guard.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4"
 model_reasoning_effort = "low"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/worker.toml
+++ b/.codex/agents/worker.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "medium"
 developer_instructions = """
 Follow Plan.md milestone-by-milestone. Keep diffs scoped.


### PR DESCRIPTION
Summary
- サブエージェント定義ファイルの `model` をすべて `gpt-5.4` に更新しました。
- explorer/monitor/worker/reviewer 系など、すべてのエージェント構成に対して統一しています。

Testing
- Not run (not requested)