### PR TITLE
chore: codex-worktree の Codex 起動を承認不要モードに固定

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ make codex-worktree NAME=lin-300 BASE=origin/main
 ```
 
 - 実体スクリプト: `setup/create-worktree-and-codex.sh`
+- 起動する Codex CLI には既定で `--ask-for-approval never` を付与します。
 - `setup/create-worktree-with-env.sh` で `gitignore` 済み開発用ファイルを同期します（既定は `.env` 系）。
 - 追加対象は `WORKTREE_SYNC_IGNORED_PATHS`（カンマ区切りの git pathspec）で上書きできます。
 

--- a/setup/create-worktree-and-codex.sh
+++ b/setup/create-worktree-and-codex.sh
@@ -66,6 +66,7 @@ task_name=""
 base_ref=""
 open_codex=1
 codex_args=()
+codex_default_args=(--ask-for-approval never)
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -172,7 +173,11 @@ echo "Branch: $branch_name"
 echo "Base ref: $base_ref"
 
 if [[ "$open_codex" -eq 0 ]]; then
-    printf 'Run: codex --cd %q' "$worktree_path"
+    printf 'Run: codex'
+    for arg in "${codex_default_args[@]}"; do
+        printf ' %q' "$arg"
+    done
+    printf ' --cd %q' "$worktree_path"
     if [[ ${#codex_args[@]} -gt 0 ]]; then
         for arg in "${codex_args[@]}"; do
             printf ' %q' "$arg"
@@ -183,7 +188,7 @@ if [[ "$open_codex" -eq 0 ]]; then
 fi
 
 if [[ ${#codex_args[@]} -gt 0 ]]; then
-    exec codex --cd "$worktree_path" "${codex_args[@]}"
+    exec codex "${codex_default_args[@]}" --cd "$worktree_path" "${codex_args[@]}"
 else
-    exec codex --cd "$worktree_path"
+    exec codex "${codex_default_args[@]}" --cd "$worktree_path"
 fi


### PR DESCRIPTION
## 概要
- `make codex-worktree` から起動する `codex` に既定で `--ask-for-approval never` を付与
- `--no-open` 時に表示する再実行コマンドにも同じ既定引数を反映
- README に既定挙動を追記して利用者の認識と実挙動を一致させる

## 意図
- worktree 作成後の Codex 起動ポリシーを毎回手で指定せずに統一するため
- 表示される案内コマンドと実際の起動挙動のズレをなくすため

## 確認
- `bash -n setup/create-worktree-and-codex.sh`