### PR TITLE
LIN-943 チャンネルカテゴリのフロントエンドを実装

### DIFF
--- a/docs/agent_runs/LIN-943/Documentation.md
+++ b/docs/agent_runs/LIN-943/Documentation.md
@@ -1,0 +1,50 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now:
+  - branch `codex/LIN-943-channel-category-frontend` を `LIN-942` merge 後の HEAD から作成した。
+  - category-aware な frontend 実装、review 指摘の修正、validation、runtime smoke まで完了した。
+- Next:
+  - commit / PR を作成し、child issue を merge 可能な状態にする。
+
+## Decisions
+- category row は非 message target のため、sidebar では header toggle 専用にする。
+- child channel 作成導線は「server 直下 category 作成」と「選択中 category 配下 text channel 作成」を分ける。
+- category 作成後は route 遷移せず、配下 text channel 作成後のみ `/channels/{guildId}/{channelId}` へ遷移する。
+- delete 後 fallback と server page redirect は text channel のみを遷移先候補にする。
+- direct category route は `ChannelView` 側で最初の text channel か guild root へ redirect する。
+
+## Validation log
+- 2026-03-09: `cd typescript && npm run typecheck` 成功
+- 2026-03-09: `cd typescript && npm test -- src/shared/api/guild-channel-api-client.test.ts src/features/modals/ui/create-channel-modal.test.tsx src/features/modals/ui/channel-delete-modal.test.tsx src/features/context-menus/ui/server-context-menu.test.tsx src/features/context-menus/ui/channel-context-menu.test.tsx src/widgets/channel-sidebar/ui/channel-item.test.tsx src/widgets/chat/ui/channel-view.test.tsx 'src/app/channels/[serverId]/page.test.ts'` 成功（8 files / 56 tests）
+- 2026-03-09: `make validate` 成功
+- 2026-03-10: reviewer 指摘 3 件を修正
+  - category route redirect が guild channel list 未読込時に guild root へ誤遷移する race を解消
+  - sidebar の top-level 並び順を `position` 準拠へ修正
+  - category delete 後に child detail query cache が残る不整合を解消
+- 2026-03-10: `cd typescript && npm test -- src/widgets/chat/ui/channel-view.test.tsx src/widgets/channel-sidebar/ui/channel-sidebar.test.ts src/shared/api/mutations/use-channel-actions.test.ts` 成功（3 files / 6 tests）
+- 2026-03-10: `cd typescript && npm run typecheck` 成功
+- 2026-03-10: `make validate` 成功
+
+## Review log
+- 2026-03-10: reviewer
+  - block 1 件, major 2 件
+  - 対応完了。再検証で `make validate` / targeted tests を通過。
+- 2026-03-10: UI gate
+  - UI 変更あり判定。対象は sidebar / modal / channel route 一式。
+
+## Runtime smoke
+- `cd typescript && npm run dev -- --port 3010` 起動成功
+- `GET /` -> `307 /channels/me`
+- `GET /channels/2001` -> `200`
+- `GET /channels/2001/3100` -> `200`
+- limits:
+  - local auth 付きの category 作成 UI 完遂までは未実施
+  - direct category route の実際の client redirect は component test を primary evidence とした
+
+## How to run / demo
+- 1. `cd typescript && npm run typecheck`
+- 2. `make validate`
+
+## Known issues / follow-ups
+- `LIN-944` で `times` / `times-abe` シナリオの回帰試験と検証手順を固める。

--- a/docs/agent_runs/LIN-943/Implement.md
+++ b/docs/agent_runs/LIN-943/Implement.md
@@ -1,0 +1,7 @@
+# Implement.md (Runbook)
+
+- `LIN-943` は frontend の DTO 接続と UI 導線に限定し、backend 契約や migration は触らない。
+- `LIN-942` の `guild_category` / `parent_id` / `position` を唯一の前提にする。
+- 変更対象は API client、shared model、sidebar、create/edit/delete modal、route fallback 周辺に絞る。
+- category row は message target にしない。必要なフォールバックは text channel か guild root へ戻す。
+- validation / review / runtime evidence は `Documentation.md` に逐次追記する。

--- a/docs/agent_runs/LIN-943/Plan.md
+++ b/docs/agent_runs/LIN-943/Plan.md
@@ -1,0 +1,31 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: if validation fails, repair it before moving to the next step.
+
+## Milestones
+### M1: API client / shared model を hierarchy-aware に更新
+- Acceptance criteria:
+  - [x] `GuildChannelAPIClient` が `type`, `parent_id`, `position` を正規化する
+  - [x] create/update/delete cache path が category を壊さない
+  - [x] API client tests が backend DTO を前提に通る
+- Validation:
+  - `cd typescript && npm run typecheck`
+  - `cd typescript && npm run test -- src/shared/api/guild-channel-api-client.test.ts`
+
+### M2: sidebar / modal / route fallback を category-aware 化
+- Acceptance criteria:
+  - [x] sidebar が category row を非遷移で描画し、top-level channel と child channel を分離表示する
+  - [x] server context menu と channel context menu から category 作成 / 配下作成を出し分けられる
+  - [x] delete fallback と server page redirect が category を遷移先に選ばない
+- Validation:
+  - `cd typescript && npm run test -- src/features/modals/ui/create-channel-modal.test.tsx src/features/modals/ui/channel-delete-modal.test.tsx src/app/channels/[serverId]/page.test.ts`
+
+### M3: 統合確認と delivery evidence
+- Acceptance criteria:
+  - [x] `make validate` が通る
+  - [x] reviewer / UI gate / runtime smoke の準備ができている
+  - [x] PR 用 evidence を Documentation.md に残す
+- Validation:
+  - `make validate`
+  - `cd typescript && npm run typecheck`

--- a/docs/agent_runs/LIN-943/Prompt.md
+++ b/docs/agent_runs/LIN-943/Prompt.md
@@ -1,0 +1,26 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- `LIN-942` backend DTO に合わせて frontend の channel model / API client を hierarchy-aware に更新する。
+- sidebar で category と top-level text channel を実 API データから安定表示し、collapse state を機能させる。
+- category 作成、category 配下 text channel 作成、category delete 後の route fallback を既存 modal / context menu 導線で成立させる。
+
+## Non-goals
+- drag-and-drop 並び替え、thread UI、voice/forum/stage UI は扱わない。
+- backend 契約や AuthZ ルールの再定義は行わない。
+
+## Deliverables
+- `GuildChannelAPIClient` / shared model の DTO 正規化更新。
+- sidebar / create modal / edit-delete modal / route fallback の category-aware 化。
+- frontend regression tests と validation evidence。
+
+## Done when
+- [ ] category と top-level channel が左カラムで正しく分離表示される。
+- [ ] category 作成と category 配下 channel 作成ができる。
+- [ ] child channel 作成後の route / active state が崩れない。
+- [ ] category 非遷移 / delete fallback / error 表示が既存 UX と整合する。
+
+## Constraints
+- Perf: 既存 query key と cache shape を大きく変えない。
+- Security: category は message target にしない前提を崩さない。
+- Compatibility: `LIN-942` の `type`, `parent_id`, `position` を additive に取り込む。

--- a/typescript/src/app/channels/[serverId]/[channelId]/page.tsx
+++ b/typescript/src/app/channels/[serverId]/[channelId]/page.tsx
@@ -5,7 +5,7 @@ export default async function ChannelPage({
 }: {
   params: Promise<{ serverId: string; channelId: string }>;
 }) {
-  const { channelId } = await params;
+  const { serverId, channelId } = await params;
 
-  return <ChannelView channelId={channelId} />;
+  return <ChannelView channelId={channelId} serverId={serverId} />;
 }

--- a/typescript/src/features/context-menus/ui/channel-context-menu.test.tsx
+++ b/typescript/src/features/context-menus/ui/channel-context-menu.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { vi } from "vitest";
 import { render, screen, userEvent } from "@/test/test-utils";
 import { useUIStore } from "@/shared/model/stores/ui-store";
+import type { Channel } from "@/shared/model/types/channel";
 import { ChannelContextMenu } from "./channel-context-menu";
 
 const useActionGuardMock = vi.hoisted(() => vi.fn());
@@ -11,7 +12,14 @@ vi.mock("@/shared/api/queries", () => ({
   useActionGuard: useActionGuardMock,
 }));
 
-function createChannel() {
+function createChannel(overrides: Partial<Channel> = {}): Channel {
+  return {
+    ...createChannelBase(),
+    ...overrides,
+  };
+}
+
+function createChannelBase(): Channel {
   return {
     id: "3001",
     guildId: "2001",
@@ -56,7 +64,27 @@ describe("ChannelContextMenu", () => {
     expect(useUIStore.getState().modalProps).toMatchObject({
       channelId: "3001",
       channelName: "general",
+      channelType: 0,
       serverId: "2001",
+    });
+  });
+
+  test("opens child create modal from category context menu", async () => {
+    render(
+      <ChannelContextMenu
+        data={{
+          channel: createChannel({ id: "3100", type: 4, name: "times" }),
+          serverId: "2001",
+        }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("menuitem", { name: "チャンネルを作成" }));
+
+    expect(useUIStore.getState().activeModal).toBe("create-channel");
+    expect(useUIStore.getState().modalProps).toMatchObject({
+      serverId: "2001",
+      parentId: "3100",
     });
   });
 

--- a/typescript/src/features/context-menus/ui/channel-context-menu.tsx
+++ b/typescript/src/features/context-menus/ui/channel-context-menu.tsx
@@ -8,10 +8,16 @@ import type { Channel } from "@/shared/model/types/channel";
 export function ChannelContextMenu({ data }: { data: { channel: Channel; serverId: string } }) {
   const openModal = useUIStore((s) => s.openModal);
   const hideContextMenu = useUIStore((s) => s.hideContextMenu);
+  const isCategory = data.channel.type === 4;
   const manageChannelGuard = useActionGuard({
     serverId: data.serverId,
     channelId: data.channel.id,
     requirement: "channel:manage",
+  });
+  const createChannelGuard = useActionGuard({
+    serverId: data.serverId,
+    requirement: "guild:create-channel",
+    enabled: isCategory,
   });
 
   const handleCopyLink = () => {
@@ -30,13 +36,14 @@ export function ChannelContextMenu({ data }: { data: { channel: Channel; serverI
           openModal("channel-edit", {
             channelId: data.channel.id,
             channelName: data.channel.name,
+            channelType: data.channel.type,
           });
           hideContextMenu();
         }}
       >
-        チャンネルを編集
+        {isCategory ? "カテゴリーを編集" : "チャンネルを編集"}
       </MenuItem>
-      <MenuItem onClick={handleCopyLink}>チャンネルリンクをコピー</MenuItem>
+      {!isCategory && <MenuItem onClick={handleCopyLink}>チャンネルリンクをコピー</MenuItem>}
       {useUIStore.getState().developerMode && (
         <MenuItem
           onClick={() => {
@@ -48,7 +55,22 @@ export function ChannelContextMenu({ data }: { data: { channel: Channel; serverI
         </MenuItem>
       )}
       <MenuSeparator />
-      <MenuItem disabled>招待を作成</MenuItem>
+      {isCategory ? (
+        <MenuItem
+          disabled={!createChannelGuard.isAllowed}
+          onClick={() => {
+            openModal("create-channel", {
+              serverId: data.serverId,
+              parentId: data.channel.id,
+            });
+            hideContextMenu();
+          }}
+        >
+          チャンネルを作成
+        </MenuItem>
+      ) : (
+        <MenuItem disabled>招待を作成</MenuItem>
+      )}
       <MenuItem
         danger
         disabled={!manageChannelGuard.isAllowed}
@@ -56,12 +78,13 @@ export function ChannelContextMenu({ data }: { data: { channel: Channel; serverI
           openModal("channel-delete", {
             channelId: data.channel.id,
             channelName: data.channel.name,
+            channelType: data.channel.type,
             serverId: data.serverId,
           });
           hideContextMenu();
         }}
       >
-        チャンネルを削除
+        {isCategory ? "カテゴリーを削除" : "チャンネルを削除"}
       </MenuItem>
     </ContextMenu>
   );

--- a/typescript/src/features/context-menus/ui/server-context-menu.test.tsx
+++ b/typescript/src/features/context-menus/ui/server-context-menu.test.tsx
@@ -62,6 +62,44 @@ describe("ServerContextMenu", () => {
     expect(state.contextMenu).toBeNull();
   });
 
+  test("opens create-channel modal in category mode", async () => {
+    useUIStore.setState({
+      activeModal: null,
+      modalProps: {},
+      contextMenu: {
+        type: "server",
+        position: { x: 0, y: 0 },
+        data: {},
+      },
+    });
+
+    render(
+      <ServerContextMenu
+        data={{
+          server: {
+            id: "2001",
+            name: "LinkLynx Developers",
+            icon: null,
+            banner: null,
+            ownerId: "1001",
+            memberCount: 1,
+            boostLevel: 0,
+            boostCount: 0,
+            features: [],
+            description: null,
+          },
+        }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("menuitem", { name: "カテゴリーを作成" }));
+
+    const state = useUIStore.getState();
+    expect(state.activeModal).toBe("create-channel");
+    expect(state.modalProps).toMatchObject({ serverId: "2001", initialChannelType: 4 });
+    expect(state.contextMenu).toBeNull();
+  });
+
   test("opens server-settings modal with selected server id", async () => {
     useUIStore.setState({
       activeModal: null,

--- a/typescript/src/features/context-menus/ui/server-context-menu.tsx
+++ b/typescript/src/features/context-menus/ui/server-context-menu.tsx
@@ -30,6 +30,18 @@ export function ServerContextMenu({ data }: { data: { server: Guild } }) {
       >
         チャンネルを作成
       </MenuItem>
+      <MenuItem
+        disabled={!createChannelGuard.isAllowed}
+        onClick={() => {
+          openModal("create-channel", {
+            serverId: data.server.id,
+            initialChannelType: 4,
+          });
+          hideContextMenu();
+        }}
+      >
+        カテゴリーを作成
+      </MenuItem>
       <MenuSeparator />
       <MenuItem disabled>招待を作成</MenuItem>
       <MenuItem

--- a/typescript/src/features/modals/ui/channel-delete-modal.test.tsx
+++ b/typescript/src/features/modals/ui/channel-delete-modal.test.tsx
@@ -113,6 +113,48 @@ describe("ChannelDeleteModal", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  test("redirects when deleting category also removes selected child route", async () => {
+    usePathnameMock.mockReturnValue("/channels/2001/3001");
+    useChannelsMock.mockReturnValue({
+      data: [
+        {
+          id: "3100",
+          guildId: "2001",
+          type: 4 as const,
+          name: "times",
+          topic: null,
+          position: 0,
+          parentId: null,
+          nsfw: false,
+          rateLimitPerUser: 0,
+          lastMessageId: null,
+        },
+        {
+          ...createChannel("3001", 1),
+          parentId: "3100",
+        },
+        createChannel("3002", 2),
+      ],
+    });
+    mutateAsyncMock.mockResolvedValueOnce(undefined);
+
+    render(
+      <ChannelDeleteModal
+        channelId="3100"
+        channelName="times"
+        channelType={4}
+        onClose={vi.fn()}
+        serverId="2001"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "カテゴリーを削除" }));
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/channels/2001/3002");
+    });
+  });
+
   test("keeps delete disabled when channel manage permission is missing", () => {
     useActionGuardMock.mockImplementation(() => ({
       status: "forbidden",

--- a/typescript/src/features/modals/ui/channel-delete-modal.tsx
+++ b/typescript/src/features/modals/ui/channel-delete-modal.tsx
@@ -13,17 +13,40 @@ import type { Channel } from "@/shared/model/types";
 import { Button } from "@/shared/ui/button";
 import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/shared/ui/modal";
 
+function collectDeletedChannelIds(channels: Channel[], channelId: string): Set<string> {
+  const deletedIds = new Set<string>([channelId]);
+
+  let foundChild = true;
+  while (foundChild) {
+    foundChild = false;
+    for (const channel of channels) {
+      if (
+        channel.parentId !== null &&
+        deletedIds.has(channel.parentId) &&
+        !deletedIds.has(channel.id)
+      ) {
+        deletedIds.add(channel.id);
+        foundChild = true;
+      }
+    }
+  }
+
+  return deletedIds;
+}
+
 export function ChannelDeleteModal({
   onClose,
   onDeleted,
   channelId,
   channelName,
+  channelType,
   serverId,
 }: {
   onClose: () => void;
   onDeleted?: () => void;
   channelId?: string;
   channelName?: string;
+  channelType?: number;
   serverId?: string;
 }) {
   const router = useRouter();
@@ -42,10 +65,16 @@ export function ChannelDeleteModal({
     serverId === undefined || channelId === undefined ? null : manageChannelGuard.message;
 
   const routeSelection = parseGuildChannelRoute(pathname ?? "");
+  const deletedIds =
+    channelId === undefined
+      ? new Set<string>()
+      : collectDeletedChannelIds(channels ?? [], channelId);
   const isDeletingSelectedChannel =
     routeSelection !== null &&
     routeSelection.guildId === serverId &&
-    routeSelection.channelId === channelId;
+    routeSelection.channelId !== null &&
+    deletedIds.has(routeSelection.channelId);
+  const isCategory = channelType === 4;
 
   const handleDelete = async () => {
     if (serverId === undefined || channelId === undefined) {
@@ -63,7 +92,7 @@ export function ChannelDeleteModal({
       if (isDeletingSelectedChannel) {
         const cachedChannels =
           queryClient.getQueryData<Channel[]>(["channels", serverId]) ??
-          channels?.filter((channel) => channel.id !== channelId) ??
+          channels?.filter((channel) => !deletedIds.has(channel.id)) ??
           [];
         const nextChannel = findFirstTextChannel(cachedChannels);
         const fallbackRoute =
@@ -82,13 +111,21 @@ export function ChannelDeleteModal({
 
   return (
     <Modal open onClose={onClose} className="max-w-[440px]">
-      <ModalHeader>チャンネルを削除</ModalHeader>
+      <ModalHeader>{isCategory ? "カテゴリーを削除" : "チャンネルを削除"}</ModalHeader>
       <ModalBody>
         <p className="text-sm text-discord-text-normal">
-          {channelName ? `#${channelName} を削除します。` : "このチャンネルを削除します。"}
+          {isCategory
+            ? channelName
+              ? `${channelName} カテゴリを削除します。`
+              : "このカテゴリを削除します。"
+            : channelName
+              ? `#${channelName} を削除します。`
+              : "このチャンネルを削除します。"}
         </p>
         <p className="mt-2 text-sm text-discord-text-muted">
-          この操作は取り消せません。削除するとチャンネル一覧から除外されます。
+          {isCategory
+            ? "この操作は取り消せません。削除すると配下のチャンネルも一覧から除外されます。"
+            : "この操作は取り消せません。削除するとチャンネル一覧から除外されます。"}
         </p>
         {submitError === null && guardMessage !== null && (
           <p
@@ -119,7 +156,11 @@ export function ChannelDeleteModal({
           }
           onClick={() => void handleDelete()}
         >
-          {deleteChannel.isPending ? "削除中..." : "チャンネルを削除"}
+          {deleteChannel.isPending
+            ? "削除中..."
+            : isCategory
+              ? "カテゴリーを削除"
+              : "チャンネルを削除"}
         </Button>
       </ModalFooter>
     </Modal>

--- a/typescript/src/features/modals/ui/channel-edit-modal.tsx
+++ b/typescript/src/features/modals/ui/channel-edit-modal.tsx
@@ -19,16 +19,24 @@ export function ChannelEditModal({
   onClose,
   channelId,
   channelName,
+  channelType,
 }: {
   onClose: () => void;
   channelId?: string;
   channelName?: string;
+  channelType?: number;
 }) {
   const [activeTab, setActiveTab] = useState("overview");
+  const title =
+    channelName === undefined
+      ? "チャンネルを編集"
+      : channelType === 4
+        ? `${channelName} の編集`
+        : `#${channelName} の編集`;
 
   return (
     <Modal open onClose={onClose} className="max-w-[660px]">
-      <ModalHeader>{channelName ? `#${channelName} の編集` : "チャンネルを編集"}</ModalHeader>
+      <ModalHeader>{title}</ModalHeader>
       <div className="px-4">
         <Tabs tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
       </div>

--- a/typescript/src/features/modals/ui/channel-edit-overview.tsx
+++ b/typescript/src/features/modals/ui/channel-edit-overview.tsx
@@ -82,6 +82,7 @@ export function ChannelEditOverview({
     manageChannelGuard.isAllowed &&
     !updateChannel.isPending;
   const guardMessage = channel?.guildId === undefined ? null : manageChannelGuard.message;
+  const isCategory = channel?.type === 4;
 
   return (
     <div className="space-y-6">
@@ -89,7 +90,7 @@ export function ChannelEditOverview({
         <p className="text-sm text-discord-text-muted">チャンネル情報を読み込み中...</p>
       )}
       <Input
-        label="チャンネル名"
+        label={isCategory ? "カテゴリー名" : "チャンネル名"}
         value={name}
         onChange={(event) => {
           setName(event.target.value);
@@ -119,9 +120,13 @@ export function ChannelEditOverview({
       <section className="rounded-md border border-discord-btn-danger/30 bg-discord-btn-danger/10 p-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h3 className="text-sm font-medium text-discord-text-normal">チャンネルを削除</h3>
+            <h3 className="text-sm font-medium text-discord-text-normal">
+              {isCategory ? "カテゴリーを削除" : "チャンネルを削除"}
+            </h3>
             <p className="mt-1 text-xs text-discord-text-muted">
-              削除すると一覧から消え、元に戻せません。
+              {isCategory
+                ? "削除すると配下のチャンネルも一覧から消え、元に戻せません。"
+                : "削除すると一覧から消え、元に戻せません。"}
             </p>
           </div>
           <Button
@@ -133,7 +138,7 @@ export function ChannelEditOverview({
             }
             onClick={() => setDeleteModalOpen(true)}
           >
-            チャンネルを削除
+            {isCategory ? "カテゴリーを削除" : "チャンネルを削除"}
           </Button>
         </div>
       </section>
@@ -141,6 +146,7 @@ export function ChannelEditOverview({
         <ChannelDeleteModal
           channelId={channelId}
           channelName={channel?.name ?? name}
+          channelType={channel?.type}
           onClose={() => setDeleteModalOpen(false)}
           onDeleted={onSaved}
           serverId={channel?.guildId}

--- a/typescript/src/features/modals/ui/create-channel-modal.test.tsx
+++ b/typescript/src/features/modals/ui/create-channel-modal.test.tsx
@@ -5,10 +5,11 @@ import { CreateChannelModal } from "./create-channel-modal";
 
 const mutateAsyncMock = vi.hoisted(() => vi.fn());
 const useActionGuardMock = vi.hoisted(() => vi.fn());
+const pushMock = vi.hoisted(() => vi.fn());
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
-    push: vi.fn(),
+    push: pushMock,
   }),
 }));
 
@@ -26,6 +27,7 @@ vi.mock("@/shared/api/queries", () => ({
 describe("CreateChannelModal", () => {
   beforeEach(() => {
     mutateAsyncMock.mockReset();
+    pushMock.mockReset();
     useActionGuardMock.mockImplementation(() => ({
       status: "allowed",
       isAllowed: true,
@@ -74,5 +76,41 @@ describe("CreateChannelModal", () => {
       true,
     );
     expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  test("creates category without route transition", async () => {
+    mutateAsyncMock.mockResolvedValueOnce({
+      id: "3100",
+      type: 4,
+    });
+
+    render(<CreateChannelModal onClose={() => undefined} serverId="2001" initialChannelType={4} />);
+
+    await userEvent.type(screen.getByPlaceholderText("新しいカテゴリ"), "times");
+    await userEvent.click(screen.getByRole("button", { name: "カテゴリーを作成" }));
+
+    expect(mutateAsyncMock).toHaveBeenCalledWith({
+      serverId: "2001",
+      data: { name: "times", type: 4, parentId: undefined },
+    });
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  test("creates child text channel under selected category", async () => {
+    mutateAsyncMock.mockResolvedValueOnce({
+      id: "3101",
+      type: 0,
+    });
+
+    render(<CreateChannelModal onClose={() => undefined} serverId="2001" parentId="3100" />);
+
+    await userEvent.type(screen.getByPlaceholderText("新しいチャンネル"), "times-abe");
+    await userEvent.click(screen.getByRole("button", { name: "チャンネルを作成" }));
+
+    expect(mutateAsyncMock).toHaveBeenCalledWith({
+      serverId: "2001",
+      data: { name: "times-abe", type: 0, parentId: "3100" },
+    });
+    expect(pushMock).toHaveBeenCalledWith("/channels/2001/3101");
   });
 });

--- a/typescript/src/features/modals/ui/create-channel-modal.tsx
+++ b/typescript/src/features/modals/ui/create-channel-modal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Hash, Volume2, MessageSquare, Lock } from "lucide-react";
+import { Hash, Volume2, MessageSquare, Lock, FolderClosed } from "lucide-react";
 import { Modal, ModalHeader, ModalBody, ModalFooter } from "@/shared/ui/modal";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
@@ -14,6 +14,7 @@ import { buildChannelRoute } from "@/shared/config/routes";
 import { cn } from "@/shared/lib/cn";
 
 const TEXT_CHANNEL_TYPE = 0 as const;
+const CATEGORY_CHANNEL_TYPE = 4 as const;
 
 const channelTypes = [
   {
@@ -21,6 +22,13 @@ const channelTypes = [
     label: "テキスト",
     icon: Hash,
     description: "メッセージや画像、GIFなどを送信できます",
+    supported: true,
+  },
+  {
+    type: CATEGORY_CHANNEL_TYPE,
+    label: "カテゴリ",
+    icon: FolderClosed,
+    description: "配下にテキストチャンネルを整理できます",
     supported: true,
   },
   {
@@ -42,12 +50,18 @@ const channelTypes = [
 export function CreateChannelModal({
   onClose,
   serverId,
+  parentId,
+  initialChannelType,
 }: {
   onClose: () => void;
   serverId?: string;
+  parentId?: string;
+  initialChannelType?: 0 | 4;
 }) {
   const router = useRouter();
-  const [channelType, setChannelType] = useState<0 | 2 | 15>(0);
+  const [channelType, setChannelType] = useState<0 | 4 | 2 | 15>(
+    initialChannelType ?? TEXT_CHANNEL_TYPE,
+  );
   const [channelName, setChannelName] = useState("");
   const [isPrivate, setIsPrivate] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -81,65 +95,81 @@ export function CreateChannelModal({
     try {
       const createdChannel = await createChannel.mutateAsync({
         serverId,
-        data: { name: normalizedName, type: TEXT_CHANNEL_TYPE },
+        data: {
+          name: normalizedName,
+          type: channelType,
+          parentId: channelType === CATEGORY_CHANNEL_TYPE ? undefined : parentId,
+        },
       });
       onClose();
-      router.push(buildChannelRoute(serverId, createdChannel.id));
+      if (createdChannel.type !== CATEGORY_CHANNEL_TYPE) {
+        router.push(buildChannelRoute(serverId, createdChannel.id));
+      }
     } catch (error: unknown) {
       setSubmitError(toCreateActionErrorText(error, "チャンネルの作成に失敗しました。"));
     }
   };
   const guardMessage = serverId === undefined ? null : actionGuard.message;
+  const isCategoryCreate = channelType === CATEGORY_CHANNEL_TYPE;
+  const typeSelectionLocked = initialChannelType !== undefined || parentId !== undefined;
+  const modalTitle = isCategoryCreate ? "カテゴリーを作成" : "チャンネルを作成";
+  const submitLabel = isCategoryCreate ? "カテゴリーを作成" : "チャンネルを作成";
+  const helperText =
+    parentId !== undefined
+      ? "選択したカテゴリ配下にテキストチャンネルを作成します。"
+      : isCategoryCreate
+        ? "カテゴリは配下にテキストチャンネルを整理するためのコンテナです。"
+        : "v1ではテキストチャンネルとカテゴリを作成できます。";
 
   return (
     <Modal open onClose={handleClose} className="max-w-[460px]">
-      <ModalHeader>チャンネルを作成</ModalHeader>
+      <ModalHeader>{modalTitle}</ModalHeader>
       <ModalBody>
         <div className="space-y-4">
           <div>
             <p className="mb-2 text-xs font-bold uppercase text-discord-header-secondary">
               チャンネルの種類
             </p>
-            <p className="mb-2 text-xs text-discord-text-muted">
-              v1ではテキストチャンネルのみ作成できます。
-            </p>
-            <div className="space-y-2">
-              {channelTypes.map((ct) => {
-                const Icon = ct.icon;
-                const isDisabled = !ct.supported;
-                return (
-                  <button
-                    key={ct.type}
-                    disabled={isDisabled}
-                    onClick={() => {
-                      if (isDisabled) {
-                        return;
-                      }
-                      setChannelType(ct.type);
-                    }}
-                    className={cn(
-                      "flex w-full items-center gap-3 rounded-[3px] px-3 py-2.5 text-left transition-colors",
-                      isDisabled && "cursor-not-allowed opacity-55",
-                      channelType === ct.type
-                        ? "bg-discord-bg-mod-selected"
-                        : "bg-discord-bg-secondary hover:bg-discord-bg-mod-hover",
-                    )}
-                  >
-                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-discord-bg-tertiary">
-                      <Icon className="h-5 w-5 text-discord-interactive-normal" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-discord-text-normal">{ct.label}</div>
-                      <div className="text-xs text-discord-text-muted">{ct.description}</div>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
+            <p className="mb-2 text-xs text-discord-text-muted">{helperText}</p>
+            {!typeSelectionLocked && (
+              <div className="space-y-2">
+                {channelTypes.map((ct) => {
+                  const Icon = ct.icon;
+                  const isDisabled = !ct.supported;
+                  return (
+                    <button
+                      key={ct.type}
+                      disabled={isDisabled}
+                      onClick={() => {
+                        if (isDisabled) {
+                          return;
+                        }
+                        setChannelType(ct.type);
+                      }}
+                      className={cn(
+                        "flex w-full items-center gap-3 rounded-[3px] px-3 py-2.5 text-left transition-colors",
+                        isDisabled && "cursor-not-allowed opacity-55",
+                        channelType === ct.type
+                          ? "bg-discord-bg-mod-selected"
+                          : "bg-discord-bg-secondary hover:bg-discord-bg-mod-hover",
+                      )}
+                    >
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-discord-bg-tertiary">
+                        <Icon className="h-5 w-5 text-discord-interactive-normal" />
+                      </div>
+                      <div>
+                        <div className="font-medium text-discord-text-normal">{ct.label}</div>
+                        <div className="text-xs text-discord-text-muted">{ct.description}</div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
           <Input
-            label="チャンネル名"
-            placeholder="新しいチャンネル"
+            label={isCategoryCreate ? "カテゴリー名" : "チャンネル名"}
+            placeholder={isCategoryCreate ? "新しいカテゴリ" : "新しいチャンネル"}
             value={channelName}
             onChange={(e) => {
               setChannelName(e.target.value);
@@ -191,7 +221,7 @@ export function CreateChannelModal({
           }
           onClick={() => void handleCreate()}
         >
-          チャンネルを作成
+          {submitLabel}
         </Button>
       </ModalFooter>
     </Modal>

--- a/typescript/src/features/modals/ui/modal-manager.tsx
+++ b/typescript/src/features/modals/ui/modal-manager.tsx
@@ -59,6 +59,8 @@ export function ModalManager() {
         <CreateChannelModal
           onClose={closeModal}
           serverId={modalProps.serverId as string | undefined}
+          parentId={modalProps.parentId as string | undefined}
+          initialChannelType={modalProps.initialChannelType as 0 | 4 | undefined}
         />
       );
     case "create-invite":
@@ -84,6 +86,7 @@ export function ModalManager() {
           onClose={closeModal}
           channelId={modalProps.channelId as string | undefined}
           channelName={modalProps.channelName as string | undefined}
+          channelType={modalProps.channelType as number | undefined}
           serverId={modalProps.serverId as string | undefined}
         />
       );
@@ -151,6 +154,7 @@ export function ModalManager() {
           onClose={closeModal}
           channelId={modalProps.channelId as string | undefined}
           channelName={modalProps.channelName as string | undefined}
+          channelType={modalProps.channelType as number | undefined}
         />
       );
     case "onboarding":

--- a/typescript/src/shared/api/guild-channel-api-client.test.ts
+++ b/typescript/src/shared/api/guild-channel-api-client.test.ts
@@ -83,8 +83,20 @@ describe("GuildChannelAPIClient", () => {
             {
               channel_id: 3001,
               guild_id: 2001,
+              type: "guild_text",
               name: "general",
+              parent_id: null,
+              position: 7,
               created_at: "2026-03-03T00:00:00Z",
+            },
+            {
+              channel_id: 3002,
+              guild_id: 2001,
+              type: "guild_category",
+              name: "times",
+              parent_id: null,
+              position: 3,
+              created_at: "2026-03-03T00:00:10Z",
             },
           ],
         }),
@@ -102,7 +114,19 @@ describe("GuildChannelAPIClient", () => {
         guildId: "2001",
         name: "general",
         topic: null,
-        position: 0,
+        position: 7,
+        parentId: null,
+        nsfw: false,
+        rateLimitPerUser: 0,
+        lastMessageId: null,
+      },
+      {
+        id: "3002",
+        type: 4,
+        guildId: "2001",
+        name: "times",
+        topic: null,
+        position: 3,
         parentId: null,
         nsfw: false,
         rateLimitPerUser: 0,
@@ -403,7 +427,10 @@ describe("GuildChannelAPIClient", () => {
           channel: {
             channel_id: 3010,
             guild_id: 2001,
+            type: "guild_text",
             name: "release",
+            parent_id: null,
+            position: 2,
             created_at: "2026-03-03T00:00:00Z",
           },
         }),
@@ -418,6 +445,7 @@ describe("GuildChannelAPIClient", () => {
     expect(created.id).toBe("3010");
     expect(created.guildId).toBe("2001");
     expect(created.name).toBe("release");
+    expect(created.position).toBe(2);
     expect(resolved.id).toBe("3010");
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -427,6 +455,78 @@ describe("GuildChannelAPIClient", () => {
     expect(new Headers(init.headers).get("Authorization")).toBe("Bearer token-1");
     expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
     expect(init.body).toBe(JSON.stringify({ name: "release" }));
+  });
+
+  test("createChannel sends category payload and maps category response", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          channel: {
+            channel_id: 3011,
+            guild_id: 2001,
+            type: "guild_category",
+            name: "times",
+            parent_id: null,
+            position: 5,
+            created_at: "2026-03-03T00:00:00Z",
+          },
+        }),
+        { status: 201 },
+      ),
+    );
+
+    const client = new GuildChannelAPIClient();
+    const created = await client.createChannel("2001", { name: "times", type: 4 });
+
+    expect(created).toMatchObject({
+      id: "3011",
+      type: 4,
+      guildId: "2001",
+      name: "times",
+      parentId: null,
+      position: 5,
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.body).toBe(JSON.stringify({ name: "times", type: "guild_category" }));
+  });
+
+  test("createChannel sends parent_id for child text channels", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          channel: {
+            channel_id: 3012,
+            guild_id: 2001,
+            type: "guild_text",
+            name: "times-abe",
+            parent_id: 3011,
+            position: 6,
+            created_at: "2026-03-03T00:00:00Z",
+          },
+        }),
+        { status: 201 },
+      ),
+    );
+
+    const client = new GuildChannelAPIClient();
+    const created = await client.createChannel("2001", {
+      name: "times-abe",
+      type: 0,
+      parentId: "3011",
+    });
+
+    expect(created).toMatchObject({
+      id: "3012",
+      type: 0,
+      parentId: "3011",
+      position: 6,
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.body).toBe(
+      JSON.stringify({ name: "times-abe", type: "guild_text", parent_id: 3011 }),
+    );
   });
 
   test("createChannel rejects unsupported channel types in v1", async () => {
@@ -505,15 +605,30 @@ describe("GuildChannelAPIClient", () => {
           JSON.stringify({
             channels: [
               {
+                channel_id: 3000,
+                guild_id: 2001,
+                type: "guild_category",
+                name: "times",
+                parent_id: null,
+                position: 0,
+                created_at: "2026-03-03T00:00:00Z",
+              },
+              {
                 channel_id: 3001,
                 guild_id: 2001,
-                name: "general",
+                type: "guild_text",
+                name: "times-abe",
+                parent_id: 3000,
+                position: 1,
                 created_at: "2026-03-03T00:00:00Z",
               },
               {
                 channel_id: 3002,
                 guild_id: 2001,
+                type: "guild_text",
                 name: "random",
+                parent_id: null,
+                position: 2,
                 created_at: "2026-03-03T00:00:30Z",
               },
             ],
@@ -525,13 +640,13 @@ describe("GuildChannelAPIClient", () => {
 
     const client = new GuildChannelAPIClient();
     await client.getChannels("2001");
-    await client.deleteChannel("3001");
+    await client.deleteChannel("3000");
     const channels = await client.getChannels("2001");
 
     expect(channels.map((channel) => channel.id)).toEqual(["3002"]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
-    expect(url).toBe("http://localhost:8080/channels/3001");
+    expect(url).toBe("http://localhost:8080/channels/3000");
     expect(init.method).toBe("DELETE");
     expect(new Headers(init.headers).get("Authorization")).toBe("Bearer token-1");
   });

--- a/typescript/src/shared/api/guild-channel-api-client.ts
+++ b/typescript/src/shared/api/guild-channel-api-client.ts
@@ -41,6 +41,9 @@ const CHANNEL_SUMMARY_SCHEMA = z.object({
   channel_id: z.number().int().positive(),
   guild_id: z.number().int().positive(),
   name: z.string().trim().min(1),
+  type: z.enum(["guild_text", "guild_category"]).optional(),
+  parent_id: z.number().int().positive().nullable().optional(),
+  position: z.number().int().nonnegative().optional(),
   created_at: z.string().trim().min(1),
 });
 const CHANNEL_LIST_RESPONSE_SCHEMA = z.object({
@@ -136,7 +139,8 @@ const DEFAULT_CHANNEL_VALUES = {
   rateLimitPerUser: 0,
   lastMessageId: null,
 } as const;
-const SUPPORTED_CHANNEL_TYPES = [0] as const;
+const SUPPORTED_CHANNEL_TYPES = [0, 4] as const;
+const CATEGORY_CHANNEL_TYPE = 4 as const;
 const CREATE_ERROR_MESSAGES = {
   validation: "入力内容を確認してください。",
   authzDenied: "この操作を行う権限がありません。",
@@ -436,11 +440,13 @@ function mapCreatedGuild(summary: GuildCreateResponse["guild"]): Guild {
 
 function mapChannel(summary: ChannelListResponse["channels"][number], position: number): Channel {
   return {
+    ...DEFAULT_CHANNEL_VALUES,
     id: String(summary.channel_id),
+    type: summary.type === "guild_category" ? CATEGORY_CHANNEL_TYPE : 0,
     guildId: String(summary.guild_id),
     name: summary.name,
-    position,
-    ...DEFAULT_CHANNEL_VALUES,
+    position: summary.position ?? position,
+    parentId: summary.parent_id == null ? null : String(summary.parent_id),
   };
 }
 
@@ -692,13 +698,64 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
     if (current !== undefined) {
       return {
         ...current,
-        id: String(summary.channel_id),
-        guildId: String(summary.guild_id),
-        name: summary.name,
+        ...mapChannel(summary, fallbackPosition),
       };
     }
 
     return mapChannel(summary, fallbackPosition);
+  }
+
+  private collectDeletedChannelIds(channelId: string, guildId: string | undefined): Set<string> {
+    const deletedIds = new Set<string>([channelId]);
+    if (guildId === undefined) {
+      return deletedIds;
+    }
+
+    const cachedChannels = this.channelCacheByGuild.get(guildId);
+    if (cachedChannels === undefined) {
+      return deletedIds;
+    }
+
+    let foundChild = true;
+    while (foundChild) {
+      foundChild = false;
+      for (const channel of cachedChannels) {
+        if (
+          channel.parentId !== null &&
+          deletedIds.has(channel.parentId) &&
+          !deletedIds.has(channel.id)
+        ) {
+          deletedIds.add(channel.id);
+          foundChild = true;
+        }
+      }
+    }
+
+    return deletedIds;
+  }
+
+  private removeChannelsFromGuildCache(channelIds: Set<string>, guildId: string | undefined): void {
+    for (const channelId of channelIds) {
+      this.channelIndex.delete(channelId);
+    }
+
+    if (guildId !== undefined) {
+      const cachedChannels = this.channelCacheByGuild.get(guildId);
+      if (cachedChannels !== undefined) {
+        this.channelCacheByGuild.set(
+          guildId,
+          cachedChannels.filter((channel) => !channelIds.has(channel.id)),
+        );
+      }
+      return;
+    }
+
+    for (const [cachedGuildId, cachedChannels] of this.channelCacheByGuild.entries()) {
+      const nextChannels = cachedChannels.filter((channel) => !channelIds.has(channel.id));
+      if (nextChannels.length !== cachedChannels.length) {
+        this.channelCacheByGuild.set(cachedGuildId, nextChannels);
+      }
+    }
   }
 
   private upsertChannelInGuildCache(channel: Channel): void {
@@ -1070,9 +1127,36 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
       });
     }
 
+    const normalizedParentId = data.parentId?.trim() ?? "";
+    if (data.type === CATEGORY_CHANNEL_TYPE && normalizedParentId.length > 0) {
+      throw new GuildChannelApiError(CREATE_ERROR_MESSAGES.validation, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    let parsedParentId: number | null = null;
+    if (normalizedParentId.length > 0) {
+      parsedParentId = Number.parseInt(normalizedParentId, 10);
+      if (!Number.isInteger(parsedParentId) || parsedParentId <= 0) {
+        throw new GuildChannelApiError(CREATE_ERROR_MESSAGES.validation, {
+          status: 400,
+          code: "VALIDATION_ERROR",
+        });
+      }
+    }
+
+    const body: Record<string, unknown> = { name: normalizedName };
+    if (data.type === CATEGORY_CHANNEL_TYPE) {
+      body.type = "guild_category";
+    } else if (parsedParentId !== null) {
+      body.type = "guild_text";
+      body.parent_id = parsedParentId;
+    }
+
     const response = await this.postJson(
       `/guilds/${encodeURIComponent(normalizedServerId)}/channels`,
-      { name: normalizedName },
+      body,
       CHANNEL_CREATE_RESPONSE_SCHEMA,
     );
     const cachedChannels = this.channelCacheByGuild.get(normalizedServerId);
@@ -1283,8 +1367,9 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
     }
 
     const indexedChannel = this.channelIndex.get(normalizedChannelId);
+    const deletedIds = this.collectDeletedChannelIds(normalizedChannelId, indexedChannel?.guildId);
     await this.deleteNoContent(`/channels/${encodeURIComponent(normalizedChannelId)}`);
-    this.removeChannelFromGuildCache(normalizedChannelId, indexedChannel?.guildId);
+    this.removeChannelsFromGuildCache(deletedIds, indexedChannel?.guildId);
   }
 }
 

--- a/typescript/src/shared/api/mutations/use-channel-actions.test.ts
+++ b/typescript/src/shared/api/mutations/use-channel-actions.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { createElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@/test/test-utils";
+import { useDeleteChannel } from "./use-channel-actions";
+
+const mockDeleteChannel = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/shared/api/api-client", () => ({
+  getAPIClient: () => ({
+    createChannel: vi.fn(),
+    deleteChannel: mockDeleteChannel,
+  }),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useDeleteChannel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("removes deleted category descendants from list and detail caches", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = createWrapper(queryClient);
+    queryClient.setQueryData(
+      ["channels", "2001"],
+      [
+        {
+          id: "3100",
+          guildId: "2001",
+          type: 4,
+          name: "times",
+          topic: null,
+          position: 0,
+          parentId: null,
+          nsfw: false,
+          rateLimitPerUser: 0,
+          lastMessageId: null,
+        },
+        {
+          id: "3200",
+          guildId: "2001",
+          type: 0,
+          name: "times-abe",
+          topic: null,
+          position: 1,
+          parentId: "3100",
+          nsfw: false,
+          rateLimitPerUser: 0,
+          lastMessageId: null,
+        },
+        {
+          id: "3001",
+          guildId: "2001",
+          type: 0,
+          name: "general",
+          topic: null,
+          position: 2,
+          parentId: null,
+          nsfw: false,
+          rateLimitPerUser: 0,
+          lastMessageId: null,
+        },
+      ],
+    );
+    queryClient.setQueryData(["channel", "3100"], { id: "3100" });
+    queryClient.setQueryData(["channel", "3200"], { id: "3200" });
+    queryClient.setQueryData(["channel", "3001"], { id: "3001" });
+
+    const { result } = renderHook(() => useDeleteChannel(), { wrapper });
+
+    result.current.mutate({ serverId: "2001", channelId: "3100" });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockDeleteChannel).toHaveBeenCalledWith("3100");
+    expect(queryClient.getQueryData(["channels", "2001"])).toEqual([
+      {
+        id: "3001",
+        guildId: "2001",
+        type: 0,
+        name: "general",
+        topic: null,
+        position: 2,
+        parentId: null,
+        nsfw: false,
+        rateLimitPerUser: 0,
+        lastMessageId: null,
+      },
+    ]);
+    expect(queryClient.getQueryData(["channel", "3100"])).toBeUndefined();
+    expect(queryClient.getQueryData(["channel", "3200"])).toBeUndefined();
+    expect(queryClient.getQueryData(["channel", "3001"])).toEqual({ id: "3001" });
+  });
+});

--- a/typescript/src/shared/api/mutations/use-channel-actions.ts
+++ b/typescript/src/shared/api/mutations/use-channel-actions.ts
@@ -5,6 +5,27 @@ import { getAPIClient } from "@/shared/api/api-client";
 import type { CreateChannelData } from "@/shared/api/api-client";
 import type { Channel } from "@/shared/model/types";
 
+function collectDeletedChannelIds(channels: Channel[], channelId: string): Set<string> {
+  const deletedIds = new Set<string>([channelId]);
+
+  let foundChild = true;
+  while (foundChild) {
+    foundChild = false;
+    for (const channel of channels) {
+      if (
+        channel.parentId !== null &&
+        deletedIds.has(channel.parentId) &&
+        !deletedIds.has(channel.id)
+      ) {
+        deletedIds.add(channel.id);
+        foundChild = true;
+      }
+    }
+  }
+
+  return deletedIds;
+}
+
 export function useCreateChannel() {
   const queryClient = useQueryClient();
   const api = getAPIClient();
@@ -38,14 +59,18 @@ export function useDeleteChannel() {
     mutationFn: ({ channelId }: { serverId: string; channelId: string }) =>
       api.deleteChannel(channelId),
     onSuccess: (_, { serverId, channelId }) => {
+      let deletedIds = new Set<string>([channelId]);
       queryClient.setQueryData<Channel[] | undefined>(["channels", serverId], (currentChannels) => {
         if (currentChannels === undefined) {
           return currentChannels;
         }
 
-        return currentChannels.filter((channel) => channel.id !== channelId);
+        deletedIds = collectDeletedChannelIds(currentChannels, channelId);
+        return currentChannels.filter((channel) => !deletedIds.has(channel.id));
       });
-      queryClient.removeQueries({ queryKey: ["channel", channelId], exact: true });
+      for (const deletedId of deletedIds) {
+        queryClient.removeQueries({ queryKey: ["channel", deletedId], exact: true });
+      }
       queryClient.invalidateQueries({ queryKey: ["channels", serverId] });
     },
   });

--- a/typescript/src/widgets/channel-sidebar/ui/channel-category.tsx
+++ b/typescript/src/widgets/channel-sidebar/ui/channel-category.tsx
@@ -1,36 +1,64 @@
 "use client";
 
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 import { cn } from "@/shared/lib/cn";
+import { useUIStore } from "@/shared/model/stores/ui-store";
+import type { Channel } from "@/shared/model/types/channel";
 
 export function ChannelCategory({
+  channel,
+  serverId,
   name,
   collapsed,
   onToggle,
+  onCreateChannel,
   children,
 }: {
+  channel: Channel;
+  serverId: string;
   name: string;
   collapsed: boolean;
   onToggle: () => void;
+  onCreateChannel: () => void;
   children: React.ReactNode;
 }) {
+  const showContextMenu = useUIStore((s) => s.showContextMenu);
+
   return (
     <div className="mt-4">
-      <button
-        onClick={onToggle}
-        className={cn(
-          "group flex w-full items-center gap-0.5 px-0.5 pb-1",
-          "text-category text-discord-channels-default",
-          "hover:text-discord-interactive-hover",
-        )}
-      >
-        {collapsed ? (
-          <ChevronRight className="h-3 w-3 shrink-0" />
-        ) : (
-          <ChevronDown className="h-3 w-3 shrink-0" />
-        )}
-        <span className="truncate">{name}</span>
-      </button>
+      <div className="group flex items-center gap-1 px-0.5 pb-1">
+        <button
+          onClick={onToggle}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            showContextMenu(
+              "channel",
+              { x: event.clientX, y: event.clientY },
+              { channel, serverId },
+            );
+          }}
+          className={cn(
+            "flex min-w-0 flex-1 items-center gap-0.5",
+            "text-category text-discord-channels-default",
+            "hover:text-discord-interactive-hover",
+          )}
+        >
+          {collapsed ? (
+            <ChevronRight className="h-3 w-3 shrink-0" />
+          ) : (
+            <ChevronDown className="h-3 w-3 shrink-0" />
+          )}
+          <span className="truncate">{name}</span>
+        </button>
+        <button
+          type="button"
+          aria-label="配下にチャンネルを作成"
+          className="rounded p-0.5 text-discord-channels-default opacity-0 transition-opacity hover:text-discord-interactive-hover group-hover:opacity-100"
+          onClick={onCreateChannel}
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </button>
+      </div>
       {!collapsed && <div>{children}</div>}
     </div>
   );

--- a/typescript/src/widgets/channel-sidebar/ui/channel-item.tsx
+++ b/typescript/src/widgets/channel-sidebar/ui/channel-item.tsx
@@ -52,9 +52,10 @@ export function ChannelItem({
       openModal("channel-edit", {
         channelId: channel.id,
         channelName: channel.name,
+        channelType: channel.type,
       });
     },
-    [channel.id, channel.name, openModal],
+    [channel.id, channel.name, channel.type, openModal],
   );
   const primeManageGuard = () => {
     if (!didPrimeManageGuard) {

--- a/typescript/src/widgets/channel-sidebar/ui/channel-sidebar.test.ts
+++ b/typescript/src/widgets/channel-sidebar/ui/channel-sidebar.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, expect, test } from "vitest";
+import { groupChannelsByCategory } from "./channel-sidebar";
+
+function createChannel({
+  id,
+  type,
+  position,
+  parentId = null,
+}: {
+  id: string;
+  type: 0 | 4;
+  position: number;
+  parentId?: string | null;
+}) {
+  return {
+    id,
+    guildId: "2001",
+    type,
+    name: id,
+    topic: null,
+    position,
+    parentId,
+    nsfw: false,
+    rateLimitPerUser: 0,
+    lastMessageId: null,
+  };
+}
+
+describe("groupChannelsByCategory", () => {
+  test("keeps a leading category before later top-level text channels", () => {
+    const groups = groupChannelsByCategory([
+      createChannel({ id: "3100", type: 4, position: 0 }),
+      createChannel({ id: "3200", type: 0, position: 1, parentId: "3100" }),
+      createChannel({ id: "3001", type: 0, position: 10 }),
+    ]);
+
+    expect(groups.map((group) => group.category?.id ?? group.channels[0]?.id)).toEqual([
+      "3100",
+      "3001",
+    ]);
+    expect(groups[0]?.channels.map((channel) => channel.id)).toEqual(["3200"]);
+  });
+
+  test("keeps a leading top-level text channel before later categories", () => {
+    const groups = groupChannelsByCategory([
+      createChannel({ id: "3001", type: 0, position: 0 }),
+      createChannel({ id: "3100", type: 4, position: 10 }),
+      createChannel({ id: "3200", type: 0, position: 11, parentId: "3100" }),
+    ]);
+
+    expect(groups.map((group) => group.category?.id ?? group.channels[0]?.id)).toEqual([
+      "3001",
+      "3100",
+    ]);
+    expect(groups[1]?.channels.map((channel) => channel.id)).toEqual(["3200"]);
+  });
+});

--- a/typescript/src/widgets/channel-sidebar/ui/channel-sidebar.tsx
+++ b/typescript/src/widgets/channel-sidebar/ui/channel-sidebar.tsx
@@ -6,6 +6,7 @@ import { useChannels } from "@/shared/api/queries/use-channels";
 import { toApiErrorText } from "@/shared/api/guild-channel-api-client";
 import { buildModerationQueueRoute, parseGuildChannelRoute } from "@/shared/config/routes";
 import { useGuildStore } from "@/shared/model/stores/guild-store";
+import { useUIStore } from "@/shared/model/stores/ui-store";
 import { useServer } from "@/shared/api/queries/use-servers";
 import { usePathname } from "next/navigation";
 import { ServerHeader } from "./server-header";
@@ -21,28 +22,24 @@ type CategoryGroup = {
   channels: Channel[];
 };
 
-function groupChannelsByCategory(channels: Channel[]): CategoryGroup[] {
-  const categories = channels.filter((c) => c.type === 4).sort((a, b) => a.position - b.position);
+function compareChannelPosition(a: Channel, b: Channel): number {
+  return a.position - b.position || a.id.localeCompare(b.id);
+}
 
-  const groups: CategoryGroup[] = [];
+export function groupChannelsByCategory(channels: Channel[]): CategoryGroup[] {
+  return channels
+    .filter((channel) => channel.type === 4 || !channel.parentId)
+    .sort(compareChannelPosition)
+    .map((channel) => {
+      if (channel.type !== 4) {
+        return { category: null, channels: [channel] };
+      }
 
-  // Channels without a parent category (top-level)
-  const orphans = channels
-    .filter((c) => c.type !== 4 && !c.parentId)
-    .sort((a, b) => a.position - b.position);
-
-  if (orphans.length > 0) {
-    groups.push({ category: null, channels: orphans });
-  }
-
-  for (const cat of categories) {
-    const children = channels
-      .filter((c) => c.parentId === cat.id && c.type !== 4)
-      .sort((a, b) => a.position - b.position);
-    groups.push({ category: cat, channels: children });
-  }
-
-  return groups;
+      const children = channels
+        .filter((child) => child.parentId === channel.id && child.type !== 4)
+        .sort(compareChannelPosition);
+      return { category: channel, channels: children };
+    });
 }
 
 export function ChannelSidebar() {
@@ -54,6 +51,7 @@ export function ChannelSidebar() {
   const activeChannelId = routeSelection ? routeSelection.channelId : activeChannelIdFromStore;
   const collapsedCategories = useGuildStore((s) => s.collapsedCategories);
   const toggleCategory = useGuildStore((s) => s.toggleCategory);
+  const openModal = useUIStore((s) => s.openModal);
 
   const { data: server } = useServer(activeServerId ?? "");
   const {
@@ -127,9 +125,17 @@ export function ChannelSidebar() {
             return (
               <ChannelCategory
                 key={key}
+                channel={group.category}
+                serverId={activeServerId}
                 name={group.category.name}
                 collapsed={isCollapsed}
                 onToggle={() => toggleCategory(activeServerId, group.category!.id)}
+                onCreateChannel={() =>
+                  openModal("create-channel", {
+                    serverId: activeServerId,
+                    parentId: group.category!.id,
+                  })
+                }
               >
                 {group.channels.map((ch) =>
                   ch.type === 2 ? (

--- a/typescript/src/widgets/chat/ui/channel-view.test.tsx
+++ b/typescript/src/widgets/chat/ui/channel-view.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { render, waitFor } from "@/test/test-utils";
+import { ChannelView } from "./channel-view";
+
+const replaceMock = vi.hoisted(() => vi.fn());
+const useChannelMock = vi.hoisted(() => vi.fn());
+const useChannelsMock = vi.hoisted(() => vi.fn());
+const useSyncChannelIdMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+}));
+
+vi.mock("@/shared/api/queries/use-channels", () => ({
+  useChannel: useChannelMock,
+  useChannels: useChannelsMock,
+}));
+
+vi.mock("@/shared/model/hooks/use-sync-guild-params", () => ({
+  useSyncChannelId: useSyncChannelIdMock,
+}));
+
+vi.mock("@/features/voice", () => ({
+  VoiceArea: () => <div>voice-area</div>,
+  StageChannelView: () => <div>stage-channel-view</div>,
+}));
+
+vi.mock("@/features/forum", () => ({
+  ForumView: () => <div>forum-view</div>,
+}));
+
+vi.mock("./chat-area", () => ({
+  ChatArea: ({ channelId, channelName }: { channelId: string; channelName: string }) => (
+    <div data-testid="chat-area">{`${channelName}:${channelId}`}</div>
+  ),
+}));
+
+describe("ChannelView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useChannelMock.mockReturnValue({
+      data: {
+        id: "3100",
+        guildId: "2001",
+        type: 4,
+        name: "times",
+        topic: null,
+        position: 0,
+        parentId: null,
+        nsfw: false,
+        rateLimitPerUser: 0,
+        lastMessageId: null,
+      },
+    });
+    useChannelsMock.mockReturnValue({
+      data: [
+        {
+          id: "3100",
+          guildId: "2001",
+          type: 4,
+          name: "times",
+          topic: null,
+          position: 0,
+          parentId: null,
+          nsfw: false,
+          rateLimitPerUser: 0,
+          lastMessageId: null,
+        },
+        {
+          id: "3200",
+          guildId: "2001",
+          type: 0,
+          name: "times-abe",
+          topic: null,
+          position: 1,
+          parentId: "3100",
+          nsfw: false,
+          rateLimitPerUser: 0,
+          lastMessageId: null,
+        },
+      ],
+      isSuccess: true,
+    });
+  });
+
+  test("redirects category route to the first text channel in the guild", async () => {
+    render(<ChannelView channelId="3100" serverId="2001" />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/channels/2001/3200");
+    });
+  });
+
+  test("redirects category route to guild root when no text channel is available", async () => {
+    useChannelsMock.mockReturnValue({
+      data: [
+        {
+          id: "3100",
+          guildId: "2001",
+          type: 4,
+          name: "times",
+          topic: null,
+          position: 0,
+          parentId: null,
+          nsfw: false,
+          rateLimitPerUser: 0,
+          lastMessageId: null,
+        },
+      ],
+      isSuccess: true,
+    });
+
+    render(<ChannelView channelId="3100" serverId="2001" />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/channels/2001");
+    });
+  });
+
+  test("waits for guild channel list before redirecting category route", async () => {
+    const loadedChannels = [
+      {
+        id: "3100",
+        guildId: "2001",
+        type: 4 as const,
+        name: "times",
+        topic: null,
+        position: 0,
+        parentId: null,
+        nsfw: false,
+        rateLimitPerUser: 0,
+        lastMessageId: null,
+      },
+      {
+        id: "3200",
+        guildId: "2001",
+        type: 0 as const,
+        name: "times-abe",
+        topic: null,
+        position: 1,
+        parentId: "3100",
+        nsfw: false,
+        rateLimitPerUser: 0,
+        lastMessageId: null,
+      },
+    ];
+    let isLoaded = false;
+    useChannelsMock.mockImplementation(() => ({
+      data: isLoaded ? loadedChannels : undefined,
+      isSuccess: isLoaded,
+    }));
+
+    const view = render(<ChannelView channelId="3100" serverId="2001" />);
+
+    expect(replaceMock).not.toHaveBeenCalled();
+
+    isLoaded = true;
+    view.rerender(<ChannelView channelId="3100" serverId="2001" />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/channels/2001/3200");
+    });
+  });
+});

--- a/typescript/src/widgets/chat/ui/channel-view.tsx
+++ b/typescript/src/widgets/chat/ui/channel-view.tsx
@@ -1,18 +1,39 @@
 "use client";
 
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { findFirstTextChannel } from "@/features/channel-navigation";
+import { useChannels, useChannel } from "@/shared/api/queries/use-channels";
+import { buildChannelRoute, buildGuildRoute } from "@/shared/config/routes";
 import { useSyncChannelId } from "@/shared/model/hooks/use-sync-guild-params";
-import { useChannel } from "@/shared/api/queries/use-channels";
 import { useVoiceStore } from "@/shared/model/stores/voice-store";
+import { ShellStatePlaceholder } from "@/widgets/app-shell";
 import { ChatArea } from "./chat-area";
 import { VoiceArea } from "@/features/voice";
 import { ForumView } from "@/features/forum";
 import { StageChannelView } from "@/features/voice";
 
-export function ChannelView({ channelId }: { channelId: string }) {
+export function ChannelView({ channelId, serverId }: { channelId: string; serverId?: string }) {
   useSyncChannelId(channelId);
+  const router = useRouter();
   const { data: channel } = useChannel(channelId);
+  const { data: guildChannels, isSuccess: isGuildChannelsSuccess } = useChannels(serverId ?? "");
   const voiceConnected = useVoiceStore((s) => s.connected);
   const voiceChannelId = useVoiceStore((s) => s.channelId);
+  const isCategoryRoute = serverId !== undefined && channel?.type === 4;
+
+  useEffect(() => {
+    if (!isCategoryRoute || serverId === undefined || !isGuildChannelsSuccess) {
+      return;
+    }
+
+    const nextChannel = findFirstTextChannel(guildChannels ?? []);
+    const nextRoute =
+      nextChannel === null
+        ? buildGuildRoute(serverId)
+        : buildChannelRoute(serverId, nextChannel.id);
+    router.replace(nextRoute);
+  }, [guildChannels, isCategoryRoute, isGuildChannelsSuccess, router, serverId]);
 
   // Forum channel (type 15)
   if (channel?.type === 15) {
@@ -27,6 +48,18 @@ export function ChannelView({ channelId }: { channelId: string }) {
   // Voice channel (type 2) - show voice area when connected to this channel
   if (channel?.type === 2 && voiceConnected && voiceChannelId === channelId) {
     return <VoiceArea channelId={channelId} channelName={channel.name} />;
+  }
+
+  if (isCategoryRoute) {
+    return (
+      <div className="p-6">
+        <ShellStatePlaceholder
+          state="loading"
+          title="表示可能なチャンネルへ移動しています"
+          description="カテゴリはメッセージを表示できないため、最初のテキストチャンネルへ移動します。"
+        />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## 概要
- チャンネルカテゴリ対応の frontend 実装を追加
- category 作成・配下チャンネル作成・編集/削除導線を category-aware に更新
- category route fallback と category delete 後の cache/fallback を安定化

## 変更内容
- `GuildChannelAPIClient` を hierarchy-aware DTO に対応し、`type` / `parentId` / `position` を正規化
- sidebar を category と top-level channel の混在順序を `position` 準拠で描画するよう更新
- server/channel context menu と create/delete/edit modal を category-aware に更新
- category を直接開いた場合は最初の text channel、なければ guild root に redirect
- category delete 時に配下 child channel の list/detail cache をまとめて除去
- LIN-943 の run memory を `docs/agent_runs/LIN-943/` に追加

## テスト
- `cd typescript && npm run typecheck`
- `cd typescript && npm test -- src/widgets/chat/ui/channel-view.test.tsx src/widgets/channel-sidebar/ui/channel-sidebar.test.ts src/shared/api/mutations/use-channel-actions.test.ts`
- `make validate`

## ADR-001 チェック
- event contract 変更: なし
- 互換性判断: frontend 実装とテスト追加のみのため、既存 contract への破壊的変更なし
