### PR TITLE
LIN-645 認証E2Eスモークとrunbookを追加

### DIFF
--- a/docs/agent_runs/LIN-645/Documentation.md
+++ b/docs/agent_runs/LIN-645/Documentation.md
@@ -1,0 +1,48 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now: 実装完了。コード/ドキュメント差分と review 反映済みで、runtime smoke は環境待ち
+- Next: smoke 用資格情報と backend/spicedb runtime を揃えて happy-path / dependency-unavailable を実行し、PR 用の実行証跡を確定する
+
+## Decisions
+- 最小E2Eは Playwright ではなく Node smoke script で実装する。
+- 障害系は AuthZ dependency unavailable を対象にし、`503 / 1011` を確認する。
+- token / ticket はログ出力しない。
+- smoke script は test user の email も標準出力へ出さない。
+
+## How to run / demo
+- `cd typescript && npm run smoke:auth -- --mode=happy-path`
+- `cd typescript && npm run smoke:auth -- --mode=dependency-unavailable`
+
+## Validation results
+- `node --check typescript/scripts/auth-e2e-smoke.mjs`: passed
+- `cd typescript && npm run typecheck`: passed
+- `cd typescript && npm run test -- scripts/auth-e2e-smoke.test.mjs`: passed
+- `cd typescript && npm run test -- src/entities/auth/api/ws-ticket.test.ts src/entities/auth/api/principal-provisioning.test.ts src/app/providers/ws-auth-bridge.test.tsx`: passed
+- `cd typescript && npm run test`: passed (34 files, 179 tests)
+- `make rust-lint`: passed
+  - sandbox 内では既存の Rust SpiceDB 系テストが `Operation not permitted` で失敗したため、権限昇格後に再実行して通過
+- `make validate`: passed
+  - 同上の sandbox 制約を回避するため、権限昇格後に再実行して通過
+
+## Runtime smoke
+- 未実施
+- 理由:
+  - `typescript/.env.local` に `AUTH_SMOKE_EMAIL` / `AUTH_SMOKE_PASSWORD` が未設定で、Firebase verified test user を使った login を実行できない
+  - ローカル Docker では `postgres`, `scylladb` のみ起動中で、`rust` / `spicedb` の runtime smoke 前提が揃っていない
+
+## Review results
+- `reviewer`: timed out in this session
+- `reviewer_simple`: pass
+  - 指摘 2件は runbook 文言の精度のみで、`dependency-unavailable` の対象を AuthZ outage に限定し、SpiceDB runbook に別ターミナル実行を追記して解消
+- `reviewer_ui_guard`: `run_ui_checks=false`
+  - changed files are `typescript/scripts/**`, `typescript/package.json`, `typescript/.env.example`, `docs/**`
+  - `typescript/src/**`, `public/**`, `tailwind.config.ts`, `next.config.ts` は未変更
+- manual self-review:
+  - smoke script は token / ticket / test user email を stdout へ出さない
+  - `happy-path` で REST `principal_id` と WS `principalId` の整合を確認する
+  - dependency-unavailable は `503 / AUTHZ_UNAVAILABLE` と `1011 / AUTHZ_UNAVAILABLE` を期待値に固定する
+
+## Known issues / follow-ups
+- reviewer 系の可用性は実行時に確認する。
+- runtime smoke を完了するには `typescript/.env.local` へ smoke 用資格情報を追加し、`AUTHZ_PROVIDER=spicedb` で backend を起動したローカル環境が必要。

--- a/docs/agent_runs/LIN-645/Implement.md
+++ b/docs/agent_runs/LIN-645/Implement.md
@@ -1,0 +1,6 @@
+# Implement.md (Runbook)
+
+- `Plan.md` の順序を実行順の基準にする。順序変更が必要なら `Documentation.md` に理由を残す。
+- 差分は `LIN-645` の範囲に限定し、AuthN/AuthZ の契約変更は行わない。
+- 各マイルストーン後に validation を実行し、失敗時はその場で修正する。
+- `Documentation.md` に進捗、検証結果、runtime smoke、review 結果を継続追記する。

--- a/docs/agent_runs/LIN-645/Plan.md
+++ b/docs/agent_runs/LIN-645/Plan.md
@@ -1,0 +1,23 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: validation が失敗したら次へ進む前に修正する。
+
+## Milestones
+### M1: Auth smoke script を追加
+- Acceptance criteria:
+  - [ ] Firebase login -> protected ping -> ws identify の正常系を検証できる。
+  - [ ] `dependency-unavailable` モードで `503 / 1011` を検証できる。
+- Validation:
+  - `cd typescript && npm run typecheck`
+  - `cd typescript && npm run smoke:auth -- --mode=happy-path`
+
+### M2: env / runbook / issue evidence を更新
+- Acceptance criteria:
+  - [ ] `.env.example` に smoke 用資格情報の説明が追加される。
+  - [ ] auth / authz runbook にローカル再現と切り分けが追記される。
+  - [ ] `docs/agent_runs/LIN-645/Documentation.md` に検証結果を記録する。
+- Validation:
+  - `make validate`
+  - `make rust-lint`
+  - `cd typescript && npm run typecheck`

--- a/docs/agent_runs/LIN-645/Prompt.md
+++ b/docs/agent_runs/LIN-645/Prompt.md
@@ -1,0 +1,28 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- `login -> protected ping -> ws identify` の最小E2Eスモークをローカルで再現可能にする。
+- 正常系に加えて、依存障害時の `REST 503 / WS 1011` を運用手順で検証可能にする。
+- Firebase/AuthN と SpiceDB/AuthZ の切り分け手順を runbook に反映する。
+
+## Non-goals
+- AuthN/AuthZ の契約変更。
+- Playwright 導入や UI ブラウザ自動化基盤の追加。
+- 無関係な runbook 拡張。
+
+## Deliverables
+- `typescript/scripts/auth-e2e-smoke.mjs`
+- `typescript/package.json` の smoke command
+- `typescript/.env.example` の smoke 用 env 説明
+- `docs/runbooks/auth-firebase-principal-operations-runbook.md`
+- `docs/runbooks/authz-spicedb-local-ci-runtime-runbook.md`
+
+## Done when
+- [ ] 正常系の smoke command が login / protected ping / ws identify を検証できる。
+- [ ] 障害系の smoke command が `REST 503 / WS 1011` を検証できる。
+- [ ] runbook だけでローカル再現と切り分けができる。
+
+## Constraints
+- Perf: 追加スクリプトは最小依存で完結し、既存アプリコードへ影響を持ち込まない。
+- Security: token / ticket を stdout やファイルへ残さない。
+- Compatibility: 既存の REST/WS wire contract は変更しない。

--- a/docs/runbooks/auth-firebase-principal-operations-runbook.md
+++ b/docs/runbooks/auth-firebase-principal-operations-runbook.md
@@ -1,7 +1,7 @@
 # Firebase Auth / principal_id Operations Runbook (Draft)
 
 - Status: Draft
-- Last updated: 2026-03-02
+- Last updated: 2026-03-06
 - Owner scope: v1 auth operations baseline for REST/WS shared authentication
 - References:
   - [ADR-005 Dragonfly Outage RateLimit Failure Policy (Hybrid)](../adr/ADR-005-dragonfly-ratelimit-failure-policy.md)
@@ -130,15 +130,26 @@ Local steps (runbook-only reproducible flow):
    - `cp rust/.env.example rust/.env`
    - `cp typescript/.env.example typescript/.env.local`
 2. Set real Firebase test project values in `.env` and `typescript/.env.local` (never commit secrets).
+   - For smoke verification, also set `AUTH_SMOKE_EMAIL` and `AUTH_SMOKE_PASSWORD` in `typescript/.env.local`.
 3. Start local stack.
    - `docker compose up -d postgres`
    - `docker compose up -d rust typescript`
 4. Verify startup.
    - `docker compose logs rust` should not contain env validation errors.
    - `docker compose logs typescript` should not contain frontend env validation errors.
-5. Verify auth path.
-   - call protected REST path with valid Firebase token and confirm `200`.
-  - validate missing/invalid token path still maps to `401/403/503` per section 2.3.
+5. Run smoke verification.
+   - `cd typescript && npm run smoke:auth -- --mode=happy-path`
+6. Verify auth path expectations.
+   - `happy-path` must complete `Firebase login -> GET /protected/ping -> POST /auth/ws-ticket -> GET /ws + auth.identify`.
+   - `protected/ping` success payload must include `request_id`, `principal_id`, `firebase_uid`.
+   - `auth.ready` payload must include `principalId` and match the REST `principal_id`.
+7. Validate missing/invalid token path separately when needed.
+   - invalid token path still maps to `401/403/503` per section 2.3.
+
+Operational note:
+
+- The smoke script uses Firebase Identity Toolkit login and local backend endpoints directly.
+- The script must not print ID tokens or WS tickets; only status, request IDs, and close codes are allowed in output.
 
 ## 3. Required logs and audit fields
 
@@ -237,11 +248,32 @@ Primary response:
 2. Verify duplicate/parallel login burst behavior from clients.
 3. Keep fail-close response and resolve conflicting identity records operationally.
 
+### 5.5 Scenario E: local smoke triage
+
+This scenario is the default first triage path when `npm run smoke:auth` fails locally.
+
+1. Firebase login step fails:
+   - Confirm `NEXT_PUBLIC_FIREBASE_API_KEY`, `AUTH_SMOKE_EMAIL`, and `AUTH_SMOKE_PASSWORD` in `typescript/.env.local`.
+   - Confirm the smoke user exists in the Firebase test project and the password is current.
+2. `protected/ping` fails with `401` or `403`:
+   - Confirm the smoke user is `emailVerified=true`.
+   - Confirm backend auth logs include the same `firebase_uid` and an expected `request_id`.
+3. `protected/ping` fails with `503` unexpectedly:
+   - Check backend startup logs for `DATABASE_URL`, JWKS, or AuthZ provider initialization failures.
+   - If `AUTHZ_PROVIDER=spicedb`, verify SpiceDB health before treating it as AuthN failure.
+4. `ws-ticket` issuance fails:
+   - Confirm the same ID token succeeds on `protected/ping`.
+   - Confirm the backend returns an auth code (`AUTH_*`) instead of transport errors.
+5. `/ws + auth.identify` fails:
+   - Confirm `WS_ALLOWED_ORIGINS` includes the local frontend origin.
+   - Distinguish deterministic close (`1008`) from dependency unavailable (`1011`) before escalating.
+
 ## 6. Verification procedure
 
 1. Valid token + mapped UID:
 - REST protected endpoint returns `200`.
 - WS handshake succeeds.
+- `cd typescript && npm run smoke:auth -- --mode=happy-path` passes.
 
 2. Invalid/expired token:
 - REST returns `401`.
@@ -252,9 +284,16 @@ Primary response:
 - REST returns `403` when conflict is unrecoverable.
 - WS follows equivalent allow/deny behavior.
 
-4. Dependency unavailable simulation (JWKS/store):
+4. AuthZ provider unavailable simulation (local smoke):
 - REST returns `503`.
 - WS closes with `1011`.
+- For local AuthZ outage verification, use the AuthZ SpiceDB runbook and run:
+  - `cd typescript && npm run smoke:auth -- --mode=dependency-unavailable`
+
+Operational note:
+
+- `dependency-unavailable` mode verifies the AuthZ provider outage path (`AUTHZ_UNAVAILABLE`) only.
+- AuthN dependency outages such as JWKS or principal store failures remain manual verification scenarios in section 5.
 
 5. Unverified email token:
 - REST returns `403` with `AUTH_EMAIL_NOT_VERIFIED`.

--- a/docs/runbooks/authz-spicedb-local-ci-runtime-runbook.md
+++ b/docs/runbooks/authz-spicedb-local-ci-runtime-runbook.md
@@ -1,7 +1,7 @@
 # AuthZ SpiceDB Local/CI Runtime Foundation Runbook
 
 - Status: Draft
-- Last updated: 2026-03-04
+- Last updated: 2026-03-06
 - Owner scope: LIN-863 local/CI runtime baseline + LIN-865 fail-close integration
 - References:
   - `database/contracts/lin862_spicedb_namespace_relation_permission_contract.md`
@@ -71,6 +71,20 @@ make rust-dev
 - if config is valid: `AUTHZ_PROVIDER=spicedb runtime config is ready`
 - if config is invalid: `AUTHZ_PROVIDER=spicedb runtime config is invalid; fail-close authorizer is active`
 - if authorizer initialization fails: `failed to initialize spicedb authorizer; fail-close authorizer is active`
+5. Optional auth smoke verification (run in a separate terminal while API is still running):
+
+```bash
+cd typescript && npm run smoke:auth -- --mode=happy-path
+```
+
+Prerequisites:
+- `typescript/.env.local` is populated per `docs/runbooks/auth-firebase-principal-operations-runbook.md`
+- `AUTH_SMOKE_EMAIL` and `AUTH_SMOKE_PASSWORD` point to a verified Firebase test user
+
+Expected:
+- Firebase login succeeds.
+- `GET /protected/ping` returns `200`.
+- `/ws + auth.identify` reaches `auth.ready`.
 
 ## 4. CI baseline
 
@@ -102,6 +116,21 @@ CI baseline job must:
   - REST returns `503` with `AUTHZ_UNAVAILABLE`
   - WS closes with `1011`
 - If request is accepted, treat as contract violation and rollback latest authz runtime changes.
+
+Recommended end-to-end verification:
+
+1. Keep API running with `AUTHZ_PROVIDER=spicedb`.
+2. Stop SpiceDB:
+   - `make authz-spicedb-down`
+3. Run:
+   - `cd typescript && npm run smoke:auth -- --mode=dependency-unavailable`
+4. Expected smoke output:
+   - `protected/ping` fails with `503 / AUTHZ_UNAVAILABLE`
+   - `/ws + auth.identify` closes with `1011 / AUTHZ_UNAVAILABLE`
+   - command requires the same `typescript/.env.local` prerequisites as the happy-path smoke
+5. Restart SpiceDB and health check:
+   - `make authz-spicedb-up`
+   - `make authz-spicedb-health`
 
 ## 6. Exit criteria for LIN-863
 

--- a/typescript/.env.example
+++ b/typescript/.env.example
@@ -24,6 +24,12 @@ NEXT_PUBLIC_FIREBASE_APP_ID=replace-with-your-firebase-app-id
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=replace-with-your-messaging-sender-id
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=replace-with-your-firebase-storage-bucket
 
+# 認証 smoke script 用のテスト資格情報（任意）
+# - `npm run smoke:auth` を使う場合のみ設定してください。
+# - emailVerified=true の Firebase テストユーザーを指定してください。
+AUTH_SMOKE_EMAIL=verified-smoke-user@example.com
+AUTH_SMOKE_PASSWORD=replace-with-smoke-password
+
 # Next.js 実行ポート（任意）
 PORT=3000
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "fsd:check": "node ./scripts/check-fsd.mjs",
+    "smoke:auth": "node ./scripts/auth-e2e-smoke.mjs",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",

--- a/typescript/scripts/auth-e2e-smoke.mjs
+++ b/typescript/scripts/auth-e2e-smoke.mjs
@@ -1,0 +1,468 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { z } from "zod";
+
+const MODE_SCHEMA = z.enum(["happy-path", "dependency-unavailable"]);
+const ENV_SCHEMA = z.object({
+  NEXT_PUBLIC_API_URL: z.string().url(),
+  NEXT_PUBLIC_FIREBASE_API_KEY: z.string().trim().min(1),
+  AUTH_SMOKE_EMAIL: z.string().trim().email(),
+  AUTH_SMOKE_PASSWORD: z.string().trim().min(1),
+});
+const LOGIN_RESPONSE_SCHEMA = z.object({
+  idToken: z.string().trim().min(1),
+  localId: z.string().trim().min(1),
+});
+const PROTECTED_PING_SUCCESS_SCHEMA = z.object({
+  ok: z.literal(true),
+  request_id: z.string().trim().min(1),
+  principal_id: z.number().int().positive(),
+  firebase_uid: z.string().trim().min(1),
+});
+const BACKEND_ERROR_SCHEMA = z.object({
+  code: z.string().trim().min(1),
+  message: z.string().trim().min(1),
+  request_id: z.string().trim().min(1),
+});
+const WS_TICKET_SUCCESS_SCHEMA = z.object({
+  ticket: z.string().trim().min(1),
+  expiresAt: z.string().trim().min(1),
+});
+const WS_READY_SCHEMA = z.object({
+  type: z.literal("auth.ready"),
+  d: z.object({
+    principalId: z.number().int().positive(),
+  }),
+});
+const FIREBASE_ERROR_SCHEMA = z.object({
+  error: z.object({
+    message: z.string().trim().min(1),
+  }),
+});
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+function logStep(message) {
+  console.log(`[auth-smoke] ${message}`);
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+export function parseArgs(argv) {
+  let mode = "happy-path";
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--mode") {
+      const next = argv[index + 1];
+      if (next === undefined) {
+        fail("--mode requires a value.");
+      }
+      mode = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--mode=")) {
+      mode = arg.slice("--mode=".length);
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    mode: MODE_SCHEMA.parse(mode),
+  };
+}
+
+export function parseEnvFileLine(line) {
+  const trimmed = line.trim();
+  if (trimmed.length === 0 || trimmed.startsWith("#")) {
+    return null;
+  }
+
+  const separatorIndex = trimmed.indexOf("=");
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const key = trimmed.slice(0, separatorIndex).trim();
+  let value = trimmed.slice(separatorIndex + 1).trim();
+
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+
+  return { key, value };
+}
+
+function loadLocalEnv() {
+  const envPath = fileURLToPath(new URL("../.env.local", import.meta.url));
+  if (!existsSync(envPath)) {
+    return;
+  }
+
+  const file = readFileSync(envPath, "utf8");
+  for (const line of file.split(/\r?\n/u)) {
+    const parsed = parseEnvFileLine(line);
+    if (parsed === null) {
+      continue;
+    }
+
+    if (process.env[parsed.key] === undefined) {
+      process.env[parsed.key] = parsed.value;
+    }
+  }
+}
+
+function resolveEnv() {
+  loadLocalEnv();
+  return ENV_SCHEMA.parse(process.env);
+}
+
+export function createApiUrl(baseUrl, path) {
+  const url = new URL(baseUrl);
+  const normalizedPathname = url.pathname.replace(/\/+$/u, "");
+  url.pathname = `${normalizedPathname}${path}`.replace(/\/{2,}/gu, "/");
+  url.search = "";
+  url.hash = "";
+  return url;
+}
+
+export function createWsUrl(baseUrl) {
+  const url = new URL(baseUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    fail("NEXT_PUBLIC_API_URL must use http or https.");
+  }
+  if (url.username !== "" || url.password !== "") {
+    fail("NEXT_PUBLIC_API_URL must not contain userinfo.");
+  }
+  if (url.hostname.trim().length === 0) {
+    fail("NEXT_PUBLIC_API_URL must include a hostname.");
+  }
+
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  const normalizedPathname = url.pathname.replace(/\/+$/u, "");
+  url.pathname = `${normalizedPathname}/ws`.replace(/\/{2,}/gu, "/");
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+async function parseJsonResponse(response) {
+  try {
+    return await response.json();
+  } catch {
+    fail(`Expected JSON response from ${response.url}, but parsing failed.`);
+  }
+}
+
+async function loginWithFirebase(env) {
+  logStep("Logging in with Firebase test user.");
+
+  const loginUrl = new URL("https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword");
+  loginUrl.searchParams.set("key", env.NEXT_PUBLIC_FIREBASE_API_KEY);
+
+  const response = await fetch(loginUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      email: env.AUTH_SMOKE_EMAIL,
+      password: env.AUTH_SMOKE_PASSWORD,
+      returnSecureToken: true,
+    }),
+  });
+
+  const payload = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    const parsedError = FIREBASE_ERROR_SCHEMA.safeParse(payload);
+    if (parsedError.success) {
+      fail(`Firebase login failed: ${parsedError.data.error.message}.`);
+    }
+    fail(`Firebase login failed with unexpected response status ${response.status}.`);
+  }
+
+  const parsed = LOGIN_RESPONSE_SCHEMA.safeParse(payload);
+  if (!parsed.success) {
+    fail("Firebase login response shape is invalid.");
+  }
+
+  return parsed.data;
+}
+
+async function callProtectedPing(apiBaseUrl, idToken) {
+  logStep("Calling protected ping.");
+
+  const response = await fetch(createApiUrl(apiBaseUrl, "/protected/ping"), {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+    },
+  });
+  const payload = await parseJsonResponse(response);
+
+  return {
+    status: response.status,
+    payload,
+  };
+}
+
+async function issueWsTicket(apiBaseUrl, idToken) {
+  logStep("Issuing WS ticket.");
+
+  const response = await fetch(createApiUrl(apiBaseUrl, "/auth/ws-ticket"), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+    },
+  });
+  const payload = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    const parsedError = BACKEND_ERROR_SCHEMA.safeParse(payload);
+    if (parsedError.success) {
+      fail(
+        `WS ticket issuance failed with status ${response.status}: ${parsedError.data.code} (request_id: ${parsedError.data.request_id}).`,
+      );
+    }
+    fail(`WS ticket issuance failed with unexpected response status ${response.status}.`);
+  }
+
+  const parsed = WS_TICKET_SUCCESS_SCHEMA.safeParse(payload);
+  if (!parsed.success) {
+    fail("WS ticket response shape is invalid.");
+  }
+
+  return parsed.data;
+}
+
+async function waitForSocketResult(params) {
+  const { apiBaseUrl, ticket, mode, expectedPrincipalId } = params;
+  logStep(`Connecting to ${createWsUrl(apiBaseUrl)}.`);
+
+  return await new Promise((resolve, reject) => {
+    const socket = new WebSocket(createWsUrl(apiBaseUrl));
+    let settled = false;
+    const timeout = setTimeout(() => {
+      finish(() => {
+        socket.close();
+        reject(new Error(`Timed out waiting for WS ${mode} result.`));
+      });
+    }, DEFAULT_TIMEOUT_MS);
+
+    function finish(callback) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      callback();
+    }
+
+    socket.addEventListener("open", () => {
+      socket.send(
+        JSON.stringify({
+          type: "auth.identify",
+          d: {
+            method: "ticket",
+            ticket,
+          },
+        }),
+      );
+    });
+
+    socket.addEventListener("message", (event) => {
+      if (mode !== "happy-path") {
+        finish(() => {
+          socket.close();
+          reject(new Error(`Expected WS close 1011, but received message: ${String(event.data)}`));
+        });
+        return;
+      }
+
+      let payload;
+      try {
+        payload = JSON.parse(String(event.data));
+      } catch {
+        finish(() => {
+          socket.close();
+          reject(new Error("WS ready message is not valid JSON."));
+        });
+        return;
+      }
+
+      const parsed = WS_READY_SCHEMA.safeParse(payload);
+      if (!parsed.success) {
+        finish(() => {
+          socket.close();
+          reject(new Error("WS ready message shape is invalid."));
+        });
+        return;
+      }
+
+      if (parsed.data.d.principalId !== expectedPrincipalId) {
+        finish(() => {
+          socket.close();
+          reject(
+            new Error(
+              `WS principal mismatch: expected ${expectedPrincipalId}, got ${parsed.data.d.principalId}.`,
+            ),
+          );
+        });
+        return;
+      }
+
+      finish(() => {
+        socket.close();
+        resolve({
+          closeCode: null,
+          closeReason: null,
+          principalId: parsed.data.d.principalId,
+        });
+      });
+    });
+
+    socket.addEventListener("close", (event) => {
+      if (mode === "happy-path") {
+        if (settled) {
+          return;
+        }
+        finish(() => {
+          reject(
+            new Error(
+              `WS closed before auth.ready: code=${event.code}, reason=${event.reason || "<empty>"}.`,
+            ),
+          );
+        });
+        return;
+      }
+
+      finish(() => {
+        resolve({
+          closeCode: event.code,
+          closeReason: event.reason,
+          principalId: null,
+        });
+      });
+    });
+
+    socket.addEventListener("error", () => {
+      finish(() => {
+        reject(new Error("WebSocket connection failed before expected result."));
+      });
+    });
+  });
+}
+
+function assertHappyPathPing(result, localId) {
+  if (result.status !== 200) {
+    fail(`Protected ping returned ${result.status}, expected 200.`);
+  }
+
+  const parsed = PROTECTED_PING_SUCCESS_SCHEMA.safeParse(result.payload);
+  if (!parsed.success) {
+    fail("Protected ping success response shape is invalid.");
+  }
+
+  if (parsed.data.firebase_uid !== localId) {
+    fail(
+      `Firebase UID mismatch: expected ${localId}, got ${parsed.data.firebase_uid} (request_id: ${parsed.data.request_id}).`,
+    );
+  }
+
+  logStep(
+    `Protected ping passed (request_id: ${parsed.data.request_id}, principal_id: ${parsed.data.principal_id}).`,
+  );
+
+  return parsed.data;
+}
+
+function assertDependencyUnavailablePing(result) {
+  if (result.status !== 503) {
+    fail(`Protected ping returned ${result.status}, expected 503.`);
+  }
+
+  const parsed = BACKEND_ERROR_SCHEMA.safeParse(result.payload);
+  if (!parsed.success) {
+    fail("Protected ping error response shape is invalid.");
+  }
+
+  if (parsed.data.code !== "AUTHZ_UNAVAILABLE") {
+    fail(
+      `Protected ping returned ${parsed.data.code}, expected AUTHZ_UNAVAILABLE (request_id: ${parsed.data.request_id}).`,
+    );
+  }
+
+  logStep(
+    `Protected ping failed as expected (request_id: ${parsed.data.request_id}, code: ${parsed.data.code}).`,
+  );
+}
+
+function assertDependencyUnavailableWs(result) {
+  if (result.closeCode !== 1011) {
+    fail(`WS closed with ${result.closeCode}, expected 1011.`);
+  }
+  if (result.closeReason !== "AUTHZ_UNAVAILABLE") {
+    fail(`WS close reason was ${result.closeReason || "<empty>"}, expected AUTHZ_UNAVAILABLE.`);
+  }
+
+  logStep(
+    `WS identify failed as expected (code: ${result.closeCode}, reason: ${result.closeReason}).`,
+  );
+}
+
+async function main() {
+  const { mode } = parseArgs(process.argv.slice(2));
+  const env = resolveEnv();
+  const loginResult = await loginWithFirebase(env);
+  const protectedPingResult = await callProtectedPing(env.NEXT_PUBLIC_API_URL, loginResult.idToken);
+
+  if (mode === "happy-path") {
+    const protectedPing = assertHappyPathPing(protectedPingResult, loginResult.localId);
+    const wsTicket = await issueWsTicket(env.NEXT_PUBLIC_API_URL, loginResult.idToken);
+    const wsResult = await waitForSocketResult({
+      apiBaseUrl: env.NEXT_PUBLIC_API_URL,
+      ticket: wsTicket.ticket,
+      mode,
+      expectedPrincipalId: protectedPing.principal_id,
+    });
+
+    logStep(`WS identify passed (principal_id: ${wsResult.principalId}).`);
+    logStep("Smoke test completed successfully.");
+    return;
+  }
+
+  assertDependencyUnavailablePing(protectedPingResult);
+  const wsTicket = await issueWsTicket(env.NEXT_PUBLIC_API_URL, loginResult.idToken);
+  const wsResult = await waitForSocketResult({
+    apiBaseUrl: env.NEXT_PUBLIC_API_URL,
+    ticket: wsTicket.ticket,
+    mode,
+    expectedPrincipalId: null,
+  });
+  assertDependencyUnavailableWs(wsResult);
+  logStep("Dependency-unavailable smoke test completed successfully.");
+}
+
+const isExecutedAsScript =
+  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (isExecutedAsScript) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[auth-smoke] ${message}`);
+    process.exitCode = 1;
+  });
+}

--- a/typescript/scripts/auth-e2e-smoke.test.mjs
+++ b/typescript/scripts/auth-e2e-smoke.test.mjs
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { createApiUrl, createWsUrl, parseArgs, parseEnvFileLine } from "./auth-e2e-smoke.mjs";
+
+describe("auth-e2e-smoke", () => {
+  test("parseArgs parses --mode=value", () => {
+    expect(parseArgs(["--mode=dependency-unavailable"])).toEqual({
+      mode: "dependency-unavailable",
+    });
+  });
+
+  test("parseArgs rejects unknown flags", () => {
+    expect(() => parseArgs(["--unexpected"])).toThrow("Unknown argument");
+  });
+
+  test("createApiUrl preserves base path and appends endpoint", () => {
+    expect(createApiUrl("https://api.example.com/v1/", "/protected/ping").toString()).toBe(
+      "https://api.example.com/v1/protected/ping",
+    );
+  });
+
+  test("createWsUrl converts http api url into ws endpoint", () => {
+    expect(createWsUrl("http://localhost:8080/api")).toBe("ws://localhost:8080/api/ws");
+  });
+
+  test("createWsUrl rejects userinfo", () => {
+    expect(() => createWsUrl("https://user:pass@example.com")).toThrow("must not contain userinfo");
+  });
+
+  test("parseEnvFileLine ignores comments and unwraps quoted values", () => {
+    expect(parseEnvFileLine("# comment")).toBeNull();
+    expect(parseEnvFileLine('AUTH_SMOKE_EMAIL="user@example.com"')).toEqual({
+      key: "AUTH_SMOKE_EMAIL",
+      value: "user@example.com",
+    });
+  });
+});


### PR DESCRIPTION
## 概要
- 認証の最小E2Eスモークを Node script で追加
- runbook にローカル再現手順と AuthZ 障害系の確認手順を追記
- agent_runs に実装/検証証跡を追加

## 変更内容
- `typescript/scripts/auth-e2e-smoke.mjs` を追加
- `typescript/package.json` に `smoke:auth` を追加
- `typescript/.env.example` に smoke 用資格情報を追加
- auth 関連 runbook を更新
- `docs/agent_runs/LIN-645/*` を追加

## 変更の意図
- Firebase login から REST/WS 認証完了までを最小構成で自動確認できるようにするため
- AuthZ fail-close の `503 / 1011` をローカルで再現・切り分けしやすくするため
- 実装と運用手順の前提を runbook に揃えるため

## 受け入れ条件対応
- Firebase login -> protected ping -> ws-ticket -> ws identify の最小自動スモークを追加済み
- AuthZ dependency unavailable 時の `503 / AUTHZ_UNAVAILABLE` と `1011 / AUTHZ_UNAVAILABLE` を検証可能
- runbook からローカル再現手順を追える状態に更新済み

## テスト
- `node --check typescript/scripts/auth-e2e-smoke.mjs`
- `cd typescript && npm run typecheck`
- `cd typescript && npm run test -- scripts/auth-e2e-smoke.test.mjs`
- `cd typescript && npm run test -- src/entities/auth/api/ws-ticket.test.ts src/entities/auth/api/principal-provisioning.test.ts src/app/providers/ws-auth-bridge.test.tsx`
- `cd typescript && npm run test`
- `make rust-lint`
- `make validate`

## Review / UI Gate
- `reviewer_ui_guard`: run_ui_checks=false
- `reviewer`: この session ではタイムアウト
- `reviewer_simple`: pass

## Runtime smoke
- 未実施
- 理由: `typescript/.env.local` に `AUTH_SMOKE_EMAIL` / `AUTH_SMOKE_PASSWORD` が未設定で、ローカルでは `rust` / `spicedb` も未起動だったため
- 実行コマンド:
  - `cd typescript && npm run smoke:auth -- --mode=happy-path`
  - `cd typescript && npm run smoke:auth -- --mode=dependency-unavailable`

## Linear
- https://linear.app/linklynx-ai/issue/LIN-645

## レビュー確認項目
- [ ] smoke script の入出力と期待値
- [ ] runbook 手順と実装の整合
- [ ] runtime smoke 未実施理由の妥当性