### PR TITLE
LIN-795 REST rate-limit 契約と制御を追加

### DIFF
--- a/database/contracts/lin139_runtime_contracts.md
+++ b/database/contracts/lin139_runtime_contracts.md
@@ -110,11 +110,20 @@ LIN-139 のスコープに含め、スキーマ実装とセットで適用しま
 - Dragonfly（Redis互換L2）障害時はハイブリッド方針を適用する。
   - 高リスク操作（認証試行、招待悪用対策、アカウント保護系）は `fail-close`
   - 継続性重視の主要書き込み/読み取り・セッション継続は `degraded fail-open`（L1判定のみ継続）
+- v1 最小REST surface の current mapping:
+  - `GET /v1/guilds/{guild_id}/invites/{invite_code}` は high-risk abuse surface
+  - `PATCH /v1/moderation/guilds/{guild_id}/members/{member_id}` は high-risk abuse surface
+  - `POST /v1/guilds/{guild_id}/channels/{channel_id}/messages` は core write path
+  - `POST /v1/dms/{channel_id}/messages` は core write path
 - Degraded移行条件:
-  - healthcheck連続失敗（約30秒）または L2 エラー率 `>= 20%`（1分窓）
+  - healthcheck連続失敗（約30秒）または L2 エラー率 `>= 20%`（1分窓、最低 `10` サンプル到達後）
 - Degraded解除条件:
   - 10分連続健全 かつ L2 エラー率 `< 1%`
 - 復旧後は全量再計算を行わず、既存の `SET ... NX EX` ベース再構築手順を継続しつつ10分ウォームアップ監視を実施する。
+- REST contract:
+  - 対象surfaceで閾値超過時は `429 Too Many Requests` + `Retry-After`
+  - high-risk surface は degraded 時も `429 + Retry-After` で fail-close
+  - degraded 状態を変更する公開/保護 REST endpoint は提供しない
 
 - 必須キー:
   - `rl2:gcra:user:{user_id}:{action}`

--- a/docs/agent_runs/LIN-795/Documentation.md
+++ b/docs/agent_runs/LIN-795/Documentation.md
@@ -1,0 +1,28 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now:
+  - `LIN-795` 親実装として REST rate-limit 基盤、対象 route 適用、しきい値/契約更新を完了。
+  - 既存 WS 用固定窓リミッタを REST 側でも使えるよう一般化し、`429 + Retry-After` を返すようにした。
+  - internal の rate-limit mutation/metrics endpoint は review 指摘を受けて撤去し、公開 API から degraded 状態を操作できない形に修正した。
+- Verification:
+  - `cargo test -p linklynx_backend`
+  - `make rust-lint`
+  - `make validate`
+  - `reviewer_simple` 再レビューで internal ratelimit endpoint 起因の security finding 解消を確認
+
+## Decisions
+- Dragonfly 実クライアント導入はこの issue の非対象とし、ADR-005 の policy / threshold / observability を先に固定する。
+- 高リスク経路は degraded 時に `429 + Retry-After` で fail-close し、message create は degraded 時も L1-only で継続する。
+- L2 error-rate による degraded enter は単発エラーで誤作動しないよう、最低 `10` サンプル到達後に評価する。
+- operational control を通常 AuthZ 経路の `View` へ載せるのは危険なので、rate-limit の internal REST endpoint は追加しない。
+
+## How to run / demo
+- 1. `cd rust && cargo test -p linklynx_backend ratelimit`
+- 2. `cd rust && cargo test -p linklynx_backend main::tests`
+- 3. `make rust-lint`
+- 4. `make validate`
+
+## Known issues / follow-ups
+- Dragonfly への実 healthcheck / shared L2 call はまだ未接続で、rate-limit 実装は現在もノード内 L1 固定窓が中心。
+- review では「実 Dragonfly-backed shared limiter への接続」と「runtime からの自動 degraded 観測投入」が追加フォローアップ候補として残った。

--- a/docs/agent_runs/LIN-795/Implement.md
+++ b/docs/agent_runs/LIN-795/Implement.md
@@ -1,0 +1,6 @@
+# Implement.md (Runbook)
+
+- `LIN-805 -> LIN-809 -> LIN-815` の順を崩さない。
+- 差分は rate-limit 基盤、REST 適用、runbook/metrics の 3 論理単位に保つ。
+- 検証失敗時はその場で修正し、次のマイルストーンへ進まない。
+- `Documentation.md` に判断・検証結果・既知制約を随時追記する。

--- a/docs/agent_runs/LIN-795/Plan.md
+++ b/docs/agent_runs/LIN-795/Plan.md
@@ -1,0 +1,41 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: if validation fails, repair it before moving to the next step.
+
+## Milestones
+### M1: LIN-805 ポリシー基盤の実装
+- Acceptance criteria:
+  - [ ] operation class と action mapping が Rust コードに入る
+  - [ ] degraded enter/exit threshold がコード上で表現される
+  - [ ] internal metrics snapshot で threshold と状態を観測できる
+- Validation:
+  - `cd rust && cargo test -p linklynx_backend ratelimit`
+
+### M2: LIN-809 REST rate limit 適用
+- Acceptance criteria:
+  - [ ] 投稿/招待/モデレーション経路へ rate limit が適用される
+  - [ ] 超過時 `429 + Retry-After` を返す
+  - [ ] degraded 時に高リスク fail-close / message create fail-open が分岐する
+- Validation:
+  - `cd rust && cargo test -p linklynx_backend main::tests`
+
+### M3: LIN-815 監視/文書/障害試験整備
+- Acceptance criteria:
+  - [ ] runbook を追加し監視条件と障害模擬手順を記載する
+  - [ ] rate-limit internal metrics / observation が runbook 手順を支える
+  - [ ] runtime contract 参照文書が更新される
+- Validation:
+  - `cd rust && cargo test -p linklynx_backend ratelimit`
+  - `make validate`
+  - `make rust-lint`
+
+### M4: 横断検証
+- Acceptance criteria:
+  - [ ] `make validate` が成功
+  - [ ] `make rust-lint` が成功
+  - [ ] reviewer gate を通過する
+- Validation:
+  - `make validate`
+  - `make rust-lint`
+  - `spawn_agent(reviewer)`

--- a/docs/agent_runs/LIN-795/Prompt.md
+++ b/docs/agent_runs/LIN-795/Prompt.md
@@ -1,0 +1,27 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- `LIN-795` 親 issue として、`LIN-805 -> LIN-809 -> LIN-815` の順で最小レート制限/スパム対策を実装する。
+- 投稿/招待/モデレーション経路へ最小限の rate limit を適用し、`429 + Retry-After` 契約を統一する。
+- Dragonfly 障害時の degraded enter/exit 条件と fail-close / fail-open の経路別挙動をコードと運用手順に固定する。
+
+## Non-goals
+- ML ベースのスパム判定。
+- Redis/Dragonfly の実通信プロバイダ導入やアルゴリズム刷新。
+- 対象外経路への横展開。
+
+## Deliverables
+- Rust backend に operation class / degraded threshold / internal metrics を備えた rate-limit 基盤を追加する。
+- `/v1/guilds/{guild_id}/invites/{invite_code}`、`/v1/guilds/{guild_id}/channels/{channel_id}/messages`、`/v1/dms/{channel_id}/messages`、`/v1/moderation/guilds/{guild_id}/members/{member_id}` へ rate limit を適用する。
+- `docs/runbooks/dragonfly-ratelimit-operations-runbook.md` を追加し、監視条件と障害模擬試験手順を文書化する。
+
+## Done when
+- [ ] operation class と degraded threshold が ADR-005 / `database/contracts/lin139_runtime_contracts.md` と整合する。
+- [ ] 対象 REST 経路で超過時に `429 + Retry-After` が返る。
+- [ ] 高リスク経路は degraded 時に fail-close、message create は degraded 時に L1-only で継続する。
+- [ ] internal metrics / observation と runbook で degraded 遷移と復帰手順が再現できる。
+
+## Constraints
+- Perf: 既存 `FixedWindowRateLimiter` を再利用し、最小差分で実装する。
+- Security: invite / moderation は高リスク経路として degraded 時に fail-close を維持する。
+- Compatibility: 既存 Auth/AuthZ 応答契約は維持し、対象経路にのみ `429 + Retry-After` を追加する。

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -9,6 +9,7 @@
 - `authz-spicedb-local-ci-runtime-runbook.md`: SpiceDB local/CI runtime baseline (env contract, docker startup, health check, and troubleshooting).
 - `authz-spicedb-tuple-sync-operations-runbook.md`: Postgres -> SpiceDB tuple mapping/backfill/outbox delta-sync baseline and full-resync operational hook.
 - `session-resume-dragonfly-operations-runbook.md`: Session/resume/TTL continuity baseline on Dragonfly, including degraded behavior and TTL rollout/rollback procedure.
+- `dragonfly-ratelimit-operations-runbook.md`: Dragonfly-backed rate-limit degraded enter/exit, `429 + Retry-After`, and outage simulation baseline for minimal v1 abuse controls.
 - `realtime-nats-core-subject-subscription-runbook.md`: NATS Core subject naming contract, Gateway/Fanout subscribe-unsubscribe lifecycle, reconnect baseline, and outage handling for v0 realtime delivery.
 - `scylla-node-loss-backup-runbook.md`: Scylla node-loss continuity decisions and minimum backup/restore execution baseline for v0.
 - `gcs-signed-url-retention-operations-runbook.md`: GCS attachment signed URL issuance/reissue flow, accidental deletion recovery, and retention policy change baseline.

--- a/docs/runbooks/dragonfly-ratelimit-operations-runbook.md
+++ b/docs/runbooks/dragonfly-ratelimit-operations-runbook.md
@@ -1,0 +1,134 @@
+# Dragonfly RateLimit Operations Runbook (Draft)
+
+- Status: Draft
+- Last updated: 2026-03-06
+- Owner scope: v1 minimal rate-limit / spam protection baseline
+- References:
+  - `database/contracts/lin139_runtime_contracts.md`
+  - [ADR-005 Dragonfly Outage RateLimit Failure Policy (Hybrid)](../adr/ADR-005-dragonfly-ratelimit-failure-policy.md)
+  - `LIN-795`
+
+## 1. Purpose and scope
+
+This runbook fixes one operational baseline for the minimal v1 rate-limit controls on invite, moderation, and message-create surfaces.
+
+In scope:
+
+- Operation class mapping for current v1 minimal REST surfaces
+- `429 + Retry-After` verification steps
+- Dragonfly degraded enter/exit monitoring conditions
+- Failure simulation and threshold validation in controlled test code
+- Recovery observation and warm-up checks
+
+Out of scope:
+
+- Dragonfly provider implementation details
+- Full L2 bucket reconstruction algorithm changes
+- Rate-limit expansion to other surfaces
+
+## 2. Fixed baseline values
+
+| item | baseline |
+| --- | --- |
+| Invite access limit | `10/min` |
+| Moderation action limit | `5/min` |
+| Message create limit | `30/min` |
+| Degraded enter | `30s` continuous healthcheck failure or `>= 20%` L2 error rate in `1m` after `10` samples |
+| Degraded exit | `10m` healthy streak and `< 1%` L2 error rate |
+| Fail-close retry-after | `60s` |
+
+## 3. Operation class mapping
+
+| route surface | class | degraded behavior |
+| --- | --- | --- |
+| `GET /v1/guilds/{guild_id}/invites/{invite_code}` | `high-risk abuse surface` | fail-close |
+| `PATCH /v1/moderation/guilds/{guild_id}/members/{member_id}` | `high-risk abuse surface` | fail-close |
+| `POST /v1/guilds/{guild_id}/channels/{channel_id}/messages` | `core write path` | degraded fail-open (L1 only) |
+| `POST /v1/dms/{channel_id}/messages` | `core write path` | degraded fail-open (L1 only) |
+
+## 4. Exposure boundary
+
+- No public or protected REST endpoint is exposed to mutate degraded state.
+- Failure/degraded drills for this phase are validated through automated Rust tests and direct service hooks in controlled environments only.
+
+## 5. Verification procedures
+
+### 5.1 Scenario A: rate limit exceeded
+
+Procedure:
+
+1. Send repeated requests to one protected surface with the same principal.
+2. Exceed the configured per-minute threshold.
+3. Confirm the response becomes `429 Too Many Requests`.
+4. Confirm `Retry-After` is present.
+
+Pass criteria:
+
+- `429` is returned only after threshold exceed.
+- `Retry-After` is present and non-zero.
+
+### 5.2 Scenario B: Dragonfly degraded -> high-risk fail-close
+
+Procedure:
+
+1. In a controlled test harness, inject repeated failure observations into the rate-limit monitor.
+2. Wait until degraded enters by threshold.
+3. Call invite or moderation endpoint.
+4. Confirm request is rejected with `429 + Retry-After`.
+5. Confirm the rejection occurs only after degraded entry.
+
+Pass criteria:
+
+- degraded state becomes `true`.
+- invite / moderation clearly fail-close with no ambiguous behavior.
+
+### 5.3 Scenario C: Dragonfly degraded -> message create continuity
+
+Procedure:
+
+1. Enter degraded mode as in Scenario B.
+2. Call one of the message create endpoints.
+3. Confirm the request still succeeds while local fixed-window budget remains.
+
+Pass criteria:
+
+- message create continues under degraded state.
+- L1 threshold still applies normally.
+
+### 5.4 Scenario D: recovery and exit
+
+Procedure:
+
+1. After degraded entry, submit healthy observations in the same controlled harness.
+2. Keep healthy streak for at least `10m`.
+3. Keep L2 error rate below `1%`.
+4. Confirm degraded exits.
+5. Observe for another `10m` warm-up window.
+
+Pass criteria:
+
+- degraded returns to `false` only after both exit conditions are met.
+- no full bucket recomputation is required.
+
+## 6. Suggested alerts
+
+1. degraded entered immediately
+2. degraded duration exceeds `15m`
+3. `dragonfly_unavailable_total` keeps increasing for `5m`
+4. `high_risk_fail_close_total` spikes above baseline
+
+## 7. Operational record template
+
+```markdown
+### Dragonfly RateLimit Incident Record
+
+- Date:
+- Environment:
+- Trigger:
+- Degraded entered at:
+- High-risk fail-close observed: yes/no
+- Message create continuity observed: yes/no
+- Degraded exited at:
+- Warm-up result:
+- Follow-up issues:
+```

--- a/rust/apps/api/src/auth/tests.rs
+++ b/rust/apps/api/src/auth/tests.rs
@@ -473,6 +473,19 @@ mod tests {
         assert!(!limiter.check_and_record("k-1").await);
     }
 
+    #[tokio::test]
+    async fn fixed_window_rate_limiter_returns_retry_after_when_limited() {
+        let limiter = FixedWindowRateLimiter::new(1, Duration::from_secs(60));
+        let allowed = limiter.check_and_record_with_retry_after("k-2").await;
+        let limited = limiter.check_and_record_with_retry_after("k-2").await;
+
+        assert!(allowed.allowed);
+        assert_eq!(allowed.retry_after, None);
+        assert!(!limited.allowed);
+        assert!(limited.retry_after.is_some());
+        assert!(limited.retry_after.unwrap() > Duration::from_secs(0));
+    }
+
     #[test]
     fn parse_ws_origin_allowlist_normalizes_entries() {
         let parsed =

--- a/rust/apps/api/src/auth/ws_ticket.rs
+++ b/rust/apps/api/src/auth/ws_ticket.rs
@@ -121,6 +121,12 @@ struct FixedWindowBucket {
     count: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FixedWindowDecision {
+    pub allowed: bool,
+    pub retry_after: Option<Duration>,
+}
+
 #[derive(Debug, Clone)]
 pub struct FixedWindowRateLimiter {
     max_requests: u32,
@@ -147,6 +153,14 @@ impl FixedWindowRateLimiter {
     /// @returns 許可時 `true`
     /// @throws なし
     pub async fn check_and_record(&self, key: &str) -> bool {
+        self.check_and_record_with_retry_after(key).await.allowed
+    }
+
+    /// キーごとにリクエスト可否と待機時間を判定して記録する。
+    /// @param key 判定キー
+    /// @returns 判定結果
+    /// @throws なし
+    pub async fn check_and_record_with_retry_after(&self, key: &str) -> FixedWindowDecision {
         let now = Instant::now();
         let mut buckets = self.buckets.lock().await;
 
@@ -167,11 +181,17 @@ impl FixedWindowRateLimiter {
         }
 
         if bucket.count >= self.max_requests {
-            return false;
+            return FixedWindowDecision {
+                allowed: false,
+                retry_after: Some(self.window.saturating_sub(now.duration_since(bucket.window_started_at))),
+            };
         }
 
         bucket.count = bucket.count.saturating_add(1);
-        true
+        FixedWindowDecision {
+            allowed: true,
+            retry_after: None,
+        }
     }
 }
 

--- a/rust/apps/api/src/main.rs
+++ b/rust/apps/api/src/main.rs
@@ -2,6 +2,7 @@ mod auth;
 mod authz;
 mod guild_channel;
 mod profile;
+mod ratelimit;
 
 use std::{
     collections::HashSet,
@@ -30,7 +31,7 @@ use axum::{
         ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade},
         Extension, Path, Query, State,
     },
-    http::{HeaderMap, Request, StatusCode},
+    http::{header::RETRY_AFTER, HeaderMap, HeaderValue, Request, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, patch, post},
@@ -43,6 +44,9 @@ use guild_channel::{
 use profile::{
     build_runtime_profile_service, profile_error_response, ProfileError, ProfilePatchInput,
     ProfileService,
+};
+use ratelimit::{
+    build_runtime_rest_rate_limit_service, rest_rate_limit_action_for_request, RestRateLimitService,
 };
 use serde::{Deserialize, Serialize};
 use tower_http::cors::{Any, CorsLayer};
@@ -62,6 +66,7 @@ pub(crate) struct AppState {
     ws_ticket_rate_limiter: Arc<FixedWindowRateLimiter>,
     ws_identify_rate_limiter: Arc<FixedWindowRateLimiter>,
     ws_origin_allowlist: Arc<WsOriginAllowlist>,
+    rest_rate_limit_service: Arc<RestRateLimitService>,
 }
 
 #[tokio::main]
@@ -143,6 +148,7 @@ fn build_runtime_state() -> AppState {
             Duration::from_secs(60),
         )),
         ws_origin_allowlist: Arc::new(build_runtime_ws_origin_allowlist()),
+        rest_rate_limit_service: Arc::new(build_runtime_rest_rate_limit_service()),
     }
 }
 

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -517,6 +517,31 @@ struct ApiErrorResponse {
     request_id: String,
 }
 
+/// レート制限エラー応答を生成する。
+/// @param code エラーコード
+/// @param message エラーメッセージ
+/// @param request_id リクエストID
+/// @param retry_after_seconds Retry-After秒
+/// @returns RESTエラーレスポンス
+/// @throws なし
+fn rate_limit_error_response(
+    code: &'static str,
+    message: &'static str,
+    request_id: String,
+    retry_after_seconds: u64,
+) -> Response {
+    let body = ApiErrorResponse {
+        code,
+        message,
+        request_id,
+    };
+    let mut response = (StatusCode::TOO_MANY_REQUESTS, Json(body)).into_response();
+    if let Ok(retry_after_value) = HeaderValue::from_str(&retry_after_seconds.max(1).to_string()) {
+        response.headers_mut().insert(RETRY_AFTER, retry_after_value);
+    }
+    response
+}
+
 /// WS identify用ワンタイムチケットを発行する。
 /// @param state アプリケーション状態
 /// @param headers HTTPヘッダー
@@ -1131,6 +1156,50 @@ async fn rest_auth_middleware(
         email_verified = true,
         "REST auth accepted"
     );
+
+    if let Some(rate_limit_action) = rest_rate_limit_action_for_request(&request_method, &request_path)
+    {
+        let decision = state
+            .rest_rate_limit_service
+            .evaluate(authenticated.principal_id, rate_limit_action)
+            .await;
+        if !decision.allowed() {
+            let error_class = if decision.is_fail_close() {
+                "rate_limit_fail_close"
+            } else {
+                "rate_limited"
+            };
+            let reason = if decision.is_fail_close() {
+                "dragonfly_degraded_fail_close"
+            } else {
+                "rate_limit_exceeded"
+            };
+            let message = if decision.is_fail_close() {
+                "request rejected while rate-limit dependency is degraded"
+            } else {
+                "request rate limit exceeded"
+            };
+            tracing::warn!(
+                decision = "deny",
+                request_id = %request_id,
+                principal_id = authenticated.principal_id.0,
+                error_class = error_class,
+                reason = reason,
+                resource = %request_path,
+                action = decision.action().label(),
+                operation_class = ?decision.operation_class(),
+                degraded = decision.degraded(),
+                decision_source = "rest_rate_limit_service",
+                "REST request rejected by rate limit"
+            );
+            return rate_limit_error_response(
+                "RATE_LIMITED",
+                message,
+                request_id,
+                decision.retry_after_seconds().unwrap_or(1),
+            );
+        }
+    }
 
     let action = rest_authz_action_for_request(&request_method, &request_path);
     let action_label = match action {

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ratelimit::RestRateLimitConfig;
     use async_trait::async_trait;
     use std::collections::HashSet;
     use auth::{
@@ -17,7 +18,7 @@ mod tests {
     use profile::{ProfileError, ProfilePatchInput, ProfileService, ProfileSettings};
     use axum::{
         body::to_bytes,
-        http::{Method, StatusCode},
+        http::{header::RETRY_AFTER, Method, StatusCode},
     };
     use linklynx_shared::PrincipalId;
     use tower::ServiceExt;
@@ -460,6 +461,9 @@ mod tests {
                 "http://localhost:3000".to_owned(),
                 "http://127.0.0.1:3000".to_owned(),
             ]))),
+            rest_rate_limit_service: Arc::new(RestRateLimitService::new(
+                RestRateLimitConfig::default(),
+            )),
         }
     }
 
@@ -1832,6 +1836,116 @@ mod tests {
         let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
         assert_eq!(json["code"], "AUTHZ_UNAVAILABLE");
         assert_eq!(json["request_id"], "moderation-authz-unavailable-test");
+    }
+
+    #[tokio::test]
+    async fn invite_endpoint_returns_retry_after_when_rate_limited() {
+        let app = app_for_test_with_authorizer(Arc::new(RoleScenarioAuthorizer)).await;
+        let token = format!("u-owner:{}", unix_timestamp_seconds() + 300);
+        let mut last_response = None;
+
+        for _ in 0..11 {
+            last_response = Some(
+                app.clone()
+                    .oneshot(
+                        Request::builder()
+                            .uri("/v1/guilds/10/invites/invite-abc")
+                            .header("authorization", format!("Bearer {token}"))
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        let response = last_response.unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            response
+                .headers()
+                .get(RETRY_AFTER)
+                .and_then(|value| value.to_str().ok()),
+            Some("60")
+        );
+    }
+
+    #[tokio::test]
+    async fn moderation_endpoint_fail_closes_when_ratelimit_degraded() {
+        let state = state_for_test_with_authorizer(Arc::new(RoleScenarioAuthorizer)).await;
+        state.rest_rate_limit_service.set_degraded_for_test(true).await;
+        let app = app_with_state(state);
+        let token = format!("u-admin:{}", unix_timestamp_seconds() + 300);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/v1/moderation/guilds/10/members/9003")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            response
+                .headers()
+                .get(RETRY_AFTER)
+                .and_then(|value| value.to_str().ok()),
+            Some("60")
+        );
+    }
+
+    #[tokio::test]
+    async fn message_create_continues_with_l1_when_ratelimit_degraded() {
+        let state = state_for_test_with_authorizer(Arc::new(RoleScenarioAuthorizer)).await;
+        state.rest_rate_limit_service.set_degraded_for_test(true).await;
+        let app = app_with_state(state);
+        let token = format!("u-member:{}", unix_timestamp_seconds() + 300);
+        let first_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/dms/55/messages")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first_response.status(), StatusCode::OK);
+
+        let mut last_response = None;
+
+        for _ in 0..30 {
+            last_response = Some(
+                app.clone()
+                    .oneshot(
+                        Request::builder()
+                            .method("POST")
+                            .uri("/v1/dms/55/messages")
+                            .header("authorization", format!("Bearer {token}"))
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        let response = last_response.unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            response
+                .headers()
+                .get(RETRY_AFTER)
+                .and_then(|value| value.to_str().ok()),
+            Some("60")
+        );
     }
 
     #[test]

--- a/rust/apps/api/src/ratelimit.rs
+++ b/rust/apps/api/src/ratelimit.rs
@@ -1,0 +1,976 @@
+use std::{
+    collections::VecDeque,
+    env,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use axum::http::Method;
+use linklynx_shared::PrincipalId;
+use serde::Serialize;
+use tokio::sync::Mutex;
+
+use crate::auth::FixedWindowRateLimiter;
+
+const DEFAULT_WINDOW_SECONDS: u64 = 60;
+const DEFAULT_MESSAGE_CREATE_MAX_PER_MINUTE: u32 = 30;
+const DEFAULT_INVITE_ACCESS_MAX_PER_MINUTE: u32 = 10;
+const DEFAULT_MODERATION_MAX_PER_MINUTE: u32 = 5;
+const DEFAULT_DEGRADED_ENTER_HEALTHCHECK_FAILURE_SECONDS: u64 = 30;
+const DEFAULT_DEGRADED_ENTER_L2_ERROR_RATE_PERCENT: u64 = 20;
+const DEFAULT_DEGRADED_ENTER_MIN_L2_SAMPLES: u64 = 10;
+const DEFAULT_DEGRADED_EXIT_HEALTHY_SECONDS: u64 = 600;
+const DEFAULT_DEGRADED_EXIT_L2_ERROR_RATE_PERCENT: u64 = 1;
+const DEFAULT_FAIL_CLOSE_RETRY_AFTER_SECONDS: u64 = 60;
+const L2_ERROR_RATE_WINDOW_SECONDS: u64 = 60;
+
+/// レート制限の operation class を表現する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RateLimitOperationClass {
+    HighRiskAbuseSurface,
+    CoreWritePath,
+    #[allow(dead_code)]
+    // ADR-005 contract includes continuity class; this module does not map a REST surface to it yet.
+    ReadSessionContinuity,
+}
+
+/// RESTレート制限対象アクションを表現する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestRateLimitAction {
+    InviteAccess,
+    ModerationAction,
+    MessageCreate,
+}
+
+impl RestRateLimitAction {
+    /// アクションのログ/キー用ラベルを返す。
+    /// @param なし
+    /// @returns アクションラベル
+    /// @throws なし
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::InviteAccess => "invite_access",
+            Self::ModerationAction => "moderation_action",
+            Self::MessageCreate => "message_create",
+        }
+    }
+
+    /// アクションの operation class を返す。
+    /// @param なし
+    /// @returns operation class
+    /// @throws なし
+    pub fn operation_class(self) -> RateLimitOperationClass {
+        match self {
+            Self::InviteAccess | Self::ModerationAction => {
+                RateLimitOperationClass::HighRiskAbuseSurface
+            }
+            Self::MessageCreate => RateLimitOperationClass::CoreWritePath,
+        }
+    }
+
+    /// アクションの既定リクエスト上限を返す。
+    /// @param なし
+    /// @returns 1分あたり上限
+    /// @throws なし
+    fn default_max_requests(self) -> u32 {
+        match self {
+            Self::InviteAccess => DEFAULT_INVITE_ACCESS_MAX_PER_MINUTE,
+            Self::ModerationAction => DEFAULT_MODERATION_MAX_PER_MINUTE,
+            Self::MessageCreate => DEFAULT_MESSAGE_CREATE_MAX_PER_MINUTE,
+        }
+    }
+}
+
+/// Dragonfly degraded 判定しきい値を保持する。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DragonflyDegradedThresholds {
+    pub enter_after_healthcheck_failure: Duration,
+    pub enter_after_l2_error_rate: f64,
+    pub enter_min_l2_samples: usize,
+    pub exit_after_healthy_duration: Duration,
+    pub exit_when_l2_error_rate_below: f64,
+}
+
+impl Default for DragonflyDegradedThresholds {
+    /// ADR-005 既定値を返す。
+    /// @param なし
+    /// @returns 既定しきい値
+    /// @throws なし
+    fn default() -> Self {
+        Self {
+            enter_after_healthcheck_failure: Duration::from_secs(
+                DEFAULT_DEGRADED_ENTER_HEALTHCHECK_FAILURE_SECONDS,
+            ),
+            enter_after_l2_error_rate: DEFAULT_DEGRADED_ENTER_L2_ERROR_RATE_PERCENT as f64 / 100.0,
+            enter_min_l2_samples: DEFAULT_DEGRADED_ENTER_MIN_L2_SAMPLES as usize,
+            exit_after_healthy_duration: Duration::from_secs(DEFAULT_DEGRADED_EXIT_HEALTHY_SECONDS),
+            exit_when_l2_error_rate_below: DEFAULT_DEGRADED_EXIT_L2_ERROR_RATE_PERCENT as f64
+                / 100.0,
+        }
+    }
+}
+
+/// RESTレート制限構成を保持する。
+#[derive(Debug, Clone, Copy)]
+pub struct RestRateLimitConfig {
+    pub window: Duration,
+    pub message_create_max_requests: u32,
+    pub invite_access_max_requests: u32,
+    pub moderation_max_requests: u32,
+    pub degraded_thresholds: DragonflyDegradedThresholds,
+    pub fail_close_retry_after: Duration,
+}
+
+impl Default for RestRateLimitConfig {
+    /// ADR-005 と v1 最小 REST surface の既定構成を返す。
+    /// @param なし
+    /// @returns 既定構成
+    /// @throws なし
+    fn default() -> Self {
+        Self {
+            window: Duration::from_secs(DEFAULT_WINDOW_SECONDS),
+            message_create_max_requests: DEFAULT_MESSAGE_CREATE_MAX_PER_MINUTE,
+            invite_access_max_requests: DEFAULT_INVITE_ACCESS_MAX_PER_MINUTE,
+            moderation_max_requests: DEFAULT_MODERATION_MAX_PER_MINUTE,
+            degraded_thresholds: DragonflyDegradedThresholds::default(),
+            fail_close_retry_after: Duration::from_secs(DEFAULT_FAIL_CLOSE_RETRY_AFTER_SECONDS),
+        }
+    }
+}
+
+impl RestRateLimitConfig {
+    /// 環境変数から構成を生成する。
+    /// @param なし
+    /// @returns 実行時構成
+    /// @throws なし
+    pub fn from_env() -> Self {
+        Self {
+            window: Duration::from_secs(parse_env_u64(
+                "RATE_LIMIT_WINDOW_SECONDS",
+                DEFAULT_WINDOW_SECONDS,
+            )),
+            message_create_max_requests: parse_env_u32(
+                "RATE_LIMIT_MESSAGE_CREATE_MAX_PER_MINUTE",
+                RestRateLimitAction::MessageCreate.default_max_requests(),
+            ),
+            invite_access_max_requests: parse_env_u32(
+                "RATE_LIMIT_INVITE_ACCESS_MAX_PER_MINUTE",
+                RestRateLimitAction::InviteAccess.default_max_requests(),
+            ),
+            moderation_max_requests: parse_env_u32(
+                "RATE_LIMIT_MODERATION_MAX_PER_MINUTE",
+                RestRateLimitAction::ModerationAction.default_max_requests(),
+            ),
+            degraded_thresholds: DragonflyDegradedThresholds {
+                enter_after_healthcheck_failure: Duration::from_secs(parse_env_u64(
+                    "RATE_LIMIT_DEGRADED_ENTER_HEALTHCHECK_FAILURE_SECONDS",
+                    DEFAULT_DEGRADED_ENTER_HEALTHCHECK_FAILURE_SECONDS,
+                )),
+                enter_after_l2_error_rate: parse_env_u64(
+                    "RATE_LIMIT_DEGRADED_ENTER_L2_ERROR_RATE_PERCENT",
+                    DEFAULT_DEGRADED_ENTER_L2_ERROR_RATE_PERCENT,
+                ) as f64
+                    / 100.0,
+                enter_min_l2_samples: parse_env_u64(
+                    "RATE_LIMIT_DEGRADED_ENTER_MIN_L2_SAMPLES",
+                    DEFAULT_DEGRADED_ENTER_MIN_L2_SAMPLES,
+                ) as usize,
+                exit_after_healthy_duration: Duration::from_secs(parse_env_u64(
+                    "RATE_LIMIT_DEGRADED_EXIT_HEALTHY_SECONDS",
+                    DEFAULT_DEGRADED_EXIT_HEALTHY_SECONDS,
+                )),
+                exit_when_l2_error_rate_below: parse_env_u64(
+                    "RATE_LIMIT_DEGRADED_EXIT_L2_ERROR_RATE_PERCENT",
+                    DEFAULT_DEGRADED_EXIT_L2_ERROR_RATE_PERCENT,
+                ) as f64
+                    / 100.0,
+            },
+            fail_close_retry_after: Duration::from_secs(parse_env_u64(
+                "RATE_LIMIT_FAIL_CLOSE_RETRY_AFTER_SECONDS",
+                DEFAULT_FAIL_CLOSE_RETRY_AFTER_SECONDS,
+            )),
+        }
+    }
+}
+
+/// Dragonfly 観測入力を保持する。
+#[derive(Debug, Clone, Copy)]
+#[cfg(test)]
+pub struct DragonflyObservation {
+    pub healthcheck_success: Option<bool>,
+    pub l2_result_success: Option<bool>,
+}
+
+/// Dragonfly 状態スナップショットを保持する。
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct DragonflyStatusSnapshot {
+    pub degraded: bool,
+    pub healthcheck_failure_streak_seconds: u64,
+    pub healthy_streak_seconds: u64,
+    pub l2_error_rate: f64,
+    pub l2_sample_total: u64,
+}
+
+/// リクエスト判定結果を保持する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RateLimitDecision {
+    allowed: bool,
+    fail_close: bool,
+    retry_after_seconds: Option<u64>,
+    action: RestRateLimitAction,
+    operation_class: RateLimitOperationClass,
+    degraded: bool,
+}
+
+impl RateLimitDecision {
+    /// 許可判定を生成する。
+    /// @param action 対象アクション
+    /// @param degraded degraded状態
+    /// @returns 許可判定
+    /// @throws なし
+    fn allow(action: RestRateLimitAction, degraded: bool) -> Self {
+        Self {
+            allowed: true,
+            fail_close: false,
+            retry_after_seconds: None,
+            action,
+            operation_class: action.operation_class(),
+            degraded,
+        }
+    }
+
+    /// 拒否判定を生成する。
+    /// @param action 対象アクション
+    /// @param fail_close fail-close適用有無
+    /// @param retry_after_seconds Retry-After秒
+    /// @param degraded degraded状態
+    /// @returns 拒否判定
+    /// @throws なし
+    fn reject(
+        action: RestRateLimitAction,
+        fail_close: bool,
+        retry_after_seconds: u64,
+        degraded: bool,
+    ) -> Self {
+        Self {
+            allowed: false,
+            fail_close,
+            retry_after_seconds: Some(retry_after_seconds.max(1)),
+            action,
+            operation_class: action.operation_class(),
+            degraded,
+        }
+    }
+
+    /// 判定が許可かを返す。
+    /// @param なし
+    /// @returns 許可時 `true`
+    /// @throws なし
+    pub fn allowed(self) -> bool {
+        self.allowed
+    }
+
+    /// fail-close 拒否かを返す。
+    /// @param なし
+    /// @returns fail-close時 `true`
+    /// @throws なし
+    pub fn is_fail_close(self) -> bool {
+        self.fail_close
+    }
+
+    /// Retry-After 秒を返す。
+    /// @param なし
+    /// @returns Retry-After秒
+    /// @throws なし
+    pub fn retry_after_seconds(self) -> Option<u64> {
+        self.retry_after_seconds
+    }
+
+    /// 対象 action を返す。
+    /// @param なし
+    /// @returns action
+    /// @throws なし
+    pub fn action(self) -> RestRateLimitAction {
+        self.action
+    }
+
+    /// operation class を返す。
+    /// @param なし
+    /// @returns operation class
+    /// @throws なし
+    pub fn operation_class(self) -> RateLimitOperationClass {
+        self.operation_class
+    }
+
+    /// degraded 状態を返す。
+    /// @param なし
+    /// @returns degraded時 `true`
+    /// @throws なし
+    pub fn degraded(self) -> bool {
+        self.degraded
+    }
+}
+
+#[derive(Default)]
+struct RateLimitMetrics {
+    invite_access_requests_total: AtomicU64,
+    invite_access_limited_total: AtomicU64,
+    moderation_requests_total: AtomicU64,
+    moderation_limited_total: AtomicU64,
+    message_create_requests_total: AtomicU64,
+    message_create_limited_total: AtomicU64,
+    allowed_total: AtomicU64,
+    limited_total: AtomicU64,
+    high_risk_fail_close_total: AtomicU64,
+    dragonfly_unavailable_total: AtomicU64,
+}
+
+impl RateLimitMetrics {
+    /// 対象アクションのリクエスト総数を記録する。
+    /// @param action 対象アクション
+    /// @returns なし
+    /// @throws なし
+    fn record_request(&self, action: RestRateLimitAction) {
+        counter_for_action(self, action, CounterKind::Requests).fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// 許可結果を記録する。
+    /// @param なし
+    /// @returns なし
+    /// @throws なし
+    fn record_allowed(&self) {
+        self.allowed_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// 拒否結果を記録する。
+    /// @param action 対象アクション
+    /// @param fail_close fail-close適用有無
+    /// @returns なし
+    /// @throws なし
+    fn record_rejected(&self, action: RestRateLimitAction, fail_close: bool) {
+        counter_for_action(self, action, CounterKind::Limited).fetch_add(1, Ordering::Relaxed);
+        self.limited_total.fetch_add(1, Ordering::Relaxed);
+        if fail_close {
+            self.high_risk_fail_close_total
+                .fetch_add(1, Ordering::Relaxed);
+            self.dragonfly_unavailable_total
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CounterKind {
+    Requests,
+    Limited,
+}
+
+/// アクション別カウンタを返す。
+/// @param metrics メトリクス
+/// @param action 対象アクション
+/// @param kind 取得種別
+/// @returns 対象AtomicU64
+/// @throws なし
+fn counter_for_action(
+    metrics: &RateLimitMetrics,
+    action: RestRateLimitAction,
+    kind: CounterKind,
+) -> &AtomicU64 {
+    match (action, kind) {
+        (RestRateLimitAction::InviteAccess, CounterKind::Requests) => {
+            &metrics.invite_access_requests_total
+        }
+        (RestRateLimitAction::InviteAccess, CounterKind::Limited) => {
+            &metrics.invite_access_limited_total
+        }
+        (RestRateLimitAction::ModerationAction, CounterKind::Requests) => {
+            &metrics.moderation_requests_total
+        }
+        (RestRateLimitAction::ModerationAction, CounterKind::Limited) => {
+            &metrics.moderation_limited_total
+        }
+        (RestRateLimitAction::MessageCreate, CounterKind::Requests) => {
+            &metrics.message_create_requests_total
+        }
+        (RestRateLimitAction::MessageCreate, CounterKind::Limited) => {
+            &metrics.message_create_limited_total
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct L2ResultSample {
+    at: Instant,
+    success: bool,
+}
+
+#[derive(Debug, Default)]
+struct DragonflyMonitorState {
+    degraded: bool,
+    continuous_failure_since: Option<Instant>,
+    healthy_since: Option<Instant>,
+    l2_samples: VecDeque<L2ResultSample>,
+}
+
+struct DragonflyRateLimitMonitor {
+    thresholds: DragonflyDegradedThresholds,
+    state: Mutex<DragonflyMonitorState>,
+    degraded_enter_total: AtomicU64,
+    degraded_exit_total: AtomicU64,
+}
+
+impl DragonflyRateLimitMonitor {
+    /// degraded 監視器を生成する。
+    /// @param thresholds しきい値
+    /// @returns degraded監視器
+    /// @throws なし
+    fn new(thresholds: DragonflyDegradedThresholds) -> Self {
+        Self {
+            thresholds,
+            state: Mutex::new(DragonflyMonitorState::default()),
+            degraded_enter_total: AtomicU64::new(0),
+            degraded_exit_total: AtomicU64::new(0),
+        }
+    }
+
+    /// 観測結果を指定時刻で反映する。
+    /// @param observation 観測入力
+    /// @param now 判定時刻
+    /// @returns なし
+    /// @throws なし
+    #[cfg(test)]
+    async fn observe_at(&self, observation: DragonflyObservation, now: Instant) {
+        let mut state = self.state.lock().await;
+        apply_observation(&mut state, observation, now);
+        self.refresh_degraded_state(&mut state, now);
+    }
+
+    /// 現在状態のスナップショットを返す。
+    /// @param なし
+    /// @returns 状態スナップショット
+    /// @throws なし
+    async fn snapshot(&self) -> DragonflyStatusSnapshot {
+        self.snapshot_at(Instant::now()).await
+    }
+
+    /// 指定時刻の状態スナップショットを返す。
+    /// @param now 判定時刻
+    /// @returns 状態スナップショット
+    /// @throws なし
+    async fn snapshot_at(&self, now: Instant) -> DragonflyStatusSnapshot {
+        let mut state = self.state.lock().await;
+        self.refresh_degraded_state(&mut state, now);
+        build_dragonfly_snapshot(&state, now)
+    }
+
+    /// テスト用に degraded 状態を直接設定する。
+    /// @param degraded 設定値
+    /// @returns なし
+    /// @throws なし
+    #[cfg(test)]
+    async fn set_degraded_for_test(&self, degraded: bool) {
+        let now = Instant::now();
+        let mut state = self.state.lock().await;
+        if state.degraded == degraded {
+            return;
+        }
+
+        state.degraded = degraded;
+        state.continuous_failure_since = degraded.then_some(now);
+        state.healthy_since = (!degraded).then_some(now);
+        state.l2_samples.clear();
+        if degraded {
+            self.degraded_enter_total.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.degraded_exit_total.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// degraded 状態遷移を評価する。
+    /// @param state 内部状態
+    /// @param now 判定時刻
+    /// @returns なし
+    /// @throws なし
+    fn refresh_degraded_state(&self, state: &mut DragonflyMonitorState, now: Instant) {
+        prune_l2_samples(state, now);
+        let snapshot = build_dragonfly_snapshot(state, now);
+        let should_enter = snapshot.healthcheck_failure_streak_seconds
+            >= self.thresholds.enter_after_healthcheck_failure.as_secs()
+            || (snapshot.l2_sample_total >= self.thresholds.enter_min_l2_samples as u64
+                && snapshot.l2_error_rate >= self.thresholds.enter_after_l2_error_rate);
+        let should_exit = snapshot.healthy_streak_seconds
+            >= self.thresholds.exit_after_healthy_duration.as_secs()
+            && snapshot.l2_error_rate < self.thresholds.exit_when_l2_error_rate_below;
+
+        if !state.degraded && should_enter {
+            state.degraded = true;
+            self.degraded_enter_total.fetch_add(1, Ordering::Relaxed);
+        } else if state.degraded && should_exit {
+            state.degraded = false;
+            self.degraded_exit_total.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// RESTレート制限サービスを保持する。
+#[derive(Clone)]
+pub struct RestRateLimitService {
+    config: RestRateLimitConfig,
+    message_create_limiter: Arc<FixedWindowRateLimiter>,
+    invite_access_limiter: Arc<FixedWindowRateLimiter>,
+    moderation_limiter: Arc<FixedWindowRateLimiter>,
+    dragonfly_monitor: Arc<DragonflyRateLimitMonitor>,
+    metrics: Arc<RateLimitMetrics>,
+}
+
+impl RestRateLimitService {
+    /// サービスを生成する。
+    /// @param config レート制限構成
+    /// @returns レート制限サービス
+    /// @throws なし
+    pub fn new(config: RestRateLimitConfig) -> Self {
+        Self {
+            config,
+            message_create_limiter: Arc::new(FixedWindowRateLimiter::new(
+                config.message_create_max_requests,
+                config.window,
+            )),
+            invite_access_limiter: Arc::new(FixedWindowRateLimiter::new(
+                config.invite_access_max_requests,
+                config.window,
+            )),
+            moderation_limiter: Arc::new(FixedWindowRateLimiter::new(
+                config.moderation_max_requests,
+                config.window,
+            )),
+            dragonfly_monitor: Arc::new(DragonflyRateLimitMonitor::new(config.degraded_thresholds)),
+            metrics: Arc::new(RateLimitMetrics::default()),
+        }
+    }
+
+    /// principal と action に対するレート制限判定を返す。
+    /// @param principal_id 対象principal
+    /// @param action 対象アクション
+    /// @returns 判定結果
+    /// @throws なし
+    pub async fn evaluate(
+        &self,
+        principal_id: PrincipalId,
+        action: RestRateLimitAction,
+    ) -> RateLimitDecision {
+        self.metrics.record_request(action);
+        let dragonfly = self.dragonfly_monitor.snapshot().await;
+
+        if action.operation_class() == RateLimitOperationClass::HighRiskAbuseSurface
+            && dragonfly.degraded
+        {
+            self.metrics.record_rejected(action, true);
+            return RateLimitDecision::reject(
+                action,
+                true,
+                ceil_duration_seconds(self.config.fail_close_retry_after),
+                true,
+            );
+        }
+
+        let rate_limit_key = format!("principal:{}:{}", principal_id.0, action.label());
+        let decision = limiter_for_action(self, action)
+            .check_and_record_with_retry_after(&rate_limit_key)
+            .await;
+
+        if decision.allowed {
+            self.metrics.record_allowed();
+            return RateLimitDecision::allow(action, dragonfly.degraded);
+        }
+
+        self.metrics.record_rejected(action, false);
+        RateLimitDecision::reject(
+            action,
+            false,
+            ceil_duration_seconds(decision.retry_after.unwrap_or(self.config.window)),
+            dragonfly.degraded,
+        )
+    }
+
+    /// テスト用に degraded 状態を直接設定する。
+    /// @param degraded 設定値
+    /// @returns なし
+    /// @throws なし
+    #[cfg(test)]
+    pub(crate) async fn set_degraded_for_test(&self, degraded: bool) {
+        self.dragonfly_monitor.set_degraded_for_test(degraded).await;
+    }
+}
+
+/// 実行時構成でサービスを生成する。
+/// @param なし
+/// @returns 実行時レート制限サービス
+/// @throws なし
+pub fn build_runtime_rest_rate_limit_service() -> RestRateLimitService {
+    RestRateLimitService::new(RestRateLimitConfig::from_env())
+}
+
+/// RESTリクエストからレート制限対象アクションを返す。
+/// @param method HTTPメソッド
+/// @param path リクエストパス
+/// @returns 対象アクション
+/// @throws なし
+pub fn rest_rate_limit_action_for_request(
+    method: &Method,
+    path: &str,
+) -> Option<RestRateLimitAction> {
+    if *method == Method::GET && is_guild_invite_path(path) {
+        return Some(RestRateLimitAction::InviteAccess);
+    }
+    if *method == Method::PATCH && is_moderation_path(path) {
+        return Some(RestRateLimitAction::ModerationAction);
+    }
+    if *method == Method::POST
+        && (is_guild_message_create_path(path) || is_dm_message_create_path(path))
+    {
+        return Some(RestRateLimitAction::MessageCreate);
+    }
+
+    None
+}
+
+/// guild message create パスかを判定する。
+/// @param path リクエストパス
+/// @returns 対象時 `true`
+/// @throws なし
+fn is_guild_message_create_path(path: &str) -> bool {
+    let segments = path.trim_matches('/').split('/').collect::<Vec<_>>();
+    segments.len() == 6
+        && segments[0] == "v1"
+        && segments[1] == "guilds"
+        && segments[3] == "channels"
+        && segments[5] == "messages"
+}
+
+/// DM message create パスかを判定する。
+/// @param path リクエストパス
+/// @returns 対象時 `true`
+/// @throws なし
+fn is_dm_message_create_path(path: &str) -> bool {
+    let segments = path.trim_matches('/').split('/').collect::<Vec<_>>();
+    segments.len() == 4 && segments[0] == "v1" && segments[1] == "dms" && segments[3] == "messages"
+}
+
+/// guild invite パスかを判定する。
+/// @param path リクエストパス
+/// @returns 対象時 `true`
+/// @throws なし
+fn is_guild_invite_path(path: &str) -> bool {
+    let segments = path.trim_matches('/').split('/').collect::<Vec<_>>();
+    segments.len() == 5
+        && segments[0] == "v1"
+        && segments[1] == "guilds"
+        && segments[3] == "invites"
+}
+
+/// moderation パスかを判定する。
+/// @param path リクエストパス
+/// @returns 対象時 `true`
+/// @throws なし
+fn is_moderation_path(path: &str) -> bool {
+    let segments = path.trim_matches('/').split('/').collect::<Vec<_>>();
+    segments.len() == 6
+        && segments[0] == "v1"
+        && segments[1] == "moderation"
+        && segments[2] == "guilds"
+        && segments[4] == "members"
+}
+
+/// 実際に使う limiter を返す。
+/// @param service レート制限サービス
+/// @param action 対象アクション
+/// @returns 対応 limiter
+/// @throws なし
+fn limiter_for_action(
+    service: &RestRateLimitService,
+    action: RestRateLimitAction,
+) -> &Arc<FixedWindowRateLimiter> {
+    match action {
+        RestRateLimitAction::InviteAccess => &service.invite_access_limiter,
+        RestRateLimitAction::ModerationAction => &service.moderation_limiter,
+        RestRateLimitAction::MessageCreate => &service.message_create_limiter,
+    }
+}
+
+/// 観測を状態へ反映する。
+/// @param state 内部状態
+/// @param observation 観測入力
+/// @param now 判定時刻
+/// @returns なし
+/// @throws なし
+#[cfg(test)]
+fn apply_observation(
+    state: &mut DragonflyMonitorState,
+    observation: DragonflyObservation,
+    now: Instant,
+) {
+    if let Some(healthcheck_success) = observation.healthcheck_success {
+        if healthcheck_success {
+            state.continuous_failure_since = None;
+            if state.healthy_since.is_none() {
+                state.healthy_since = Some(now);
+            }
+        } else {
+            if state.continuous_failure_since.is_none() {
+                state.continuous_failure_since = Some(now);
+            }
+            state.healthy_since = None;
+        }
+    }
+
+    if let Some(l2_result_success) = observation.l2_result_success {
+        state.l2_samples.push_back(L2ResultSample {
+            at: now,
+            success: l2_result_success,
+        });
+    }
+}
+
+/// 時間窓外の L2 サンプルを削除する。
+/// @param state 内部状態
+/// @param now 判定時刻
+/// @returns なし
+/// @throws なし
+fn prune_l2_samples(state: &mut DragonflyMonitorState, now: Instant) {
+    let window = Duration::from_secs(L2_ERROR_RATE_WINDOW_SECONDS);
+    while let Some(sample) = state.l2_samples.front() {
+        if now.duration_since(sample.at) <= window {
+            break;
+        }
+        state.l2_samples.pop_front();
+    }
+}
+
+/// 現在状態から Dragonfly スナップショットを生成する。
+/// @param state 内部状態
+/// @param now 判定時刻
+/// @returns Dragonfly状態スナップショット
+/// @throws なし
+fn build_dragonfly_snapshot(
+    state: &DragonflyMonitorState,
+    now: Instant,
+) -> DragonflyStatusSnapshot {
+    let l2_error_count = state
+        .l2_samples
+        .iter()
+        .filter(|sample| !sample.success)
+        .count() as f64;
+    let l2_sample_total = state.l2_samples.len() as f64;
+    let l2_error_rate = if l2_sample_total > 0.0 {
+        l2_error_count / l2_sample_total
+    } else {
+        0.0
+    };
+
+    DragonflyStatusSnapshot {
+        degraded: state.degraded,
+        healthcheck_failure_streak_seconds: state
+            .continuous_failure_since
+            .map(|instant| now.duration_since(instant).as_secs())
+            .unwrap_or(0),
+        healthy_streak_seconds: state
+            .healthy_since
+            .map(|instant| now.duration_since(instant).as_secs())
+            .unwrap_or(0),
+        l2_error_rate,
+        l2_sample_total: l2_sample_total as u64,
+    }
+}
+
+/// Duration を Retry-After の秒へ切り上げ変換する。
+/// @param duration 変換対象
+/// @returns 秒数
+/// @throws なし
+fn ceil_duration_seconds(duration: Duration) -> u64 {
+    if duration.is_zero() {
+        return 1;
+    }
+
+    let seconds = duration.as_secs();
+    if duration.subsec_nanos() > 0 {
+        seconds.saturating_add(1)
+    } else {
+        seconds.max(1)
+    }
+}
+
+/// u32 環境変数を解釈する。
+/// @param name 環境変数名
+/// @param default 既定値
+/// @returns 解析結果
+/// @throws なし
+fn parse_env_u32(name: &str, default: u32) -> u32 {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(default)
+        .max(1)
+}
+
+/// u64 環境変数を解釈する。
+/// @param name 環境変数名
+/// @param default 既定値
+/// @returns 解析結果
+/// @throws なし
+fn parse_env_u64(name: &str, default: u64) -> u64 {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(default)
+        .max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rest_rate_limit_action_maps_supported_paths() {
+        assert_eq!(
+            rest_rate_limit_action_for_request(&Method::GET, "/v1/guilds/10/invites/invite-abc"),
+            Some(RestRateLimitAction::InviteAccess)
+        );
+        assert_eq!(
+            rest_rate_limit_action_for_request(
+                &Method::PATCH,
+                "/v1/moderation/guilds/10/members/9003"
+            ),
+            Some(RestRateLimitAction::ModerationAction)
+        );
+        assert_eq!(
+            rest_rate_limit_action_for_request(&Method::POST, "/v1/guilds/10/channels/55/messages"),
+            Some(RestRateLimitAction::MessageCreate)
+        );
+        assert_eq!(
+            rest_rate_limit_action_for_request(&Method::POST, "/v1/dms/55/messages"),
+            Some(RestRateLimitAction::MessageCreate)
+        );
+        assert_eq!(
+            rest_rate_limit_action_for_request(&Method::GET, "/v1/dms/55/messages"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn dragonfly_monitor_enters_degraded_after_healthcheck_failure_window() {
+        let monitor = DragonflyRateLimitMonitor::new(DragonflyDegradedThresholds::default());
+        let base = Instant::now();
+
+        monitor
+            .observe_at(
+                DragonflyObservation {
+                    healthcheck_success: Some(false),
+                    l2_result_success: None,
+                },
+                base,
+            )
+            .await;
+        let snapshot = monitor.snapshot_at(base + Duration::from_secs(31)).await;
+
+        assert!(snapshot.degraded);
+        assert!(snapshot.healthcheck_failure_streak_seconds >= 31);
+    }
+
+    #[tokio::test]
+    async fn dragonfly_monitor_enters_degraded_after_l2_error_rate_threshold() {
+        let monitor = DragonflyRateLimitMonitor::new(DragonflyDegradedThresholds::default());
+        let base = Instant::now();
+
+        for index in 0..10 {
+            monitor
+                .observe_at(
+                    DragonflyObservation {
+                        healthcheck_success: Some(true),
+                        l2_result_success: Some(index < 7),
+                    },
+                    base + Duration::from_secs(index),
+                )
+                .await;
+        }
+
+        let snapshot = monitor.snapshot_at(base + Duration::from_secs(10)).await;
+        assert!(snapshot.degraded);
+        assert!(snapshot.l2_error_rate >= 0.2);
+    }
+
+    #[tokio::test]
+    async fn dragonfly_monitor_does_not_enter_degraded_before_min_l2_samples() {
+        let monitor = DragonflyRateLimitMonitor::new(DragonflyDegradedThresholds::default());
+        let base = Instant::now();
+
+        monitor
+            .observe_at(
+                DragonflyObservation {
+                    healthcheck_success: Some(true),
+                    l2_result_success: Some(false),
+                },
+                base,
+            )
+            .await;
+
+        let snapshot = monitor.snapshot_at(base + Duration::from_secs(1)).await;
+        assert!(!snapshot.degraded);
+        assert_eq!(snapshot.l2_sample_total, 1);
+    }
+
+    #[tokio::test]
+    async fn dragonfly_monitor_exits_degraded_after_healthy_window() {
+        let monitor = DragonflyRateLimitMonitor::new(DragonflyDegradedThresholds::default());
+        let base = Instant::now();
+
+        monitor
+            .observe_at(
+                DragonflyObservation {
+                    healthcheck_success: Some(false),
+                    l2_result_success: Some(false),
+                },
+                base,
+            )
+            .await;
+        let degraded_snapshot = monitor.snapshot_at(base + Duration::from_secs(31)).await;
+        assert!(degraded_snapshot.degraded);
+
+        monitor
+            .observe_at(
+                DragonflyObservation {
+                    healthcheck_success: Some(true),
+                    l2_result_success: Some(true),
+                },
+                base + Duration::from_secs(32),
+            )
+            .await;
+        let recovered_snapshot = monitor
+            .snapshot_at(base + Duration::from_secs(32 + 601))
+            .await;
+
+        assert!(!recovered_snapshot.degraded);
+        assert!(recovered_snapshot.healthy_streak_seconds >= 600);
+        assert!(recovered_snapshot.l2_error_rate < 0.01);
+    }
+
+    #[tokio::test]
+    async fn rest_rate_limit_service_fail_closes_high_risk_actions_when_degraded() {
+        let service = RestRateLimitService::new(RestRateLimitConfig::default());
+        service.set_degraded_for_test(true).await;
+
+        let invite_decision = service
+            .evaluate(PrincipalId(42), RestRateLimitAction::InviteAccess)
+            .await;
+        let message_decision = service
+            .evaluate(PrincipalId(42), RestRateLimitAction::MessageCreate)
+            .await;
+
+        assert!(!invite_decision.allowed());
+        assert!(invite_decision.is_fail_close());
+        assert!(message_decision.allowed());
+    }
+}


### PR DESCRIPTION
## 概要
- REST rate-limit の operation class と degraded しきい値を追加
- invite / moderation / message create に `429 Too Many Requests` と `Retry-After` を返す制御を追加
- review 指摘を受けて internal ratelimit HTTP endpoint を撤去し、公開 API から degraded 状態を変更できないように修正
- runtime contract / runbook / agent run 記録を更新

## テスト
- `cargo test -p linklynx_backend`
- `make rust-lint`
- `make validate`

## ADR-001 チェック
- 結果: `N.A.`
- 理由: event schema / payload / stream contract の変更はなく、REST rate-limit と runtime contract の更新のみ

## フォローアップ
- Dragonfly 共有 L2 limiter への接続
- runtime からの自動 degraded 観測投入
- `rust/apps/api/src/ratelimit.rs` の責務分割