### PR TITLE
LIN-937 message usecase を Scylla / Postgres metadata に配線する

### DIFF
--- a/docs/agent_runs/LIN-937/Documentation.md
+++ b/docs/agent_runs/LIN-937/Documentation.md
@@ -1,0 +1,54 @@
+# Documentation
+
+## Current status
+- Now: LIN-937 の message domain / adapter / apps/api 配線は実装済み
+- Next: PR 向け説明を固める
+
+## Decisions
+- archived な LIN-846 / LIN-847 / LIN-851 の message 用最小断面は LIN-937 に内包する。
+- Scylla `bucket` は UTC 日次 `YYYYMMDD` 整数で扱う。
+- guild message create は request_id 単位の生成 ID キャッシュで同一プロセス内 retry を吸収する。
+
+## How to run / demo
+- `make db-up`
+- `make scylla-bootstrap`
+- `SCYLLA_HOSTS=127.0.0.1:9042 make rust-dev`
+- `curl -sS http://127.0.0.1:8080/`
+- `curl -i -sS http://127.0.0.1:8080/internal/scylla/health`
+- `cd rust && cargo test -p linklynx_message_domain -p linklynx_platform_scylla_message -p linklynx_platform_postgres_message`
+- `cd rust && cargo test -p linklynx_backend list_channel_messages`
+- `cd rust && cargo test -p linklynx_backend create_channel_message`
+- `make validate`
+
+## Known issues / follow-ups
+- 実 Scylla を使った広い append/list integration は LIN-938 で厚くする。
+- edit / delete / reply metadata の書き込み拡張は後続 issue で扱う。
+- request_id による create 冪等性は同一プロセス内キャッシュに留まる。複数 API instance 間での完全な冪等化には durable な request-id mapping か caller-supplied identity が必要で、この issue では扱わない。
+
+## Review gate
+- `reviewer`: cross-instance の request_id retry では同一 `message_id` を再利用できず、LIN-289 の duplicate no-op を API instance 間で完全には保証できない、という残リスク指摘あり。現実装は issue 合意スコープどおり同一プロセス内 retry の吸収に留める。
+- `reviewer_ui_guard`: UI 変更なし。差分は `rust/` と `docs/agent_runs/LIN-937/` のみで、`typescript/src/**` や `typescript/public/**` に変更はないため UI review は skip。
+
+## Runtime smoke
+- `docker compose up -d postgres scylladb` と `make scylla-bootstrap` を実行し、local Postgres/Scylla を起動した。
+- `set -a && source .env && set +a && cd rust && cargo run -p linklynx_backend` は sandbox 内では localhost bind/connect 制約で失敗したため、escalated で再実行した。最初の retry は `0.0.0.0:8080` が使用中で bind に失敗したが、listener 解放後の再試行で `Scylla runtime is ready` と `server starting address=0.0.0.0:8080` を確認した。
+- `curl -i -sS http://127.0.0.1:8080/` は `200 OK` / `LinkLynx API Server` を返した。
+- `curl -i -sS http://127.0.0.1:8080/internal/scylla/health` は `200 OK` / `{"service":"scylla","status":"ready"}` を返した。
+- guild message create/list の live smoke は skip。ローカル DB に smoke 用 guild/channel/auth principal をこの issue では投入していないため、runtime 起動と dependency health までを確認対象とした。
+
+## Validation log
+- `cd rust && cargo test -p linklynx_message_domain -p linklynx_platform_scylla_message -p linklynx_platform_postgres_message -p linklynx_backend --no-run`: pass
+- `cd rust && cargo test -p linklynx_message_domain`: pass
+- `cd rust && cargo test -p linklynx_platform_scylla_message`: pass
+- `cd rust && cargo test -p linklynx_platform_postgres_message`: pass
+- `cd rust && cargo test -p linklynx_backend list_channel_messages`: pass
+- `cd rust && cargo test -p linklynx_backend create_channel_message`: pass
+- `make rust-lint`: pass（sandbox 外で再実行）
+- `CI=true pnpm -C typescript install --frozen-lockfile`: pass
+- `make validate`: pass
+- `cd typescript && npm run typecheck`: pass
+- `docker compose up -d postgres scylladb`: pass
+- `make scylla-bootstrap`: pass
+- `set -a && source .env && set +a && cd rust && cargo run -p linklynx_backend`: pass（sandbox では bind/connect 制約で失敗。escalated retry で `Scylla runtime is ready` と `server starting address=0.0.0.0:8080` を確認）
+- `curl -i -sS http://127.0.0.1:8080/`: pass
+- `curl -i -sS http://127.0.0.1:8080/internal/scylla/health`: pass

--- a/docs/agent_runs/LIN-937/Implement.md
+++ b/docs/agent_runs/LIN-937/Implement.md
@@ -1,0 +1,20 @@
+# Implement
+
+- `Plan.md` の順序を実装の基準にする。順序変更時は `Documentation.md` に理由を残す。
+- message slice の追加は 1 issue 範囲に閉じ、既存 auth/authz/rate-limit の挙動は変えない。
+- `bucket` は UTC 日次 `YYYYMMDD` として扱い、実装とテストをこの前提で揃える。
+- runtime 側は fail-close を優先し、Scylla / Postgres どちらかが使えない時点で unavailable service を返す。
+- validation, review, runtime smoke の結果は都度 `Documentation.md` に追記する。
+
+## Implemented
+- `rust/crates/domains/message` を追加し、append/list 用 usecase と Scylla/Postgres port を切り出した。
+- `rust/crates/platform/scylla/message` を追加し、UTC 日次 bucket・idempotent append・history paging を実装した。
+- `rust/crates/platform/postgres/message` を追加し、`channels` / `channel_last_message` 由来の channel context 読み取りと monotonic upsert を実装した。
+- `rust/apps/api/src/message.rs` を追加し、runtime service・error mapping・request_id 単位の create 冪等キャッシュを実装した。
+- guild message の list/create handler を fixture 直返しから `message_service` 呼び出しへ差し替えた。
+- Scylla runtime の接続初期化 helper を `scylla_health` から再利用できる形に寄せた。
+- request_id identity の生成は monotonic な `message_id` allocator に揃え、同一 timestamp でも衝突しないようにした。
+- Scylla list は `last_message_at` が欠けている channel でも current UTC day を上限 bucket に使って読み出せるようにした。
+
+## Notes
+- request_id 冪等キャッシュは同一プロセス内 retry の吸収に限定される。複数 API instance 間での durable な duplicate no-op は、この issue では未対応。

--- a/docs/agent_runs/LIN-937/Plan.md
+++ b/docs/agent_runs/LIN-937/Plan.md
@@ -1,0 +1,41 @@
+# Plan
+
+## Rules
+- Stop-and-fix: validation / review 失敗時は次工程へ進まず修正する。
+- Scope lock: LIN-937 は message usecase 配線に限定し、DM / edit / delete / WS fanout は触らない。
+- Start mode: child issue start (`LIN-937` under `LIN-935`).
+- Branch: `codex/lin-937`
+
+## Milestones
+### M1: run memory と message crate 境界を追加する
+- Acceptance criteria:
+  - [ ] `docs/agent_runs/LIN-937/` の 4 ファイルを作成
+  - [ ] message domain / platform crate が workspace member として解決される
+- Validation:
+  - `cd rust && cargo test -p linklynx_message_domain`
+
+### M2: Scylla adapter / Postgres metadata repository / usecase を実装する
+- Acceptance criteria:
+  - [ ] append / list が port 経由で実行できる
+  - [ ] `channel_last_message` 更新境界が monotonic に固定される
+  - [ ] bucket / cursor / tombstone の扱いが helper と test で固定される
+- Validation:
+  - `cd rust && cargo test -p linklynx_message_domain -p linklynx_platform_scylla_message -p linklynx_platform_postgres_message`
+
+### M3: apps/api を runtime service へ差し替える
+- Acceptance criteria:
+  - [ ] guild message list/create handler が fixture を使わない
+  - [ ] Scylla / Postgres 未初期化時は fail-close の unavailable service になる
+  - [ ] main tests で contract payload と error mapping を維持する
+- Validation:
+  - `cd rust && cargo test -p linklynx_backend list_channel_messages`
+  - `cd rust && cargo test -p linklynx_backend create_channel_message`
+
+### M4: 全体検証と review gate を通す
+- Acceptance criteria:
+  - [ ] `make rust-lint` が通る
+  - [ ] `make validate` が通る
+  - [ ] reviewer gate の blocking finding が解消される
+- Validation:
+  - `make rust-lint`
+  - `make validate`

--- a/docs/agent_runs/LIN-937/Prompt.md
+++ b/docs/agent_runs/LIN-937/Prompt.md
@@ -1,0 +1,27 @@
+# Prompt
+
+## Goals
+- Scylla message SoR と Postgres metadata を `domains/message` 経由で利用できるようにする。
+- `apps/api` の guild message handler が direct CQL / fixture なしで append / list を呼べる状態にする。
+- 後続の LIN-823 / LIN-914 / LIN-915 が transport 実装に集中できる最小基盤を作る。
+
+## Non-goals
+- DM message 実装。
+- WS publish / dispatch。
+- edit / delete / search / schema 破壊的変更。
+
+## Deliverables
+- `linklynx_message_domain` / `linklynx_platform_scylla_message` / `linklynx_platform_postgres_message` の追加。
+- `apps/api` の message runtime/service 配線と guild message handler 差し替え。
+- LIN-937 run memory と関連検証記録。
+
+## Done when
+- [ ] domain/usecase から Scylla append / list を呼び出せる。
+- [ ] Postgres の message metadata 更新境界が明示されている。
+- [ ] transport 層が direct CQL なしで send / list を組み込める。
+- [ ] `make validate` と `make rust-lint` を通過している。
+
+## Constraints
+- Perf: Scylla paging は `limit + 1` と `(created_at, message_id)` の既存契約を維持する。
+- Security: Scylla / Postgres 障害時は fail-open せず 503 系へ接続できること。
+- Compatibility: message API / event / schema の additive-only 方針を守る。

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -897,6 +897,9 @@ dependencies = [
  "http",
  "jsonwebtoken",
  "linklynx_message_api",
+ "linklynx_message_domain",
+ "linklynx_platform_postgres_message",
+ "linklynx_platform_scylla_message",
  "linklynx_protocol_events",
  "linklynx_protocol_ws",
  "linklynx_shared",
@@ -948,6 +951,38 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "linklynx_message_domain"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "linklynx_message_api",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "linklynx_platform_postgres_message"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "linklynx_message_domain",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "linklynx_platform_scylla_message"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "linklynx_message_api",
+ "linklynx_message_domain",
+ "scylla",
+ "time",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,7 +6,10 @@ members = [
     "crates/contracts/protocol-events",
     "crates/contracts/protocol-ws",
     "crates/domains",
+    "crates/domains/message",
     "crates/infra",
+    "crates/platform/postgres/message",
+    "crates/platform/scylla/message",
     "crates/shared",
     "crates/worker",
     "apps/api",
@@ -29,7 +32,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "2"
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["full"] }
 tokio-postgres = "0.7"
 tower = { version = "0.5", features = ["util"] }

--- a/rust/apps/api/Cargo.toml
+++ b/rust/apps/api/Cargo.toml
@@ -9,8 +9,11 @@ axum.workspace = true
 http.workspace = true
 jsonwebtoken.workspace = true
 linklynx_message_api = { path = "../../crates/contracts/message-api" }
+linklynx_message_domain = { path = "../../crates/domains/message" }
 linklynx_protocol_events = { path = "../../crates/contracts/protocol-events" }
 linklynx_protocol_ws = { path = "../../crates/contracts/protocol-ws" }
+linklynx_platform_postgres_message = { path = "../../crates/platform/postgres/message" }
+linklynx_platform_scylla_message = { path = "../../crates/platform/scylla/message" }
 linklynx_shared = { path = "../../crates/shared" }
 reqwest.workspace = true
 scylla.workspace = true

--- a/rust/apps/api/src/main.rs
+++ b/rust/apps/api/src/main.rs
@@ -2,6 +2,7 @@ mod auth;
 mod authz;
 mod guild_channel;
 mod invite;
+mod message;
 mod moderation;
 mod profile;
 mod ratelimit;
@@ -45,15 +46,12 @@ use guild_channel::{
     GuildChannelService,
 };
 use invite::{build_runtime_invite_service, invite_error_response, InviteService};
-use linklynx_message_api::{
-    paginate_messages, validate_create_request, CreateGuildChannelMessageRequestV1,
-    CreateGuildChannelMessageResponseV1, ListGuildChannelMessagesQueryV1, MessageApiError,
-    MessageItemV1,
-};
+use linklynx_message_api::{CreateGuildChannelMessageRequestV1, ListGuildChannelMessagesQueryV1};
 use linklynx_protocol_ws::{
     ClientMessageFrameV1, GuildChannelSubscriptionTargetV1, MessageSubscriptionStateV1,
     ServerMessageFrameV1,
 };
+use message::{build_runtime_message_service, message_error_response, MessageService};
 use moderation::{
     build_runtime_moderation_service, moderation_error_response, ModerationError, ModerationService,
 };
@@ -77,6 +75,7 @@ pub(crate) struct AppState {
     authz_metrics: Arc<AuthzMetrics>,
     guild_channel_service: Arc<dyn GuildChannelService>,
     invite_service: Arc<dyn InviteService>,
+    message_service: Arc<dyn MessageService>,
     moderation_service: Arc<dyn ModerationService>,
     profile_service: Arc<dyn ProfileService>,
     scylla_health_reporter: Arc<dyn ScyllaHealthReporter>,
@@ -136,6 +135,7 @@ async fn build_runtime_state() -> AppState {
     let authz_metrics = Arc::new(AuthzMetrics::default());
     let guild_channel_service = build_runtime_guild_channel_service();
     let invite_service = build_runtime_invite_service();
+    let message_service = build_runtime_message_service().await;
     let moderation_service = build_runtime_moderation_service();
     let profile_service = build_runtime_profile_service();
     let scylla_health_reporter = build_runtime_scylla_health_reporter().await;
@@ -159,6 +159,7 @@ async fn build_runtime_state() -> AppState {
         authz_metrics,
         guild_channel_service,
         invite_service,
+        message_service,
         moderation_service,
         profile_service,
         scylla_health_reporter,

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -466,6 +466,7 @@ async fn get_guild_channel(
 /// @returns メッセージ一覧最小応答
 /// @throws なし
 async fn list_channel_messages(
+    State(state): State<AppState>,
     Extension(auth_context): Extension<AuthContext>,
     Path(params): Path<GuildChannelPathParams>,
     query: Result<Query<ListGuildChannelMessagesQueryV1>, QueryRejection>,
@@ -484,9 +485,13 @@ async fn list_channel_messages(
         Err(error) => return guild_channel_error_response(&error, request_id),
     };
 
-    match paginate_messages(&message_fixture(guild_id, channel_id), &query) {
+    match state
+        .message_service
+        .list_guild_channel_messages(guild_id, channel_id, query)
+        .await
+    {
         Ok(response) => Json(response).into_response(),
-        Err(error) => message_api_error_response(&error, request_id),
+        Err(error) => message_error_response(&error, request_id),
     }
 }
 
@@ -497,6 +502,7 @@ async fn list_channel_messages(
 /// @returns メッセージ作成レスポンス
 /// @throws なし
 async fn create_channel_message(
+    State(state): State<AppState>,
     Extension(auth_context): Extension<AuthContext>,
     Path(params): Path<GuildChannelPathParams>,
     payload: Result<Json<CreateGuildChannelMessageRequestV1>, JsonRejection>,
@@ -514,20 +520,21 @@ async fn create_channel_message(
         Ok(value) => value,
         Err(error) => return guild_channel_error_response(&error, request_id),
     };
-    if let Err(error) = validate_create_request(&payload) {
-        return message_api_error_response(&error, request_id);
-    }
 
-    let response = CreateGuildChannelMessageResponseV1 {
-        message: create_message_fixture(
+    match state
+        .message_service
+        .create_guild_channel_message(
+            auth_context.principal_id,
             guild_id,
             channel_id,
-            auth_context.principal_id.0,
-            payload.content,
-        ),
-    };
-
-    (StatusCode::CREATED, Json(response)).into_response()
+            &request_id,
+            payload,
+        )
+        .await
+    {
+        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Err(error) => message_error_response(&error, request_id),
+    }
 }
 
 /// DMチャンネル情報の最小応答を返す。
@@ -1070,24 +1077,15 @@ fn parse_message_list_query(
         .map_err(|_| GuildChannelError::validation("message_query_invalid"))
 }
 
-/// message API validation エラーを既存レスポンス契約へ写像する。
-/// @param error message API エラー
-/// @param request_id リクエスト識別子
-/// @returns エラーレスポンス
-/// @throws なし
-fn message_api_error_response(error: &MessageApiError, request_id: String) -> Response {
-    let api_error = GuildChannelError::validation(error.reason_code());
-    guild_channel_error_response(&api_error, request_id)
-}
-
 /// contract 固定用のメッセージ fixture を返す。
 /// @param guild_id 対象 guild_id
 /// @param channel_id 対象 channel_id
 /// @returns newest-first のメッセージ列
 /// @throws なし
-fn message_fixture(guild_id: i64, channel_id: i64) -> Vec<MessageItemV1> {
+#[cfg(test)]
+fn message_fixture(guild_id: i64, channel_id: i64) -> Vec<linklynx_message_api::MessageItemV1> {
     vec![
-        MessageItemV1 {
+        linklynx_message_api::MessageItemV1 {
             message_id: 120_110,
             guild_id,
             channel_id,
@@ -1098,7 +1096,7 @@ fn message_fixture(guild_id: i64, channel_id: i64) -> Vec<MessageItemV1> {
             edited_at: None,
             is_deleted: false,
         },
-        MessageItemV1 {
+        linklynx_message_api::MessageItemV1 {
             message_id: 120_108,
             guild_id,
             channel_id,
@@ -1109,7 +1107,7 @@ fn message_fixture(guild_id: i64, channel_id: i64) -> Vec<MessageItemV1> {
             edited_at: None,
             is_deleted: false,
         },
-        MessageItemV1 {
+        linklynx_message_api::MessageItemV1 {
             message_id: 120_107,
             guild_id,
             channel_id,
@@ -1120,7 +1118,7 @@ fn message_fixture(guild_id: i64, channel_id: i64) -> Vec<MessageItemV1> {
             edited_at: None,
             is_deleted: false,
         },
-        MessageItemV1 {
+        linklynx_message_api::MessageItemV1 {
             message_id: 120_105,
             guild_id,
             channel_id,
@@ -1131,7 +1129,7 @@ fn message_fixture(guild_id: i64, channel_id: i64) -> Vec<MessageItemV1> {
             edited_at: None,
             is_deleted: false,
         },
-        MessageItemV1 {
+        linklynx_message_api::MessageItemV1 {
             message_id: 120_102,
             guild_id,
             channel_id,
@@ -1152,13 +1150,14 @@ fn message_fixture(guild_id: i64, channel_id: i64) -> Vec<MessageItemV1> {
 /// @param content 投稿内容
 /// @returns メッセージスナップショット
 /// @throws なし
+#[cfg(test)]
 fn create_message_fixture(
     guild_id: i64,
     channel_id: i64,
     author_id: i64,
     content: String,
-) -> MessageItemV1 {
-    MessageItemV1 {
+) -> linklynx_message_api::MessageItemV1 {
+    linklynx_message_api::MessageItemV1 {
         message_id: 120_111,
         guild_id,
         channel_id,

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -22,6 +22,7 @@ mod tests {
         InviteError, InviteJoinResult, InviteJoinStatus, InviteService, PublicInviteGuild,
         PublicInviteLookup, PublicInviteStatus,
     };
+    use message::{MessageError, MessageService};
     use moderation::{
         CreateModerationMuteInput, CreateModerationReportInput, ModerationError, ModerationReport,
         ModerationReportStatus, ModerationService, ModerationTargetType,
@@ -35,7 +36,14 @@ mod tests {
             Method, StatusCode,
         },
     };
-    use linklynx_message_api::{MessageCursorKeyV1, MessageItemV1};
+    use linklynx_message_api::{
+        CreateGuildChannelMessageRequestV1,
+        CreateGuildChannelMessageResponseV1,
+        ListGuildChannelMessagesQueryV1,
+        ListGuildChannelMessagesResponseV1,
+        MessageCursorKeyV1,
+        MessageItemV1,
+    };
     use linklynx_protocol_ws::{ClientMessageFrameV1, GuildChannelSubscriptionTargetV1, ServerMessageFrameV1};
     use linklynx_shared::PrincipalId;
     use tokio::{
@@ -68,6 +76,9 @@ mod tests {
     struct WsTextUnavailableAuthorizer;
     struct PermissionSnapshotUnavailableAuthorizer;
     struct StaticGuildChannelService;
+    struct StaticMessageService;
+    struct StaticNotFoundMessageService;
+    struct StaticUnavailableMessageService;
     struct StaticModerationService;
     struct StaticProfileService;
     struct StaticUnavailableProfileService;
@@ -295,6 +306,89 @@ mod tests {
     impl ScyllaHealthReporter for StaticScyllaHealthReporter {
         async fn report(&self) -> ScyllaHealthReport {
             self.report.clone()
+        }
+    }
+
+    #[async_trait]
+    impl MessageService for StaticMessageService {
+        async fn list_guild_channel_messages(
+            &self,
+            guild_id: i64,
+            channel_id: i64,
+            query: ListGuildChannelMessagesQueryV1,
+        ) -> Result<ListGuildChannelMessagesResponseV1, MessageError> {
+            linklynx_message_api::paginate_messages(&message_fixture(guild_id, channel_id), &query)
+                .map_err(MessageError::from)
+        }
+
+        async fn create_guild_channel_message(
+            &self,
+            principal_id: PrincipalId,
+            guild_id: i64,
+            channel_id: i64,
+            _request_id: &str,
+            request: CreateGuildChannelMessageRequestV1,
+        ) -> Result<CreateGuildChannelMessageResponseV1, MessageError> {
+            linklynx_message_api::validate_create_request(&request).map_err(MessageError::from)?;
+
+            Ok(CreateGuildChannelMessageResponseV1 {
+                message: create_message_fixture(
+                    guild_id,
+                    channel_id,
+                    principal_id.0,
+                    request.content,
+                ),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl MessageService for StaticUnavailableMessageService {
+        async fn list_guild_channel_messages(
+            &self,
+            _guild_id: i64,
+            _channel_id: i64,
+            _query: ListGuildChannelMessagesQueryV1,
+        ) -> Result<ListGuildChannelMessagesResponseV1, MessageError> {
+            Err(MessageError::dependency_unavailable(
+                "message_body_store_unavailable",
+            ))
+        }
+
+        async fn create_guild_channel_message(
+            &self,
+            _principal_id: PrincipalId,
+            _guild_id: i64,
+            _channel_id: i64,
+            _request_id: &str,
+            _request: CreateGuildChannelMessageRequestV1,
+        ) -> Result<CreateGuildChannelMessageResponseV1, MessageError> {
+            Err(MessageError::dependency_unavailable(
+                "message_body_store_unavailable",
+            ))
+        }
+    }
+
+    #[async_trait]
+    impl MessageService for StaticNotFoundMessageService {
+        async fn list_guild_channel_messages(
+            &self,
+            _guild_id: i64,
+            _channel_id: i64,
+            _query: ListGuildChannelMessagesQueryV1,
+        ) -> Result<ListGuildChannelMessagesResponseV1, MessageError> {
+            Err(MessageError::channel_not_found("message_channel_not_found"))
+        }
+
+        async fn create_guild_channel_message(
+            &self,
+            _principal_id: PrincipalId,
+            _guild_id: i64,
+            _channel_id: i64,
+            _request_id: &str,
+            _request: CreateGuildChannelMessageRequestV1,
+        ) -> Result<CreateGuildChannelMessageResponseV1, MessageError> {
+            Err(MessageError::channel_not_found("message_channel_not_found"))
         }
     }
 
@@ -933,13 +1027,14 @@ mod tests {
         profile_service: Arc<dyn ProfileService>,
         invite_service: Arc<dyn InviteService>,
     ) -> AppState {
-        state_for_test_with_authorizer_profile_invite_and_scylla(
+        state_for_test_with_authorizer_profile_invite_scylla_and_message(
             authorizer,
             profile_service,
             invite_service,
             Arc::new(StaticScyllaHealthReporter {
                 report: ScyllaHealthReport::ready(),
             }),
+            Arc::new(StaticMessageService),
         )
         .await
     }
@@ -949,6 +1044,23 @@ mod tests {
         profile_service: Arc<dyn ProfileService>,
         invite_service: Arc<dyn InviteService>,
         scylla_health_reporter: Arc<dyn ScyllaHealthReporter>,
+    ) -> AppState {
+        state_for_test_with_authorizer_profile_invite_scylla_and_message(
+            authorizer,
+            profile_service,
+            invite_service,
+            scylla_health_reporter,
+            Arc::new(StaticMessageService),
+        )
+        .await
+    }
+
+    async fn state_for_test_with_authorizer_profile_invite_scylla_and_message(
+        authorizer: Arc<dyn Authorizer>,
+        profile_service: Arc<dyn ProfileService>,
+        invite_service: Arc<dyn InviteService>,
+        scylla_health_reporter: Arc<dyn ScyllaHealthReporter>,
+        message_service: Arc<dyn MessageService>,
     ) -> AppState {
         let metrics = Arc::new(AuthMetrics::default());
         let verifier: Arc<dyn TokenVerifier> = Arc::new(StaticTokenVerifier);
@@ -978,6 +1090,7 @@ mod tests {
             authz_metrics: Arc::new(AuthzMetrics::default()),
             guild_channel_service: Arc::new(StaticGuildChannelService),
             invite_service,
+            message_service,
             moderation_service: Arc::new(StaticModerationService),
             profile_service,
             scylla_health_reporter,
@@ -1011,6 +1124,23 @@ mod tests {
             authorizer,
             profile_service,
             Arc::new(StaticInviteService),
+        )
+        .await;
+        app_with_state(state)
+    }
+
+    async fn app_for_test_with_authorizer_and_message_service(
+        authorizer: Arc<dyn Authorizer>,
+        message_service: Arc<dyn MessageService>,
+    ) -> Router {
+        let state = state_for_test_with_authorizer_profile_invite_scylla_and_message(
+            authorizer,
+            Arc::new(StaticProfileService),
+            Arc::new(StaticInviteService),
+            Arc::new(StaticScyllaHealthReporter {
+                report: ScyllaHealthReport::ready(),
+            }),
+            message_service,
         )
         .await;
         app_with_state(state)
@@ -3774,6 +3904,64 @@ mod tests {
         let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
         assert_eq!(json["code"], "VALIDATION_ERROR");
         assert_eq!(json["message"], "request payload is invalid");
+    }
+
+    #[tokio::test]
+    async fn create_channel_message_returns_service_unavailable_when_message_service_fails_close() {
+        let app = app_for_test_with_authorizer_and_message_service(
+            Arc::new(RoleScenarioAuthorizer),
+            Arc::new(StaticUnavailableMessageService),
+        )
+        .await;
+        let token = format!("u-member:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/guilds/10/channels/20/messages")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"content":"hello contract"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "AUTHZ_UNAVAILABLE");
+        assert_eq!(json["message"], "authorization dependency is unavailable");
+    }
+
+    #[tokio::test]
+    async fn list_channel_messages_returns_not_found_when_message_service_reports_missing_channel() {
+        let app = app_for_test_with_authorizer_and_message_service(
+            Arc::new(RoleScenarioAuthorizer),
+            Arc::new(StaticNotFoundMessageService),
+        )
+        .await;
+        let token = format!("u-member:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/guilds/10/channels/20/messages")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "CHANNEL_NOT_FOUND");
+        assert_eq!(json["message"], "channel resource was not found");
     }
 
     #[tokio::test]

--- a/rust/apps/api/src/message.rs
+++ b/rust/apps/api/src/message.rs
@@ -1,0 +1,34 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    env,
+    sync::{
+        atomic::{AtomicI64, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use linklynx_message_api::{
+    CreateGuildChannelMessageRequestV1, CreateGuildChannelMessageResponseV1,
+    ListGuildChannelMessagesQueryV1, ListGuildChannelMessagesResponseV1, MessageApiError,
+};
+use linklynx_message_domain::{
+    AppendGuildChannelMessageCommand, LiveMessageUsecase, MessageUsecase, MessageUsecaseError,
+};
+use linklynx_platform_postgres_message::PostgresMessageMetadataRepository;
+use linklynx_platform_scylla_message::ScyllaMessageStore;
+use linklynx_shared::PrincipalId;
+use serde::Serialize;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use tokio::sync::Mutex;
+use tracing::warn;
+
+include!("message/errors.rs");
+include!("message/service.rs");
+include!("message/runtime.rs");

--- a/rust/apps/api/src/message/errors.rs
+++ b/rust/apps/api/src/message/errors.rs
@@ -1,0 +1,134 @@
+/// message API エラー種別を表現する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageErrorKind {
+    Validation,
+    ChannelNotFound,
+    DependencyUnavailable,
+}
+
+/// message API 失敗情報を保持する。
+#[derive(Debug, Clone)]
+pub struct MessageError {
+    pub kind: MessageErrorKind,
+    pub reason: String,
+}
+
+impl MessageError {
+    /// 入力検証エラーを生成する。
+    /// @param reason 失敗理由
+    /// @returns 入力検証エラー
+    /// @throws なし
+    pub fn validation(reason: impl Into<String>) -> Self {
+        Self {
+            kind: MessageErrorKind::Validation,
+            reason: reason.into(),
+        }
+    }
+
+    /// channel未存在エラーを生成する。
+    /// @param reason 失敗理由
+    /// @returns 未存在エラー
+    /// @throws なし
+    pub fn channel_not_found(reason: impl Into<String>) -> Self {
+        Self {
+            kind: MessageErrorKind::ChannelNotFound,
+            reason: reason.into(),
+        }
+    }
+
+    /// 依存障害エラーを生成する。
+    /// @param reason 失敗理由
+    /// @returns 依存障害エラー
+    /// @throws なし
+    pub fn dependency_unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            kind: MessageErrorKind::DependencyUnavailable,
+            reason: reason.into(),
+        }
+    }
+
+    /// HTTPステータスへ変換する。
+    /// @param なし
+    /// @returns HTTPステータス
+    /// @throws なし
+    pub fn status_code(&self) -> StatusCode {
+        match self.kind {
+            MessageErrorKind::Validation => StatusCode::BAD_REQUEST,
+            MessageErrorKind::ChannelNotFound => StatusCode::NOT_FOUND,
+            MessageErrorKind::DependencyUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+        }
+    }
+
+    /// アプリケーションエラーコードを返す。
+    /// @param なし
+    /// @returns エラーコード
+    /// @throws なし
+    pub fn app_code(&self) -> &'static str {
+        match self.kind {
+            MessageErrorKind::Validation => "VALIDATION_ERROR",
+            MessageErrorKind::ChannelNotFound => "CHANNEL_NOT_FOUND",
+            MessageErrorKind::DependencyUnavailable => "AUTHZ_UNAVAILABLE",
+        }
+    }
+
+    /// 外部向け固定メッセージを返す。
+    /// @param なし
+    /// @returns 公開メッセージ
+    /// @throws なし
+    pub fn public_message(&self) -> &'static str {
+        match self.kind {
+            MessageErrorKind::Validation => "request payload is invalid",
+            MessageErrorKind::ChannelNotFound => "channel resource was not found",
+            MessageErrorKind::DependencyUnavailable => {
+                "authorization dependency is unavailable"
+            }
+        }
+    }
+}
+
+impl From<MessageApiError> for MessageError {
+    fn from(value: MessageApiError) -> Self {
+        Self::validation(value.reason_code())
+    }
+}
+
+impl From<MessageUsecaseError> for MessageError {
+    fn from(value: MessageUsecaseError) -> Self {
+        match value {
+            MessageUsecaseError::Validation(reason) => Self::validation(reason),
+            MessageUsecaseError::ChannelNotFound(reason) => Self::channel_not_found(reason),
+            MessageUsecaseError::DependencyUnavailable(reason) => {
+                Self::dependency_unavailable(reason)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct MessageErrorBody {
+    code: &'static str,
+    message: String,
+    request_id: String,
+}
+
+/// message API エラーをHTTPレスポンスへ変換する。
+/// @param error 変換対象エラー
+/// @param request_id リクエスト識別子
+/// @returns RESTエラーレスポンス
+/// @throws なし
+pub fn message_error_response(error: &MessageError, request_id: String) -> Response {
+    tracing::warn!(
+        request_id = %request_id,
+        error_kind = ?error.kind,
+        reason = %error.reason,
+        "message API request rejected"
+    );
+
+    let body = MessageErrorBody {
+        code: error.app_code(),
+        message: error.public_message().to_owned(),
+        request_id,
+    };
+
+    (error.status_code(), Json(body)).into_response()
+}

--- a/rust/apps/api/src/message/runtime.rs
+++ b/rust/apps/api/src/message/runtime.rs
@@ -1,0 +1,81 @@
+/// 実行時向けの message service を生成する。
+/// @param なし
+/// @returns message service
+/// @throws なし
+pub async fn build_runtime_message_service() -> Arc<dyn MessageService> {
+    let database_url = match env::var("DATABASE_URL") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            warn!("DATABASE_URL missing; message service will fail-close as unavailable");
+            return Arc::new(UnavailableMessageService::new(
+                "message_metadata_unconfigured",
+            ));
+        }
+    };
+
+    let allow_postgres_notls = parse_runtime_bool_env("AUTH_ALLOW_POSTGRES_NOTLS", false);
+    if !allow_postgres_notls {
+        warn!(
+            "AUTH_ALLOW_POSTGRES_NOTLS is false; message service stays fail-close until TLS connector is configured"
+        );
+        return Arc::new(UnavailableMessageService::new("postgres_tls_required"));
+    }
+
+    let scylla_config = match crate::scylla_health::build_scylla_runtime_config_from_env() {
+        Ok(config) => config,
+        Err(reason) => {
+            warn!(
+                reason = %reason,
+                "Scylla runtime config is invalid; message service will fail-close as unavailable"
+            );
+            return Arc::new(UnavailableMessageService::new(
+                "message_body_store_unconfigured",
+            ));
+        }
+    };
+
+    let session = match crate::scylla_health::build_runtime_scylla_session(&scylla_config).await {
+        Ok(session) => session,
+        Err(reason) => {
+            warn!(
+                reason = %reason,
+                "Scylla runtime session initialization failed; message service will fail-close"
+            );
+            return Arc::new(UnavailableMessageService::new(
+                "message_body_store_unavailable",
+            ));
+        }
+    };
+
+    let usecase: Arc<dyn MessageUsecase> = Arc::new(LiveMessageUsecase::new(
+        Arc::new(ScyllaMessageStore::new(session, scylla_config.keyspace.clone())),
+        Arc::new(PostgresMessageMetadataRepository::new(
+            database_url,
+            allow_postgres_notls,
+        )),
+    ));
+
+    Arc::new(RuntimeMessageService::new(usecase))
+}
+
+fn parse_runtime_bool_env(name: &str, default: bool) -> bool {
+    match env::var(name) {
+        Ok(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            match normalized.as_str() {
+                "1" | "true" | "yes" | "on" => true,
+                "0" | "false" | "no" | "off" => false,
+                _ => {
+                    warn!(
+                        env_var = %name,
+                        value = %value,
+                        default = default,
+                        "invalid bool env value; fallback to default"
+                    );
+                    default
+                }
+            }
+        }
+        Err(_) => default,
+    }
+}

--- a/rust/apps/api/src/message/service.rs
+++ b/rust/apps/api/src/message/service.rs
@@ -1,0 +1,583 @@
+const MESSAGE_REQUEST_IDENTITY_TTL: Duration = Duration::from_secs(600);
+const MESSAGE_REQUEST_IDENTITY_CACHE_MAX: usize = 8_192;
+
+#[derive(Debug, Clone)]
+struct MessageRequestIdentity {
+    message_id: i64,
+    created_at: String,
+}
+
+#[derive(Debug, Clone)]
+struct CachedMessageRequestIdentity {
+    identity: MessageRequestIdentity,
+    expires_at: Instant,
+}
+
+#[derive(Default)]
+struct MessageRequestIdentityCacheState {
+    entries: HashMap<String, CachedMessageRequestIdentity>,
+    order: VecDeque<String>,
+}
+
+/// message API ユースケース境界を表現する。
+#[async_trait]
+pub trait MessageService: Send + Sync {
+    /// guild channel message history を返す。
+    /// @param guild_id 対象 guild_id
+    /// @param channel_id 対象 channel_id
+    /// @param query list query
+    /// @returns list response
+    /// @throws MessageError validation / not found / dependency unavailable 時
+    async fn list_guild_channel_messages(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        query: ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageError>;
+
+    /// guild channel message を作成する。
+    /// @param principal_id 投稿主体
+    /// @param guild_id 対象 guild_id
+    /// @param channel_id 対象 channel_id
+    /// @param request_id 冪等キーへ利用する request_id
+    /// @param request 作成入力
+    /// @returns 作成レスポンス
+    /// @throws MessageError validation / not found / dependency unavailable 時
+    async fn create_guild_channel_message(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        channel_id: i64,
+        request_id: &str,
+        request: CreateGuildChannelMessageRequestV1,
+    ) -> Result<CreateGuildChannelMessageResponseV1, MessageError>;
+}
+
+/// 実行時 message service を表現する。
+#[derive(Clone)]
+pub struct RuntimeMessageService {
+    usecase: Arc<dyn MessageUsecase>,
+    request_identity_cache: Arc<Mutex<MessageRequestIdentityCacheState>>,
+    request_identity_ttl: Duration,
+    request_identity_cache_max: usize,
+    next_message_id: Arc<AtomicI64>,
+}
+
+impl RuntimeMessageService {
+    /// runtime service を生成する。
+    /// @param usecase message usecase
+    /// @returns runtime service
+    /// @throws なし
+    pub fn new(usecase: Arc<dyn MessageUsecase>) -> Self {
+        Self {
+            usecase,
+            request_identity_cache: Arc::new(Mutex::new(
+                MessageRequestIdentityCacheState::default(),
+            )),
+            request_identity_ttl: MESSAGE_REQUEST_IDENTITY_TTL,
+            request_identity_cache_max: MESSAGE_REQUEST_IDENTITY_CACHE_MAX,
+            next_message_id: Arc::new(AtomicI64::new(0)),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_for_test(
+        usecase: Arc<dyn MessageUsecase>,
+        request_identity_ttl: Duration,
+        request_identity_cache_max: usize,
+    ) -> Self {
+        Self {
+            usecase,
+            request_identity_cache: Arc::new(Mutex::new(
+                MessageRequestIdentityCacheState::default(),
+            )),
+            request_identity_ttl,
+            request_identity_cache_max,
+            next_message_id: Arc::new(AtomicI64::new(0)),
+        }
+    }
+
+    async fn request_identity(
+        &self,
+        principal_id: PrincipalId,
+        channel_id: i64,
+        request_id: &str,
+    ) -> Result<MessageRequestIdentity, MessageError> {
+        let cache_key = format!("{}:{channel_id}:{request_id}", principal_id.0);
+        let now = Instant::now();
+        let mut cache = self.request_identity_cache.lock().await;
+
+        self.evict_expired_locked(&mut cache, now);
+
+        if let Some(entry) = cache.entries.get(&cache_key) {
+            return Ok(entry.identity.clone());
+        }
+
+        self.evict_capacity_locked(&mut cache);
+
+        let identity = self.allocate_request_identity()?;
+        cache.entries.insert(
+            cache_key.clone(),
+            CachedMessageRequestIdentity {
+                identity: identity.clone(),
+                expires_at: now + self.request_identity_ttl,
+            },
+        );
+        cache.order.push_back(cache_key);
+        Ok(identity)
+    }
+
+    fn evict_expired_locked(
+        &self,
+        cache: &mut MessageRequestIdentityCacheState,
+        now: Instant,
+    ) {
+        while let Some(front) = cache.order.front().cloned() {
+            let should_pop = match cache.entries.get(&front) {
+                Some(entry) if entry.expires_at <= now => {
+                    cache.entries.remove(&front);
+                    true
+                }
+                Some(_) => false,
+                None => true,
+            };
+            if !should_pop {
+                break;
+            }
+            cache.order.pop_front();
+        }
+    }
+
+    fn evict_capacity_locked(&self, cache: &mut MessageRequestIdentityCacheState) {
+        while cache.entries.len() >= self.request_identity_cache_max {
+            let Some(front) = cache.order.pop_front() else {
+                break;
+            };
+            cache.entries.remove(&front);
+        }
+    }
+
+    fn allocate_request_identity(&self) -> Result<MessageRequestIdentity, MessageError> {
+        let now = OffsetDateTime::now_utc();
+        self.allocate_request_identity_at(now)
+    }
+
+    #[cfg(test)]
+    fn allocate_request_identity_at(
+        &self,
+        now: OffsetDateTime,
+    ) -> Result<MessageRequestIdentity, MessageError> {
+        let created_at = now
+            .replace_nanosecond(0)
+            .map_err(|error| {
+                MessageError::dependency_unavailable(format!(
+                    "message_timestamp_generation_failed:{error}"
+                ))
+            })?;
+        let created_at = created_at.format(&Rfc3339).map_err(|error| {
+            MessageError::dependency_unavailable(format!(
+                "message_timestamp_format_failed:{error}"
+            ))
+        })?;
+        let message_id = self.allocate_message_id(now)?;
+
+        Ok(MessageRequestIdentity {
+            message_id,
+            created_at,
+        })
+    }
+
+    #[cfg(not(test))]
+    fn allocate_request_identity_at(
+        &self,
+        now: OffsetDateTime,
+    ) -> Result<MessageRequestIdentity, MessageError> {
+        let created_at = now
+            .replace_nanosecond(0)
+            .map_err(|error| {
+                MessageError::dependency_unavailable(format!(
+                    "message_timestamp_generation_failed:{error}"
+                ))
+            })?;
+        let created_at = created_at.format(&Rfc3339).map_err(|error| {
+            MessageError::dependency_unavailable(format!(
+                "message_timestamp_format_failed:{error}"
+            ))
+        })?;
+        let message_id = self.allocate_message_id(now)?;
+
+        Ok(MessageRequestIdentity {
+            message_id,
+            created_at,
+        })
+    }
+
+    fn allocate_message_id(&self, now: OffsetDateTime) -> Result<i64, MessageError> {
+        let candidate = i64::try_from(now.unix_timestamp_nanos()).map_err(|error| {
+            MessageError::dependency_unavailable(format!("message_id_generation_failed:{error}"))
+        })?;
+        loop {
+            let previous = self.next_message_id.load(Ordering::Relaxed);
+            let next = candidate.max(previous.saturating_add(1));
+            match self.next_message_id.compare_exchange(
+                previous,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Ok(next),
+                Err(_) => continue,
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl MessageService for RuntimeMessageService {
+    /// guild channel message history を返す。
+    /// @param guild_id 対象 guild_id
+    /// @param channel_id 対象 channel_id
+    /// @param query list query
+    /// @returns list response
+    /// @throws MessageError validation / not found / dependency unavailable 時
+    async fn list_guild_channel_messages(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        query: ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageError> {
+        self.usecase
+            .list_guild_channel_messages(guild_id, channel_id, query)
+            .await
+            .map_err(MessageError::from)
+    }
+
+    /// guild channel message を作成する。
+    /// @param principal_id 投稿主体
+    /// @param guild_id 対象 guild_id
+    /// @param channel_id 対象 channel_id
+    /// @param request_id 冪等キーへ利用する request_id
+    /// @param request 作成入力
+    /// @returns 作成レスポンス
+    /// @throws MessageError validation / not found / dependency unavailable 時
+    async fn create_guild_channel_message(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        channel_id: i64,
+        request_id: &str,
+        request: CreateGuildChannelMessageRequestV1,
+    ) -> Result<CreateGuildChannelMessageResponseV1, MessageError> {
+        let identity = self
+            .request_identity(principal_id, channel_id, request_id)
+            .await?;
+        let message = self
+            .usecase
+            .append_guild_channel_message(AppendGuildChannelMessageCommand {
+                guild_id,
+                channel_id,
+                author_id: principal_id.0,
+                message_id: identity.message_id,
+                content: request.content,
+                created_at: identity.created_at,
+            })
+            .await
+            .map_err(MessageError::from)?;
+
+        Ok(CreateGuildChannelMessageResponseV1 { message })
+    }
+}
+
+/// 依存未構成時に fail-close させる message service を表現する。
+#[derive(Clone)]
+pub struct UnavailableMessageService {
+    reason: String,
+}
+
+impl UnavailableMessageService {
+    /// unavailable service を生成する。
+    /// @param reason unavailable 理由
+    /// @returns unavailable service
+    /// @throws なし
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+
+    fn unavailable_error(&self) -> MessageError {
+        MessageError::dependency_unavailable(self.reason.clone())
+    }
+}
+
+#[async_trait]
+impl MessageService for UnavailableMessageService {
+    /// guild channel message history を返す。
+    /// @param _guild_id 対象 guild_id
+    /// @param _channel_id 対象 channel_id
+    /// @param _query list query
+    /// @returns なし
+    /// @throws MessageError 常に unavailable
+    async fn list_guild_channel_messages(
+        &self,
+        _guild_id: i64,
+        _channel_id: i64,
+        _query: ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageError> {
+        Err(self.unavailable_error())
+    }
+
+    /// guild channel message を作成する。
+    /// @param _principal_id 投稿主体
+    /// @param _guild_id 対象 guild_id
+    /// @param _channel_id 対象 channel_id
+    /// @param _request_id 冪等キーへ利用する request_id
+    /// @param _request 作成入力
+    /// @returns なし
+    /// @throws MessageError 常に unavailable
+    async fn create_guild_channel_message(
+        &self,
+        _principal_id: PrincipalId,
+        _guild_id: i64,
+        _channel_id: i64,
+        _request_id: &str,
+        _request: CreateGuildChannelMessageRequestV1,
+    ) -> Result<CreateGuildChannelMessageResponseV1, MessageError> {
+        Err(self.unavailable_error())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::items_after_test_module)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+    use tokio::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingMessageUsecase {
+        appended: Mutex<Vec<AppendGuildChannelMessageCommand>>,
+    }
+
+    #[async_trait]
+    impl MessageUsecase for RecordingMessageUsecase {
+        async fn append_guild_channel_message(
+            &self,
+            command: AppendGuildChannelMessageCommand,
+        ) -> Result<linklynx_message_api::MessageItemV1, MessageUsecaseError> {
+            self.appended.lock().await.push(command.clone());
+            Ok(command.to_message_item())
+        }
+
+        async fn list_guild_channel_messages(
+            &self,
+            _guild_id: i64,
+            _channel_id: i64,
+            _query: ListGuildChannelMessagesQueryV1,
+        ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
+            Ok(ListGuildChannelMessagesResponseV1 {
+                items: vec![],
+                next_before: None,
+                next_after: None,
+                has_more: false,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn same_request_id_reuses_message_identity_within_process() {
+        let usecase = Arc::new(RecordingMessageUsecase::default());
+        let service = RuntimeMessageService::new_for_test(
+            usecase.clone(),
+            Duration::from_secs(600),
+            MESSAGE_REQUEST_IDENTITY_CACHE_MAX,
+        );
+
+        let _ = service
+            .create_guild_channel_message(
+                PrincipalId(9003),
+                10,
+                20,
+                "req-1",
+                CreateGuildChannelMessageRequestV1 {
+                    content: "first".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        let _ = service
+            .create_guild_channel_message(
+                PrincipalId(9003),
+                10,
+                20,
+                "req-1",
+                CreateGuildChannelMessageRequestV1 {
+                    content: "second".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let appended = usecase.appended.lock().await;
+        assert_eq!(appended.len(), 2);
+        assert_eq!(appended[0].message_id, appended[1].message_id);
+        assert_eq!(appended[0].created_at, appended[1].created_at);
+    }
+
+    #[tokio::test]
+    async fn different_request_identity_keys_allocate_distinct_message_ids() {
+        let usecase = Arc::new(RecordingMessageUsecase::default());
+        let service = RuntimeMessageService::new_for_test(
+            usecase.clone(),
+            Duration::from_secs(600),
+            MESSAGE_REQUEST_IDENTITY_CACHE_MAX,
+        );
+
+        let _ = service
+            .create_guild_channel_message(
+                PrincipalId(9003),
+                10,
+                20,
+                "req-1",
+                CreateGuildChannelMessageRequestV1 {
+                    content: "first".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        let _ = service
+            .create_guild_channel_message(
+                PrincipalId(9003),
+                10,
+                21,
+                "req-1",
+                CreateGuildChannelMessageRequestV1 {
+                    content: "second".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        let _ = service
+            .create_guild_channel_message(
+                PrincipalId(9003),
+                10,
+                20,
+                "req-2",
+                CreateGuildChannelMessageRequestV1 {
+                    content: "third".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let appended = usecase.appended.lock().await;
+        assert_eq!(appended.len(), 3);
+        assert_ne!(appended[0].message_id, appended[1].message_id);
+        assert_ne!(appended[0].message_id, appended[2].message_id);
+    }
+
+    #[tokio::test]
+    async fn expired_request_identity_is_regenerated() {
+        let usecase = Arc::new(RecordingMessageUsecase::default());
+        let service = RuntimeMessageService::new_for_test(
+            usecase.clone(),
+            Duration::ZERO,
+            MESSAGE_REQUEST_IDENTITY_CACHE_MAX,
+        );
+
+        let _ = service
+            .create_guild_channel_message(
+                PrincipalId(9003),
+                10,
+                20,
+                "req-1",
+                CreateGuildChannelMessageRequestV1 {
+                    content: "first".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        let _ = service
+            .create_guild_channel_message(
+                PrincipalId(9003),
+                10,
+                20,
+                "req-1",
+                CreateGuildChannelMessageRequestV1 {
+                    content: "second".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let appended = usecase.appended.lock().await;
+        assert_eq!(appended.len(), 2);
+        assert_ne!(appended[0].message_id, appended[1].message_id);
+    }
+
+    #[tokio::test]
+    async fn capacity_eviction_regenerates_oldest_request_identity() {
+        let usecase = Arc::new(RecordingMessageUsecase::default());
+        let service =
+            RuntimeMessageService::new_for_test(usecase.clone(), Duration::from_secs(600), 1);
+
+        let _ = service
+            .create_guild_channel_message(
+                PrincipalId(9003),
+                10,
+                20,
+                "req-1",
+                CreateGuildChannelMessageRequestV1 {
+                    content: "first".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        let _ = service
+            .create_guild_channel_message(
+                PrincipalId(9003),
+                10,
+                20,
+                "req-2",
+                CreateGuildChannelMessageRequestV1 {
+                    content: "second".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+        let _ = service
+            .create_guild_channel_message(
+                PrincipalId(9003),
+                10,
+                20,
+                "req-1",
+                CreateGuildChannelMessageRequestV1 {
+                    content: "third".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let appended = usecase.appended.lock().await;
+        assert_eq!(appended.len(), 3);
+        assert_ne!(appended[0].message_id, appended[2].message_id);
+    }
+
+    #[test]
+    fn allocate_message_id_remains_unique_when_timestamp_is_identical() {
+        let service = RuntimeMessageService::new_for_test(
+            Arc::new(RecordingMessageUsecase::default()),
+            Duration::from_secs(600),
+            MESSAGE_REQUEST_IDENTITY_CACHE_MAX,
+        );
+        let now = OffsetDateTime::parse("2026-03-08T10:11:12.123456789Z", &Rfc3339).unwrap();
+        let mut ids = HashSet::new();
+
+        for _ in 0..1_500 {
+            let identity = service.allocate_request_identity_at(now).unwrap();
+            assert!(ids.insert(identity.message_id));
+            assert_eq!(identity.created_at, "2026-03-08T10:11:12Z");
+        }
+    }
+}

--- a/rust/apps/api/src/scylla_health/runtime.rs
+++ b/rust/apps/api/src/scylla_health/runtime.rs
@@ -138,22 +138,32 @@ async fn build_runtime_scylla_health_reporter_from_parts(
 async fn build_live_scylla_health_reporter(
     config: &ScyllaRuntimeConfig,
 ) -> Result<LiveScyllaHealthReporter, String> {
-    let mut builder = SessionBuilder::new();
-    for host in &config.hosts {
-        builder = builder.known_node(host);
-    }
-
     let request_timeout = Duration::from_millis(config.request_timeout_ms);
-    let session = timeout(request_timeout, builder.build())
-        .await
-        .map_err(|_| format!("scylla_connect_timeout:{}ms", config.request_timeout_ms))?
-        .map_err(|error| format!("scylla_connect_failed:{error}"))?;
+    let session = build_runtime_scylla_session(config).await?;
 
     Ok(LiveScyllaHealthReporter::new(
         session,
         config.keyspace.clone(),
         request_timeout,
     ))
+}
+
+/// 実行時設定から Scylla session を初期化する。
+/// @param config Scylla runtime 設定
+/// @returns 初期化済み session
+/// @throws String session 初期化失敗時
+pub(crate) async fn build_runtime_scylla_session(
+    config: &ScyllaRuntimeConfig,
+) -> Result<Session, String> {
+    let mut builder = SessionBuilder::new();
+    for host in &config.hosts {
+        builder = builder.known_node(host);
+    }
+
+    timeout(Duration::from_millis(config.request_timeout_ms), builder.build())
+        .await
+        .map_err(|_| format!("scylla_connect_timeout:{}ms", config.request_timeout_ms))?
+        .map_err(|error| format!("scylla_connect_failed:{error}"))
 }
 
 /// 必須環境変数を CSV として読み取る。

--- a/rust/crates/domains/message/Cargo.toml
+++ b/rust/crates/domains/message/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "linklynx_message_domain"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+linklynx_message_api = { path = "../../contracts/message-api" }
+thiserror.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true

--- a/rust/crates/domains/message/src/domain.rs
+++ b/rust/crates/domains/message/src/domain.rs
@@ -1,0 +1,108 @@
+use linklynx_message_api::{CreateGuildChannelMessageRequestV1, MessageApiError, MessageItemV1};
+use thiserror::Error;
+
+/// guild channel message append command を表現する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppendGuildChannelMessageCommand {
+    pub guild_id: i64,
+    pub channel_id: i64,
+    pub author_id: i64,
+    pub message_id: i64,
+    pub content: String,
+    pub created_at: String,
+}
+
+impl AppendGuildChannelMessageCommand {
+    /// validation 用 request shape へ変換する。
+    /// @param なし
+    /// @returns create request
+    /// @throws なし
+    pub fn to_create_request(&self) -> CreateGuildChannelMessageRequestV1 {
+        CreateGuildChannelMessageRequestV1 {
+            content: self.content.clone(),
+        }
+    }
+
+    /// public message snapshot へ変換する。
+    /// @param なし
+    /// @returns message item
+    /// @throws なし
+    pub fn to_message_item(&self) -> MessageItemV1 {
+        MessageItemV1 {
+            message_id: self.message_id,
+            guild_id: self.guild_id,
+            channel_id: self.channel_id,
+            author_id: self.author_id,
+            content: self.content.clone(),
+            created_at: self.created_at.clone(),
+            version: 1,
+            edited_at: None,
+            is_deleted: false,
+        }
+    }
+}
+
+/// guild channel の message read/write に必要な context を表現する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuildChannelContext {
+    pub channel_id: i64,
+    pub guild_id: i64,
+    pub created_at: String,
+    pub last_message_id: Option<i64>,
+    pub last_message_at: Option<String>,
+}
+
+/// message usecase の失敗を表現する。
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum MessageUsecaseError {
+    #[error("validation failed: {0}")]
+    Validation(String),
+    #[error("channel not found: {0}")]
+    ChannelNotFound(String),
+    #[error("dependency unavailable: {0}")]
+    DependencyUnavailable(String),
+}
+
+impl MessageUsecaseError {
+    /// validation エラーを生成する。
+    /// @param reason 失敗理由
+    /// @returns validation error
+    /// @throws なし
+    pub fn validation(reason: impl Into<String>) -> Self {
+        Self::Validation(reason.into())
+    }
+
+    /// channel not found エラーを生成する。
+    /// @param reason 失敗理由
+    /// @returns not found error
+    /// @throws なし
+    pub fn channel_not_found(reason: impl Into<String>) -> Self {
+        Self::ChannelNotFound(reason.into())
+    }
+
+    /// dependency unavailable エラーを生成する。
+    /// @param reason 失敗理由
+    /// @returns dependency unavailable error
+    /// @throws なし
+    pub fn dependency_unavailable(reason: impl Into<String>) -> Self {
+        Self::DependencyUnavailable(reason.into())
+    }
+
+    /// transport 向け reason code を返す。
+    /// @param なし
+    /// @returns reason code
+    /// @throws なし
+    pub fn reason_code(&self) -> &str {
+        match self {
+            Self::Validation(reason)
+            | Self::ChannelNotFound(reason)
+            | Self::DependencyUnavailable(reason) => reason.as_str(),
+        }
+    }
+}
+
+impl From<MessageApiError> for MessageUsecaseError {
+    fn from(value: MessageApiError) -> Self {
+        Self::validation(value.reason_code())
+    }
+}

--- a/rust/crates/domains/message/src/lib.rs
+++ b/rust/crates/domains/message/src/lib.rs
@@ -1,0 +1,7 @@
+mod domain;
+mod ports;
+mod usecase;
+
+pub use domain::{AppendGuildChannelMessageCommand, GuildChannelContext, MessageUsecaseError};
+pub use ports::{MessageBodyStore, MessageMetadataRepository};
+pub use usecase::{LiveMessageUsecase, MessageUsecase, UnavailableMessageUsecase};

--- a/rust/crates/domains/message/src/ports.rs
+++ b/rust/crates/domains/message/src/ports.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use linklynx_message_api::{
+    ListGuildChannelMessagesQueryV1, ListGuildChannelMessagesResponseV1, MessageItemV1,
+};
+
+use crate::{GuildChannelContext, MessageUsecaseError};
+
+/// message body SoR port を表現する。
+#[async_trait]
+pub trait MessageBodyStore: Send + Sync {
+    /// guild channel message を append する。
+    /// @param message 保存対象 message snapshot
+    /// @returns 保存済み message snapshot
+    /// @throws MessageUsecaseError 依存障害時
+    async fn append_guild_channel_message(
+        &self,
+        message: &MessageItemV1,
+    ) -> Result<MessageItemV1, MessageUsecaseError>;
+
+    /// guild channel message history を list する。
+    /// @param context channel context
+    /// @param query 正規化済み query
+    /// @returns list response
+    /// @throws MessageUsecaseError validation または依存障害時
+    async fn list_guild_channel_messages(
+        &self,
+        context: &GuildChannelContext,
+        query: &ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError>;
+}
+
+/// message metadata repository port を表現する。
+#[async_trait]
+pub trait MessageMetadataRepository: Send + Sync {
+    /// channel context を取得する。
+    /// @param channel_id 対象 channel_id
+    /// @returns channel context。未存在時は `None`
+    /// @throws MessageUsecaseError 依存障害時
+    async fn get_guild_channel_context(
+        &self,
+        channel_id: i64,
+    ) -> Result<Option<GuildChannelContext>, MessageUsecaseError>;
+
+    /// channel_last_message を monotonic に更新する。
+    /// @param channel_id 対象 channel_id
+    /// @param message_id 最新 message_id
+    /// @param created_at 最新 created_at
+    /// @returns 更新成功時は `()`
+    /// @throws MessageUsecaseError 依存障害時
+    async fn upsert_last_message(
+        &self,
+        channel_id: i64,
+        message_id: i64,
+        created_at: &str,
+    ) -> Result<(), MessageUsecaseError>;
+}

--- a/rust/crates/domains/message/src/usecase.rs
+++ b/rust/crates/domains/message/src/usecase.rs
@@ -1,0 +1,423 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use linklynx_message_api::{
+    normalize_list_query, validate_create_request, ListGuildChannelMessagesQueryV1,
+    ListGuildChannelMessagesResponseV1, MessageItemV1,
+};
+
+use crate::{
+    AppendGuildChannelMessageCommand, GuildChannelContext, MessageBodyStore,
+    MessageMetadataRepository, MessageUsecaseError,
+};
+
+/// message append/list usecase 境界を表現する。
+#[async_trait]
+pub trait MessageUsecase: Send + Sync {
+    /// guild channel message を append する。
+    /// @param command append command
+    /// @returns 保存済み message snapshot
+    /// @throws MessageUsecaseError validation / not found / dependency unavailable 時
+    async fn append_guild_channel_message(
+        &self,
+        command: AppendGuildChannelMessageCommand,
+    ) -> Result<MessageItemV1, MessageUsecaseError>;
+
+    /// guild channel message history を list する。
+    /// @param guild_id 対象 guild_id
+    /// @param channel_id 対象 channel_id
+    /// @param query list query
+    /// @returns list response
+    /// @throws MessageUsecaseError validation / not found / dependency unavailable 時
+    async fn list_guild_channel_messages(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        query: ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError>;
+}
+
+/// live message usecase を表現する。
+#[derive(Clone)]
+pub struct LiveMessageUsecase {
+    body_store: Arc<dyn MessageBodyStore>,
+    metadata_repository: Arc<dyn MessageMetadataRepository>,
+}
+
+impl LiveMessageUsecase {
+    /// live usecase を生成する。
+    /// @param body_store message body store
+    /// @param metadata_repository message metadata repository
+    /// @returns live usecase
+    /// @throws なし
+    pub fn new(
+        body_store: Arc<dyn MessageBodyStore>,
+        metadata_repository: Arc<dyn MessageMetadataRepository>,
+    ) -> Self {
+        Self {
+            body_store,
+            metadata_repository,
+        }
+    }
+
+    /// guild/channel context を検証付きで取得する。
+    /// @param guild_id 対象 guild_id
+    /// @param channel_id 対象 channel_id
+    /// @returns channel context
+    /// @throws MessageUsecaseError channel 未存在または guild 不一致時
+    async fn load_channel_context(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+    ) -> Result<GuildChannelContext, MessageUsecaseError> {
+        let Some(context) = self
+            .metadata_repository
+            .get_guild_channel_context(channel_id)
+            .await?
+        else {
+            return Err(MessageUsecaseError::channel_not_found(
+                "message_channel_not_found",
+            ));
+        };
+        if context.guild_id != guild_id {
+            return Err(MessageUsecaseError::channel_not_found(
+                "message_channel_not_found",
+            ));
+        }
+        Ok(context)
+    }
+}
+
+#[async_trait]
+impl MessageUsecase for LiveMessageUsecase {
+    /// guild channel message を append する。
+    /// @param command append command
+    /// @returns 保存済み message snapshot
+    /// @throws MessageUsecaseError validation / not found / dependency unavailable 時
+    async fn append_guild_channel_message(
+        &self,
+        command: AppendGuildChannelMessageCommand,
+    ) -> Result<MessageItemV1, MessageUsecaseError> {
+        validate_create_request(&command.to_create_request())?;
+        let context = self
+            .load_channel_context(command.guild_id, command.channel_id)
+            .await?;
+        let message = command.to_message_item();
+        let stored_message = self
+            .body_store
+            .append_guild_channel_message(&message)
+            .await?;
+        self.metadata_repository
+            .upsert_last_message(
+                context.channel_id,
+                stored_message.message_id,
+                &stored_message.created_at,
+            )
+            .await?;
+        Ok(stored_message)
+    }
+
+    /// guild channel message history を list する。
+    /// @param guild_id 対象 guild_id
+    /// @param channel_id 対象 channel_id
+    /// @param query list query
+    /// @returns list response
+    /// @throws MessageUsecaseError validation / not found / dependency unavailable 時
+    async fn list_guild_channel_messages(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        query: ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
+        let normalized = normalize_list_query(&query)?;
+        let context = self.load_channel_context(guild_id, channel_id).await?;
+        self.body_store
+            .list_guild_channel_messages(&context, &normalized)
+            .await
+    }
+}
+
+/// fail-close な unavailable message usecase を表現する。
+#[derive(Clone)]
+pub struct UnavailableMessageUsecase {
+    reason: String,
+}
+
+impl UnavailableMessageUsecase {
+    /// unavailable usecase を生成する。
+    /// @param reason unavailable 理由
+    /// @returns unavailable usecase
+    /// @throws なし
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+
+    fn unavailable_error(&self) -> MessageUsecaseError {
+        MessageUsecaseError::dependency_unavailable(self.reason.clone())
+    }
+}
+
+#[async_trait]
+impl MessageUsecase for UnavailableMessageUsecase {
+    /// guild channel message を append する。
+    /// @param _command append command
+    /// @returns なし
+    /// @throws MessageUsecaseError 常に unavailable
+    async fn append_guild_channel_message(
+        &self,
+        _command: AppendGuildChannelMessageCommand,
+    ) -> Result<MessageItemV1, MessageUsecaseError> {
+        Err(self.unavailable_error())
+    }
+
+    /// guild channel message history を list する。
+    /// @param _guild_id 対象 guild_id
+    /// @param _channel_id 対象 channel_id
+    /// @param _query list query
+    /// @returns なし
+    /// @throws MessageUsecaseError 常に unavailable
+    async fn list_guild_channel_messages(
+        &self,
+        _guild_id: i64,
+        _channel_id: i64,
+        _query: ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
+        Err(self.unavailable_error())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use linklynx_message_api::{
+        ListGuildChannelMessagesQueryV1, ListGuildChannelMessagesResponseV1, MessageCursorKeyV1,
+        MessageItemV1,
+    };
+    use tokio::sync::Mutex;
+
+    use crate::{AppendGuildChannelMessageCommand, GuildChannelContext, MessageUsecase};
+
+    use super::{
+        LiveMessageUsecase, MessageBodyStore, MessageMetadataRepository, MessageUsecaseError,
+    };
+
+    #[derive(Default)]
+    struct FakeBodyStore {
+        appended: Mutex<Vec<MessageItemV1>>,
+        listed_queries: Mutex<Vec<ListGuildChannelMessagesQueryV1>>,
+        append_result: Mutex<Option<Result<MessageItemV1, MessageUsecaseError>>>,
+        list_result: Mutex<Option<Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError>>>,
+    }
+
+    #[async_trait]
+    impl MessageBodyStore for FakeBodyStore {
+        async fn append_guild_channel_message(
+            &self,
+            message: &MessageItemV1,
+        ) -> Result<MessageItemV1, MessageUsecaseError> {
+            self.appended.lock().await.push(message.clone());
+            if let Some(result) = self.append_result.lock().await.take() {
+                result
+            } else {
+                Ok(message.clone())
+            }
+        }
+
+        async fn list_guild_channel_messages(
+            &self,
+            _context: &GuildChannelContext,
+            query: &ListGuildChannelMessagesQueryV1,
+        ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
+            self.listed_queries.lock().await.push(query.clone());
+            if let Some(result) = self.list_result.lock().await.take() {
+                result
+            } else {
+                Ok(ListGuildChannelMessagesResponseV1 {
+                    items: vec![],
+                    next_before: None,
+                    next_after: None,
+                    has_more: false,
+                })
+            }
+        }
+    }
+
+    struct FakeMetadataRepository {
+        context: Option<GuildChannelContext>,
+        upserts: Mutex<Vec<(i64, i64, String)>>,
+    }
+
+    #[async_trait]
+    impl MessageMetadataRepository for FakeMetadataRepository {
+        async fn get_guild_channel_context(
+            &self,
+            _channel_id: i64,
+        ) -> Result<Option<GuildChannelContext>, MessageUsecaseError> {
+            Ok(self.context.clone())
+        }
+
+        async fn upsert_last_message(
+            &self,
+            channel_id: i64,
+            message_id: i64,
+            created_at: &str,
+        ) -> Result<(), MessageUsecaseError> {
+            self.upserts
+                .lock()
+                .await
+                .push((channel_id, message_id, created_at.to_owned()));
+            Ok(())
+        }
+    }
+
+    fn command() -> AppendGuildChannelMessageCommand {
+        AppendGuildChannelMessageCommand {
+            guild_id: 10,
+            channel_id: 20,
+            author_id: 30,
+            message_id: 120_111,
+            content: "hello".to_owned(),
+            created_at: "2026-03-08T10:00:00Z".to_owned(),
+        }
+    }
+
+    fn context() -> GuildChannelContext {
+        GuildChannelContext {
+            channel_id: 20,
+            guild_id: 10,
+            created_at: "2026-03-01T00:00:00Z".to_owned(),
+            last_message_id: Some(120_110),
+            last_message_at: Some("2026-03-07T10:00:00Z".to_owned()),
+        }
+    }
+
+    #[tokio::test]
+    async fn append_rejects_blank_content() {
+        let usecase = LiveMessageUsecase::new(
+            Arc::new(FakeBodyStore::default()),
+            Arc::new(FakeMetadataRepository {
+                context: Some(context()),
+                upserts: Mutex::new(vec![]),
+            }),
+        );
+
+        let error = usecase
+            .append_guild_channel_message(AppendGuildChannelMessageCommand {
+                content: "   ".to_owned(),
+                ..command()
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            MessageUsecaseError::validation("message_content_required")
+        );
+    }
+
+    #[tokio::test]
+    async fn append_updates_metadata_after_store() {
+        let body_store = Arc::new(FakeBodyStore::default());
+        let metadata = Arc::new(FakeMetadataRepository {
+            context: Some(context()),
+            upserts: Mutex::new(vec![]),
+        });
+        let usecase = LiveMessageUsecase::new(body_store.clone(), metadata.clone());
+
+        let stored = usecase
+            .append_guild_channel_message(command())
+            .await
+            .unwrap();
+
+        assert_eq!(stored.message_id, 120_111);
+        assert_eq!(body_store.appended.lock().await.len(), 1);
+        assert_eq!(
+            metadata.upserts.lock().await.as_slice(),
+            &[(20, 120_111, "2026-03-08T10:00:00Z".to_owned())]
+        );
+    }
+
+    #[tokio::test]
+    async fn append_returns_not_found_when_channel_is_missing() {
+        let usecase = LiveMessageUsecase::new(
+            Arc::new(FakeBodyStore::default()),
+            Arc::new(FakeMetadataRepository {
+                context: None,
+                upserts: Mutex::new(vec![]),
+            }),
+        );
+
+        let error = usecase
+            .append_guild_channel_message(command())
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            MessageUsecaseError::channel_not_found("message_channel_not_found")
+        );
+    }
+
+    #[tokio::test]
+    async fn list_normalizes_query_before_store() {
+        let body_store = Arc::new(FakeBodyStore::default());
+        let usecase = LiveMessageUsecase::new(
+            body_store.clone(),
+            Arc::new(FakeMetadataRepository {
+                context: Some(context()),
+                upserts: Mutex::new(vec![]),
+            }),
+        );
+
+        let _ = usecase
+            .list_guild_channel_messages(10, 20, ListGuildChannelMessagesQueryV1::default())
+            .await
+            .unwrap();
+
+        let listed_queries = body_store.listed_queries.lock().await;
+        assert_eq!(listed_queries.len(), 1);
+        assert_eq!(listed_queries[0].limit, Some(50));
+    }
+
+    #[tokio::test]
+    async fn list_returns_not_found_when_guild_mismatch() {
+        let usecase = LiveMessageUsecase::new(
+            Arc::new(FakeBodyStore::default()),
+            Arc::new(FakeMetadataRepository {
+                context: Some(GuildChannelContext {
+                    guild_id: 11,
+                    ..context()
+                }),
+                upserts: Mutex::new(vec![]),
+            }),
+        );
+
+        let error = usecase
+            .list_guild_channel_messages(
+                10,
+                20,
+                ListGuildChannelMessagesQueryV1 {
+                    limit: Some(1),
+                    before: Some(
+                        MessageCursorKeyV1 {
+                            created_at: "2026-03-07T10:00:00Z".to_owned(),
+                            message_id: 120_110,
+                        }
+                        .encode(),
+                    ),
+                    after: None,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            MessageUsecaseError::channel_not_found("message_channel_not_found")
+        );
+    }
+}

--- a/rust/crates/platform/postgres/message/Cargo.toml
+++ b/rust/crates/platform/postgres/message/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "linklynx_platform_postgres_message"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+linklynx_message_domain = { path = "../../../domains/message" }
+tokio.workspace = true
+tokio-postgres.workspace = true
+tracing.workspace = true

--- a/rust/crates/platform/postgres/message/src/lib.rs
+++ b/rust/crates/platform/postgres/message/src/lib.rs
@@ -1,0 +1,279 @@
+use std::{
+    env,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use async_trait::async_trait;
+use linklynx_message_domain::{
+    GuildChannelContext, MessageMetadataRepository, MessageUsecaseError,
+};
+use tokio::sync::RwLock;
+use tokio_postgres::{NoTls, Row};
+use tracing::warn;
+
+const SELECT_CHANNEL_CONTEXT_SQL: &str = "
+    SELECT
+      c.id AS channel_id,
+      c.guild_id,
+      to_char(c.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS created_at,
+      clm.last_message_id,
+      CASE
+        WHEN clm.last_message_at IS NULL THEN NULL
+        ELSE to_char(clm.last_message_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"')
+      END AS last_message_at
+    FROM channels c
+    LEFT JOIN channel_last_message clm
+      ON clm.channel_id = c.id
+    WHERE c.id = $1
+      AND c.type = 'guild_text'";
+const UPSERT_LAST_MESSAGE_SQL: &str = "
+    INSERT INTO channel_last_message (channel_id, last_message_id, last_message_at)
+    VALUES ($1, $2, $3::timestamptz)
+    ON CONFLICT (channel_id)
+    DO UPDATE SET
+      last_message_id = EXCLUDED.last_message_id,
+      last_message_at = EXCLUDED.last_message_at,
+      updated_at = now()
+    WHERE channel_last_message.last_message_at < EXCLUDED.last_message_at
+       OR (
+         channel_last_message.last_message_at = EXCLUDED.last_message_at
+         AND channel_last_message.last_message_id < EXCLUDED.last_message_id
+       )";
+
+/// Postgres-backed message metadata repository を表現する。
+#[derive(Clone)]
+pub struct PostgresMessageMetadataRepository {
+    database_url: Arc<str>,
+    allow_postgres_notls: bool,
+    clients: Arc<RwLock<Vec<Arc<tokio_postgres::Client>>>>,
+    next_index: Arc<AtomicU64>,
+    pool_size: usize,
+}
+
+impl PostgresMessageMetadataRepository {
+    const DEFAULT_POOL_SIZE: usize = 4;
+    const MAX_POOL_SIZE: usize = 100;
+
+    /// repository を生成する。
+    /// @param database_url 接続文字列
+    /// @param allow_postgres_notls 平文接続許可フラグ
+    /// @returns repository
+    /// @throws なし
+    pub fn new(database_url: String, allow_postgres_notls: bool) -> Self {
+        let pool_size = Self::parse_pool_size_from_env();
+        Self {
+            database_url: Arc::from(database_url),
+            allow_postgres_notls,
+            clients: Arc::new(RwLock::new(Vec::new())),
+            next_index: Arc::new(AtomicU64::new(0)),
+            pool_size,
+        }
+    }
+
+    fn parse_pool_size_from_env() -> usize {
+        match env::var("MESSAGE_METADATA_POOL_SIZE") {
+            Ok(value) => match value.parse::<usize>() {
+                Ok(0) => {
+                    warn!(
+                        env_var = "MESSAGE_METADATA_POOL_SIZE",
+                        value = %value,
+                        default = Self::DEFAULT_POOL_SIZE,
+                        "pool size must be >= 1; fallback to default"
+                    );
+                    Self::DEFAULT_POOL_SIZE
+                }
+                Ok(parsed) if parsed > Self::MAX_POOL_SIZE => {
+                    warn!(
+                        env_var = "MESSAGE_METADATA_POOL_SIZE",
+                        value = %value,
+                        max = Self::MAX_POOL_SIZE,
+                        "pool size exceeds upper bound; clamped"
+                    );
+                    Self::MAX_POOL_SIZE
+                }
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    warn!(
+                        env_var = "MESSAGE_METADATA_POOL_SIZE",
+                        value = %value,
+                        reason = %error,
+                        default = Self::DEFAULT_POOL_SIZE,
+                        "invalid pool size env value; fallback to default"
+                    );
+                    Self::DEFAULT_POOL_SIZE
+                }
+            },
+            Err(_) => Self::DEFAULT_POOL_SIZE,
+        }
+    }
+
+    async fn connect_client(&self) -> Result<Arc<tokio_postgres::Client>, MessageUsecaseError> {
+        if !self.allow_postgres_notls {
+            return Err(MessageUsecaseError::dependency_unavailable(
+                "postgres_tls_required",
+            ));
+        }
+
+        let (client, connection) = tokio_postgres::connect(self.database_url.as_ref(), NoTls)
+            .await
+            .map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_metadata_connect_failed:{error}"
+                ))
+            })?;
+
+        tokio::spawn(async move {
+            if let Err(error) = connection.await {
+                tracing::error!(reason = %error, "message metadata postgres connection error");
+            }
+        });
+
+        Ok(Arc::new(client))
+    }
+
+    async fn ensure_pool(&self) -> Result<(), MessageUsecaseError> {
+        {
+            let guard = self.clients.read().await;
+            if !guard.is_empty() {
+                return Ok(());
+            }
+        }
+
+        let mut guard = self.clients.write().await;
+        if !guard.is_empty() {
+            return Ok(());
+        }
+
+        for _ in 0..self.pool_size {
+            guard.push(self.connect_client().await?);
+        }
+        Ok(())
+    }
+
+    async fn select_client(&self) -> Result<Arc<tokio_postgres::Client>, MessageUsecaseError> {
+        self.ensure_pool().await?;
+        let guard = self.clients.read().await;
+        if guard.is_empty() {
+            return Err(MessageUsecaseError::dependency_unavailable(
+                "message_metadata_pool_empty",
+            ));
+        }
+        let index = (self.next_index.fetch_add(1, Ordering::Relaxed) as usize) % guard.len();
+        Ok(Arc::clone(&guard[index]))
+    }
+
+    async fn invalidate_pool(&self) {
+        self.clients.write().await.clear();
+    }
+
+    fn map_channel_context_row(
+        &self,
+        row: Row,
+    ) -> Result<GuildChannelContext, MessageUsecaseError> {
+        Ok(GuildChannelContext {
+            channel_id: row.try_get("channel_id").map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_metadata_channel_id_decode_failed:{error}"
+                ))
+            })?,
+            guild_id: row.try_get("guild_id").map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_metadata_guild_id_decode_failed:{error}"
+                ))
+            })?,
+            created_at: row.try_get("created_at").map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_metadata_created_at_decode_failed:{error}"
+                ))
+            })?,
+            last_message_id: row.try_get("last_message_id").map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_metadata_last_message_id_decode_failed:{error}"
+                ))
+            })?,
+            last_message_at: row.try_get("last_message_at").map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_metadata_last_message_at_decode_failed:{error}"
+                ))
+            })?,
+        })
+    }
+}
+
+#[async_trait]
+impl MessageMetadataRepository for PostgresMessageMetadataRepository {
+    /// channel context を取得する。
+    /// @param channel_id 対象 channel_id
+    /// @returns channel context。未存在時は `None`
+    /// @throws MessageUsecaseError 依存障害時
+    async fn get_guild_channel_context(
+        &self,
+        channel_id: i64,
+    ) -> Result<Option<GuildChannelContext>, MessageUsecaseError> {
+        let client = self.select_client().await?;
+        let row = match client
+            .query_opt(SELECT_CHANNEL_CONTEXT_SQL, &[&channel_id])
+            .await
+        {
+            Ok(row) => row,
+            Err(error) => {
+                self.invalidate_pool().await;
+                return Err(MessageUsecaseError::dependency_unavailable(format!(
+                    "message_metadata_context_query_failed:{error}"
+                )));
+            }
+        };
+        row.map(|value| self.map_channel_context_row(value))
+            .transpose()
+    }
+
+    /// channel_last_message を monotonic に更新する。
+    /// @param channel_id 対象 channel_id
+    /// @param message_id 最新 message_id
+    /// @param created_at 最新 created_at
+    /// @returns 更新成功時は `()`
+    /// @throws MessageUsecaseError 依存障害時
+    async fn upsert_last_message(
+        &self,
+        channel_id: i64,
+        message_id: i64,
+        created_at: &str,
+    ) -> Result<(), MessageUsecaseError> {
+        let client = self.select_client().await?;
+        if let Err(error) = client
+            .execute(
+                UPSERT_LAST_MESSAGE_SQL,
+                &[&channel_id, &message_id, &created_at],
+            )
+            .await
+        {
+            self.invalidate_pool().await;
+            return Err(MessageUsecaseError::dependency_unavailable(format!(
+                "message_metadata_upsert_failed:{error}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SELECT_CHANNEL_CONTEXT_SQL, UPSERT_LAST_MESSAGE_SQL};
+
+    #[test]
+    fn select_channel_context_sql_scopes_to_guild_text_channels() {
+        assert!(SELECT_CHANNEL_CONTEXT_SQL.contains("c.type = 'guild_text'"));
+        assert!(SELECT_CHANNEL_CONTEXT_SQL.contains("LEFT JOIN channel_last_message"));
+    }
+
+    #[test]
+    fn upsert_last_message_sql_is_monotonic() {
+        assert!(UPSERT_LAST_MESSAGE_SQL
+            .contains("channel_last_message.last_message_at < EXCLUDED.last_message_at"));
+        assert!(UPSERT_LAST_MESSAGE_SQL
+            .contains("channel_last_message.last_message_id < EXCLUDED.last_message_id"));
+    }
+}

--- a/rust/crates/platform/scylla/message/Cargo.toml
+++ b/rust/crates/platform/scylla/message/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "linklynx_platform_scylla_message"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+linklynx_message_api = { path = "../../../contracts/message-api" }
+linklynx_message_domain = { path = "../../../domains/message" }
+scylla.workspace = true
+time.workspace = true

--- a/rust/crates/platform/scylla/message/src/lib.rs
+++ b/rust/crates/platform/scylla/message/src/lib.rs
@@ -1,0 +1,748 @@
+use std::{collections::HashSet, sync::Arc};
+
+use async_trait::async_trait;
+use linklynx_message_api::{
+    ListGuildChannelMessagesQueryV1, ListGuildChannelMessagesResponseV1, MessageCursorKeyV1,
+    MessageItemV1,
+};
+use linklynx_message_domain::{GuildChannelContext, MessageBodyStore, MessageUsecaseError};
+use scylla::{client::session::Session, value::CqlTimestamp};
+use time::{format_description::well_known::Rfc3339, Date, Month, OffsetDateTime};
+
+const INSERT_MESSAGE_SQL_TEMPLATE: &str = "
+    INSERT INTO chat.messages_by_channel (
+      channel_id,
+      bucket,
+      message_id,
+      author_id,
+      content,
+      version,
+      edited_at,
+      is_deleted,
+      deleted_at,
+      deleted_by,
+      created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    IF NOT EXISTS";
+const SELECT_MESSAGE_SQL_TEMPLATE: &str = "
+    SELECT
+      channel_id,
+      bucket,
+      message_id,
+      author_id,
+      content,
+      version,
+      edited_at,
+      is_deleted,
+      deleted_at,
+      deleted_by,
+      created_at
+    FROM chat.messages_by_channel
+    WHERE channel_id = ?
+      AND bucket = ?
+      AND message_id = ?";
+const LIST_BUCKET_DESC_SQL_TEMPLATE: &str = "
+    SELECT
+      channel_id,
+      bucket,
+      message_id,
+      author_id,
+      content,
+      version,
+      edited_at,
+      is_deleted,
+      deleted_at,
+      deleted_by,
+      created_at
+    FROM chat.messages_by_channel
+    WHERE channel_id = ?
+      AND bucket = ?
+    ORDER BY message_id DESC
+    LIMIT ?";
+const LIST_BUCKET_ASC_SQL_TEMPLATE: &str = "
+    SELECT
+      channel_id,
+      bucket,
+      message_id,
+      author_id,
+      content,
+      version,
+      edited_at,
+      is_deleted,
+      deleted_at,
+      deleted_by,
+      created_at
+    FROM chat.messages_by_channel
+    WHERE channel_id = ?
+      AND bucket = ?
+    ORDER BY message_id ASC
+    LIMIT ?";
+const LIST_BUCKET_BEFORE_SQL_TEMPLATE: &str = "
+    SELECT
+      channel_id,
+      bucket,
+      message_id,
+      author_id,
+      content,
+      version,
+      edited_at,
+      is_deleted,
+      deleted_at,
+      deleted_by,
+      created_at
+    FROM chat.messages_by_channel
+    WHERE channel_id = ?
+      AND bucket = ?
+      AND (created_at, message_id) < (?, ?)
+    ORDER BY message_id DESC
+    LIMIT ?
+    ALLOW FILTERING";
+const LIST_BUCKET_AFTER_SQL_TEMPLATE: &str = "
+    SELECT
+      channel_id,
+      bucket,
+      message_id,
+      author_id,
+      content,
+      version,
+      edited_at,
+      is_deleted,
+      deleted_at,
+      deleted_by,
+      created_at
+    FROM chat.messages_by_channel
+    WHERE channel_id = ?
+      AND bucket = ?
+      AND (created_at, message_id) > (?, ?)
+    ORDER BY message_id ASC
+    LIMIT ?
+    ALLOW FILTERING";
+
+type ScyllaMessageRow = (
+    i64,
+    i32,
+    i64,
+    i64,
+    String,
+    i64,
+    Option<CqlTimestamp>,
+    bool,
+    Option<CqlTimestamp>,
+    Option<i64>,
+    CqlTimestamp,
+);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CursorDirection {
+    Before,
+    After,
+}
+
+/// Scylla-backed message body store を表現する。
+#[derive(Clone)]
+pub struct ScyllaMessageStore {
+    session: Arc<Session>,
+    insert_message_sql: String,
+    select_message_sql: String,
+    list_bucket_desc_sql: String,
+    list_bucket_asc_sql: String,
+    list_bucket_before_sql: String,
+    list_bucket_after_sql: String,
+}
+
+impl ScyllaMessageStore {
+    /// message store を生成する。
+    /// @param session 初期化済み Scylla session
+    /// @returns message store
+    /// @throws なし
+    pub fn new(session: Session, keyspace: impl Into<String>) -> Self {
+        let keyspace = keyspace.into();
+        Self {
+            session: Arc::new(session),
+            insert_message_sql: qualify_messages_by_channel_sql(
+                INSERT_MESSAGE_SQL_TEMPLATE,
+                &keyspace,
+            ),
+            select_message_sql: qualify_messages_by_channel_sql(
+                SELECT_MESSAGE_SQL_TEMPLATE,
+                &keyspace,
+            ),
+            list_bucket_desc_sql: qualify_messages_by_channel_sql(
+                LIST_BUCKET_DESC_SQL_TEMPLATE,
+                &keyspace,
+            ),
+            list_bucket_asc_sql: qualify_messages_by_channel_sql(
+                LIST_BUCKET_ASC_SQL_TEMPLATE,
+                &keyspace,
+            ),
+            list_bucket_before_sql: qualify_messages_by_channel_sql(
+                LIST_BUCKET_BEFORE_SQL_TEMPLATE,
+                &keyspace,
+            ),
+            list_bucket_after_sql: qualify_messages_by_channel_sql(
+                LIST_BUCKET_AFTER_SQL_TEMPLATE,
+                &keyspace,
+            ),
+        }
+    }
+
+    async fn select_message(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        bucket: i32,
+        message_id: i64,
+    ) -> Result<Option<MessageItemV1>, MessageUsecaseError> {
+        let query_result = self
+            .session
+            .query_unpaged(
+                self.select_message_sql.as_str(),
+                (channel_id, bucket, message_id),
+            )
+            .await
+            .map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_select_failed:{error}"
+                ))
+            })?;
+        let rows_result = query_result.into_rows_result().map_err(|error| {
+            MessageUsecaseError::dependency_unavailable(format!(
+                "message_select_rows_unavailable:{error}"
+            ))
+        })?;
+        let row = rows_result
+            .maybe_first_row::<ScyllaMessageRow>()
+            .map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_select_deserialize_failed:{error}"
+                ))
+            })?;
+        row.map(|value| map_row_to_message(guild_id, value))
+            .transpose()
+    }
+
+    async fn query_messages<V>(
+        &self,
+        guild_id: i64,
+        query: &str,
+        values: V,
+    ) -> Result<Vec<MessageItemV1>, MessageUsecaseError>
+    where
+        V: scylla::serialize::row::SerializeRow,
+    {
+        let query_result = self
+            .session
+            .query_unpaged(query, values)
+            .await
+            .map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_list_query_failed:{error}"
+                ))
+            })?;
+        let rows_result = query_result.into_rows_result().map_err(|error| {
+            MessageUsecaseError::dependency_unavailable(format!(
+                "message_list_rows_unavailable:{error}"
+            ))
+        })?;
+
+        rows_result
+            .rows::<ScyllaMessageRow>()
+            .map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_list_deserialize_failed:{error}"
+                ))
+            })?
+            .map(|row| {
+                row.map_err(|error| {
+                    MessageUsecaseError::dependency_unavailable(format!(
+                        "message_row_decode_failed:{error}"
+                    ))
+                })
+            })
+            .map(|row| row.and_then(|value| map_row_to_message(guild_id, value)))
+            .collect()
+    }
+
+    async fn query_bucket_desc(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        bucket: i32,
+        limit: usize,
+    ) -> Result<Vec<MessageItemV1>, MessageUsecaseError> {
+        self.query_messages(
+            guild_id,
+            &self.list_bucket_desc_sql,
+            (channel_id, bucket, limit as i32),
+        )
+        .await
+    }
+
+    async fn query_bucket_asc(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        bucket: i32,
+        limit: usize,
+    ) -> Result<Vec<MessageItemV1>, MessageUsecaseError> {
+        self.query_messages(
+            guild_id,
+            &self.list_bucket_asc_sql,
+            (channel_id, bucket, limit as i32),
+        )
+        .await
+    }
+
+    async fn query_bucket_before(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        bucket: i32,
+        cursor: &MessageCursorKeyV1,
+        limit: usize,
+    ) -> Result<Vec<MessageItemV1>, MessageUsecaseError> {
+        self.query_messages(
+            guild_id,
+            &self.list_bucket_before_sql,
+            (
+                channel_id,
+                bucket,
+                timestamp_to_cql(parse_rfc3339_timestamp(&cursor.created_at)?),
+                cursor.message_id,
+                limit as i32,
+            ),
+        )
+        .await
+    }
+
+    async fn query_bucket_after(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        bucket: i32,
+        cursor: &MessageCursorKeyV1,
+        limit: usize,
+    ) -> Result<Vec<MessageItemV1>, MessageUsecaseError> {
+        self.query_messages(
+            guild_id,
+            &self.list_bucket_after_sql,
+            (
+                channel_id,
+                bucket,
+                timestamp_to_cql(parse_rfc3339_timestamp(&cursor.created_at)?),
+                cursor.message_id,
+                limit as i32,
+            ),
+        )
+        .await
+    }
+
+    async fn insert_message(
+        &self,
+        message: &MessageItemV1,
+        bucket: i32,
+        created_at: OffsetDateTime,
+    ) -> Result<(), MessageUsecaseError> {
+        self.session
+            .query_unpaged(
+                self.insert_message_sql.as_str(),
+                (
+                    message.channel_id,
+                    bucket,
+                    message.message_id,
+                    message.author_id,
+                    &message.content,
+                    message.version,
+                    Option::<CqlTimestamp>::None,
+                    message.is_deleted,
+                    Option::<CqlTimestamp>::None,
+                    Option::<i64>::None,
+                    timestamp_to_cql(created_at),
+                ),
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| {
+                MessageUsecaseError::dependency_unavailable(format!(
+                    "message_append_insert_failed:{error}"
+                ))
+            })
+    }
+}
+
+#[async_trait]
+impl MessageBodyStore for ScyllaMessageStore {
+    /// guild channel message を append する。
+    /// @param message 保存対象 message snapshot
+    /// @returns 保存済み message snapshot
+    /// @throws MessageUsecaseError 依存障害時
+    async fn append_guild_channel_message(
+        &self,
+        message: &MessageItemV1,
+    ) -> Result<MessageItemV1, MessageUsecaseError> {
+        let bucket = bucket_from_timestamp(&message.created_at)?;
+        let created_at = parse_rfc3339_timestamp(&message.created_at)?;
+        if let Err(error) = self.insert_message(message, bucket, created_at).await {
+            if let Some(existing) = self
+                .select_message(
+                    message.guild_id,
+                    message.channel_id,
+                    bucket,
+                    message.message_id,
+                )
+                .await?
+            {
+                return Ok(existing);
+            }
+
+            self.insert_message(message, bucket, created_at)
+                .await
+                .map_err(|retry_error| {
+                    MessageUsecaseError::dependency_unavailable(format!(
+                        "message_append_failed:{error};retry:{retry_error}"
+                    ))
+                })?;
+        }
+
+        self.select_message(
+            message.guild_id,
+            message.channel_id,
+            bucket,
+            message.message_id,
+        )
+        .await?
+        .ok_or_else(|| MessageUsecaseError::dependency_unavailable("message_append_select_missing"))
+    }
+
+    /// guild channel message history を list する。
+    /// @param context channel context
+    /// @param query 正規化済み query
+    /// @returns list response
+    /// @throws MessageUsecaseError validation または依存障害時
+    async fn list_guild_channel_messages(
+        &self,
+        context: &GuildChannelContext,
+        query: &ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
+        let limit = query.limit.unwrap_or(50) as usize;
+        let collect_target = limit + 1;
+        let lower_bucket = bucket_from_timestamp(&context.created_at)?;
+        let upper_bucket = resolve_upper_bucket(context, OffsetDateTime::now_utc())?;
+        let mut items = Vec::with_capacity(collect_target);
+        let mut seen = HashSet::with_capacity(collect_target);
+
+        if let Some(after) = query.after.as_deref() {
+            let cursor = MessageCursorKeyV1::decode(after)?;
+            let start_bucket = bucket_from_timestamp(&cursor.created_at)?;
+            let mut bucket = start_bucket;
+            while bucket <= upper_bucket && items.len() < collect_target {
+                let remaining = collect_target - items.len();
+                let bucket_items = if bucket == start_bucket {
+                    self.query_bucket_after(
+                        context.guild_id,
+                        context.channel_id,
+                        bucket,
+                        &cursor,
+                        remaining,
+                    )
+                    .await?
+                } else {
+                    self.query_bucket_asc(context.guild_id, context.channel_id, bucket, remaining)
+                        .await?
+                };
+                collect_unique_items(&mut items, &mut seen, bucket_items, collect_target);
+                bucket = next_bucket(bucket)?;
+            }
+            return Ok(build_page_response(items, limit, CursorDirection::After));
+        }
+
+        let cursor = query
+            .before
+            .as_deref()
+            .map(MessageCursorKeyV1::decode)
+            .transpose()?;
+        let start_bucket = cursor
+            .as_ref()
+            .map(|value| bucket_from_timestamp(&value.created_at))
+            .transpose()?
+            .unwrap_or(upper_bucket);
+        let mut bucket = start_bucket;
+        while bucket >= lower_bucket && items.len() < collect_target {
+            let remaining = collect_target - items.len();
+            let bucket_items = match cursor.as_ref() {
+                Some(value) if bucket == start_bucket => {
+                    self.query_bucket_before(
+                        context.guild_id,
+                        context.channel_id,
+                        bucket,
+                        value,
+                        remaining,
+                    )
+                    .await?
+                }
+                _ => {
+                    self.query_bucket_desc(context.guild_id, context.channel_id, bucket, remaining)
+                        .await?
+                }
+            };
+            collect_unique_items(&mut items, &mut seen, bucket_items, collect_target);
+            if bucket == lower_bucket {
+                break;
+            }
+            bucket = previous_bucket(bucket)?;
+        }
+
+        Ok(build_page_response(items, limit, CursorDirection::Before))
+    }
+}
+
+fn qualify_messages_by_channel_sql(template: &str, keyspace: &str) -> String {
+    template.replace(
+        "chat.messages_by_channel",
+        &format!("{keyspace}.messages_by_channel"),
+    )
+}
+
+fn collect_unique_items(
+    items: &mut Vec<MessageItemV1>,
+    seen: &mut HashSet<i64>,
+    candidates: Vec<MessageItemV1>,
+    collect_target: usize,
+) {
+    for candidate in candidates {
+        if seen.insert(candidate.message_id) {
+            items.push(candidate);
+        }
+        if items.len() >= collect_target {
+            break;
+        }
+    }
+}
+
+fn resolve_upper_bucket(
+    context: &GuildChannelContext,
+    now: OffsetDateTime,
+) -> Result<i32, MessageUsecaseError> {
+    match context.last_message_at.as_deref() {
+        Some(last_message_at) => bucket_from_timestamp(last_message_at),
+        None => Ok(date_to_bucket(now.date())),
+    }
+}
+
+fn build_page_response(
+    mut items: Vec<MessageItemV1>,
+    limit: usize,
+    direction: CursorDirection,
+) -> ListGuildChannelMessagesResponseV1 {
+    let has_more = items.len() > limit;
+    if has_more {
+        items.truncate(limit);
+    }
+    let cursor = items.last().map(|item| MessageCursorKeyV1 {
+        created_at: item.created_at.clone(),
+        message_id: item.message_id,
+    });
+    let next_before = matches!(direction, CursorDirection::Before)
+        .then_some(cursor.as_ref().map(MessageCursorKeyV1::encode))
+        .flatten()
+        .filter(|_| has_more);
+    let next_after = matches!(direction, CursorDirection::After)
+        .then_some(cursor.as_ref().map(MessageCursorKeyV1::encode))
+        .flatten()
+        .filter(|_| has_more);
+
+    ListGuildChannelMessagesResponseV1 {
+        items,
+        next_before,
+        next_after,
+        has_more,
+    }
+}
+
+fn map_row_to_message(
+    guild_id: i64,
+    row: ScyllaMessageRow,
+) -> Result<MessageItemV1, MessageUsecaseError> {
+    let (
+        channel_id,
+        _bucket,
+        message_id,
+        author_id,
+        content,
+        version,
+        edited_at,
+        is_deleted,
+        _deleted_at,
+        _deleted_by,
+        created_at,
+    ) = row;
+
+    Ok(MessageItemV1 {
+        message_id,
+        guild_id,
+        channel_id,
+        author_id,
+        content,
+        created_at: format_rfc3339_timestamp(created_at)?,
+        version,
+        edited_at: edited_at.map(format_rfc3339_timestamp).transpose()?,
+        is_deleted,
+    })
+}
+
+fn parse_rfc3339_timestamp(value: &str) -> Result<OffsetDateTime, MessageUsecaseError> {
+    OffsetDateTime::parse(value, &Rfc3339).map_err(|error| {
+        MessageUsecaseError::validation(format!("message_timestamp_invalid:{error}"))
+    })
+}
+
+fn format_rfc3339_timestamp(value: CqlTimestamp) -> Result<String, MessageUsecaseError> {
+    let timestamp = OffsetDateTime::from_unix_timestamp_nanos(value.0 as i128 * 1_000_000)
+        .map_err(|error| {
+            MessageUsecaseError::dependency_unavailable(format!(
+                "message_timestamp_decode_failed:{error}"
+            ))
+        })?;
+    timestamp.format(&Rfc3339).map_err(|error| {
+        MessageUsecaseError::dependency_unavailable(format!(
+            "message_timestamp_format_failed:{error}"
+        ))
+    })
+}
+
+fn timestamp_to_cql(value: OffsetDateTime) -> CqlTimestamp {
+    CqlTimestamp(value.unix_timestamp() * 1000 + value.millisecond() as i64)
+}
+
+fn bucket_from_timestamp(value: &str) -> Result<i32, MessageUsecaseError> {
+    Ok(date_to_bucket(parse_rfc3339_timestamp(value)?.date()))
+}
+
+fn previous_bucket(bucket: i32) -> Result<i32, MessageUsecaseError> {
+    let previous = bucket_to_date(bucket)?
+        .previous_day()
+        .ok_or_else(|| MessageUsecaseError::validation("message_bucket_before_range"))?;
+    Ok(date_to_bucket(previous))
+}
+
+fn next_bucket(bucket: i32) -> Result<i32, MessageUsecaseError> {
+    let next = bucket_to_date(bucket)?
+        .next_day()
+        .ok_or_else(|| MessageUsecaseError::validation("message_bucket_after_range"))?;
+    Ok(date_to_bucket(next))
+}
+
+fn bucket_to_date(bucket: i32) -> Result<Date, MessageUsecaseError> {
+    let year = bucket / 10_000;
+    let month = ((bucket / 100) % 100) as u8;
+    let day = (bucket % 100) as u8;
+    let month = Month::try_from(month).map_err(|error| {
+        MessageUsecaseError::validation(format!("message_bucket_invalid_month:{error}"))
+    })?;
+    Date::from_calendar_date(year, month, day).map_err(|error| {
+        MessageUsecaseError::validation(format!("message_bucket_invalid_date:{error}"))
+    })
+}
+
+fn date_to_bucket(date: Date) -> i32 {
+    date.year() * 10_000 + i32::from(u8::from(date.month())) * 100 + i32::from(date.day())
+}
+
+#[cfg(test)]
+mod tests {
+    use linklynx_message_api::MessageItemV1;
+    use linklynx_message_domain::GuildChannelContext;
+    use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+    use super::{
+        bucket_from_timestamp, build_page_response, resolve_upper_bucket, CursorDirection,
+    };
+
+    fn sample_item(message_id: i64, created_at: &str) -> MessageItemV1 {
+        MessageItemV1 {
+            message_id,
+            guild_id: 10,
+            channel_id: 20,
+            author_id: 30,
+            content: "hello".to_owned(),
+            created_at: created_at.to_owned(),
+            version: 1,
+            edited_at: None,
+            is_deleted: false,
+        }
+    }
+
+    #[test]
+    fn bucket_from_timestamp_uses_utc_day() {
+        assert_eq!(
+            bucket_from_timestamp("2026-03-08T10:11:12Z").unwrap(),
+            20260308
+        );
+    }
+
+    #[test]
+    fn build_page_response_sets_next_before_for_older_direction() {
+        let response = build_page_response(
+            vec![
+                sample_item(120_110, "2026-03-08T10:00:03Z"),
+                sample_item(120_109, "2026-03-08T10:00:02Z"),
+            ],
+            1,
+            CursorDirection::Before,
+        );
+
+        assert_eq!(response.items.len(), 1);
+        assert!(response.next_before.is_some());
+        assert_eq!(response.next_after, None);
+        assert!(response.has_more);
+    }
+
+    #[test]
+    fn build_page_response_sets_next_after_for_newer_direction() {
+        let response = build_page_response(
+            vec![
+                sample_item(120_109, "2026-03-08T10:00:02Z"),
+                sample_item(120_110, "2026-03-08T10:00:03Z"),
+            ],
+            1,
+            CursorDirection::After,
+        );
+
+        assert_eq!(response.items.len(), 1);
+        assert_eq!(response.next_before, None);
+        assert!(response.next_after.is_some());
+        assert!(response.has_more);
+    }
+
+    #[test]
+    fn resolve_upper_bucket_uses_last_message_at_when_present() {
+        let context = GuildChannelContext {
+            channel_id: 20,
+            guild_id: 10,
+            created_at: "2026-03-01T00:00:00Z".to_owned(),
+            last_message_id: Some(120_111),
+            last_message_at: Some("2026-03-07T10:00:00Z".to_owned()),
+        };
+
+        let now = OffsetDateTime::parse("2026-03-08T00:00:00Z", &Rfc3339).unwrap();
+        let bucket = resolve_upper_bucket(&context, now).unwrap();
+
+        assert_eq!(bucket, 20260307);
+    }
+
+    #[test]
+    fn resolve_upper_bucket_falls_back_to_current_utc_day_when_metadata_is_missing() {
+        let context = GuildChannelContext {
+            channel_id: 20,
+            guild_id: 10,
+            created_at: "2026-03-01T00:00:00Z".to_owned(),
+            last_message_id: None,
+            last_message_at: None,
+        };
+
+        let now = OffsetDateTime::parse("2026-03-08T10:11:12Z", &Rfc3339).unwrap();
+        let bucket = resolve_upper_bucket(&context, now).unwrap();
+
+        assert_eq!(bucket, 20260308);
+    }
+}


### PR DESCRIPTION
## 概要
- guild channel message の list/create を fixture 直返しから runtime service 呼び出しへ差し替えました
- message の append/list を domain/usecase と Scylla/Postgres adapter に分離し、`apps/api` は transport mapping に戻しました
- Scylla runtime 初期化 helper を共通化し、smoke / validation 記録を `docs/agent_runs/LIN-937/` に追加しました

## 変更意図
- LIN-937 の目的どおり、message slice を Scylla SoR と Postgres metadata に実配線し、後続 transport 実装が direct CQL に依存しない境界を作るためです
- guild message create/list の本物配線を先に成立させ、後続 issue は handler ではなく usecase / service を組み合わせるだけにしたかったためです
- public response shape と既存 auth/authz/rate-limit の振る舞いは変えず、責務分割だけを進める意図です

## 変更内容
- `rust/crates/domains/message` を追加し、append/list 用 usecase と port を実装
- `rust/crates/platform/scylla/message` を追加し、UTC 日次 bucket・idempotent append・history paging を実装
- `rust/crates/platform/postgres/message` を追加し、`channels` / `channel_last_message` の context 読み出しと monotonic upsert を実装
- `rust/apps/api/src/message/` を追加し、runtime service・error mapping・request_id 単位の create retry 吸収 cache を実装
- guild message list/create handler を `message_service` 呼び出しへ差し替え
- regression tests と agent run 記録を追加

## Acceptance Criteria 対応
- domain / usecase から Scylla append/list を呼び出せる
  - `domains/message` + `platform/scylla/message` で実装
- message metadata 更新境界が明示されている
  - `platform/postgres/message` に分離し、`channel_last_message` を monotonic 更新
- transport 層が direct CQL なしで send/list を組み込める
  - handler は `message_service` だけを呼ぶ構造へ変更

## テスト
- `make rust-lint`
- `make validate`
- `cd typescript && npm run typecheck`
- `docker compose up -d postgres scylladb`
- `make scylla-bootstrap`
- `set -a && source .env && set +a && cd rust && cargo run -p linklynx_backend`
- `curl -i -sS http://127.0.0.1:8080/`
- `curl -i -sS http://127.0.0.1:8080/internal/scylla/health`

## Review / UI
- reviewer: blocking finding なし。残リスクは `request_id` 冪等性が同一プロセス内 cache に留まる点
- reviewer_ui_guard: UI 変更なしのため UI review skip

## Migration / Breaking
- DB migration なし
- public response shape の breaking change なし
- event contract scope なし（ADR-001 非該当）

## Follow-up
- cross-instance durable idempotency は兄弟 issue `LIN-948` で対応

## Linear
- LIN-937
- https://linear.app/linklynx-ai/issue/LIN-937/v1%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8-scylla-02-message-usecase-%E3%82%92-scylla-postgres-metadata-%E3%81%AB%E9%85%8D%E7%B7%9A%E3%81%99%E3%82%8B
