### PR TITLE
LIN-829 run memory を docs/agent_runs に追加

### DIFF
--- a/docs/agent_runs/LIN-829/Documentation.md
+++ b/docs/agent_runs/LIN-829/Documentation.md
@@ -1,0 +1,23 @@
+# LIN-829 Documentation
+
+## Current status
+- Now: `LIN-829` の frontend message timeline/composer 実接続と review fix まで反映済み。
+- Next: 依存導入済み環境で typecheck / Vitest を再実行して最終確認する。
+
+## Decisions
+- 対象 issue は `LIN-829`。
+- guild text channel のみ対象。DM 実装は今回含めない。
+- backend 契約拡張は行わない。
+- message REST/WS の `i64` ID は frontend 境界で string として保持する。
+- reconnect 後の取りこぼし補償は active channel history の再取得で行う。
+- own-message 判定は `principal_id` ベースで行う。
+
+## Validation plan
+- `make validate`
+- `cd typescript && npm run typecheck`
+- 必要に応じて関連 Vitest を個別実行
+
+## Notes
+- `typescript/node_modules` が存在しないためローカル typecheck / Vitest は未実行。
+- local 開発では `make dev` が `scylla-bootstrap` を先行実行するように変更した。
+- `scylla-bootstrap` は `.env` を読み込んだうえで `scylla-wait` を通すため、Scylla 起動直後の race で Rust API が不健康な session を掴む確率を下げている。

--- a/docs/agent_runs/LIN-829/Implement.md
+++ b/docs/agent_runs/LIN-829/Implement.md
@@ -1,0 +1,44 @@
+# LIN-829 Implement
+
+## 2026-03-10 frontend message timeline/composer real-data run
+
+### 必須参照
+- `docs/TYPESCRIPT.md`
+- `docs/runbooks/realtime-nats-core-subject-subscription-runbook.md`
+- `docs/runbooks/message-v1-api-ws-contract-runbook.md`
+- `.agents/skills/linear-implementation-leaf/references/core-policy.md`
+- `.agents/skills/linear-implementation-leaf/references/delivery-flow.md`
+- `.agents/skills/linear-implementation-leaf/references/review-gates.md`
+
+### Start mode
+- `standalone smallest-unit`
+- current branch: `codex/lin-829`
+
+### Scope decisions
+- guild text channel のみを対象にする
+- DM route は non-goal として read/write を有効化しない
+- author 表示は frontend 最小補完
+- paging UI は timeline 上部ボタン方式
+
+### Progress log
+- [x] memory files 更新
+- [x] message API / query / cache helper
+- [x] chat UI / composer / paging
+- [x] WS subscribe / realtime cache apply
+- [x] review 指摘の blocking 修正
+- [ ] tests / validation
+
+### Review-driven fixes
+- message REST/WS の `i64` ID は exact decimal として保持するように parser を追加
+- reconnect 後は active channel の timeline query を invalidate して履歴補償する
+- auth-store に `currentPrincipalId` を保持し、own-message 判定を Firebase UID 依存から分離した
+
+## 2026-03-10 local dev startup fix
+
+### Goal
+- `make dev` で Scylla 起動直後でも message runtime が安定して立ち上がるようにする
+
+### Changes
+- `Makefile` に `scylla-wait` を追加し、CQL 応答待ちを共通化
+- `scylla-bootstrap` で `.env` を読み込み、`SCYLLA_KEYSPACE` を local runtime と一致させる
+- `dev` 起動時に `scylla-bootstrap` を必ず実行してから Rust API を起動する

--- a/docs/agent_runs/LIN-829/Plan.md
+++ b/docs/agent_runs/LIN-829/Plan.md
@@ -1,0 +1,28 @@
+# LIN-829 Plan
+
+## Rules
+- Stop-and-fix: 検証またはレビューで失敗したら次工程へ進まず修正する。
+- Scope lock: guild text channel の frontend 接続に限定し、DM や backend 契約拡張は行わない。
+
+## Milestones
+### M1: 実装前提の更新
+- Acceptance criteria:
+  - [x] `Prompt.md` / `Plan.md` / `Implement.md` / `Documentation.md` を `LIN-829` 用に更新
+  - [x] 既存 message/chat/WS 導線の変更点を確定
+
+### M2: message API/query 基盤
+- Acceptance criteria:
+  - [x] message list/create 用型と query key を整理
+  - [x] `GuildChannelAPIClient` で guild message list/create が動く
+  - [x] cache merge helper を追加
+
+### M3: chat UI / realtime 接続
+- Acceptance criteria:
+  - [x] `ChatArea` / `MessageList` / `MessageInput` に guildId と paging/error 表示を配線
+  - [x] `WsAuthBridge` で active channel 購読と `message.created` cache 反映が動く
+
+### M4: テストと収束
+- Acceptance criteria:
+  - [x] API client / hook / WS/chat の回帰テストを更新
+  - [ ] `make validate` と `cd typescript && npm run typecheck` を実行
+  - [x] 実装内容と意図を日本語で説明できる状態にする

--- a/docs/agent_runs/LIN-829/Prompt.md
+++ b/docs/agent_runs/LIN-829/Prompt.md
@@ -1,0 +1,27 @@
+# LIN-829 Prompt
+
+## Goals
+- `LIN-829` として guild text channel の timeline/composer を実データ送受信へ接続する。
+- send/list 実 API、WS `message.subscribe` / `message.created`、履歴ページング導線を frontend で成立させる。
+- 既存 UI を維持しつつ、権限/レート制限エラーでも composer 表示を崩さない。
+
+## Non-goals
+- DM 送受信の実装。
+- backend 契約の拡張や UI 全面再設計。
+
+## Deliverables
+- `typescript/src/shared/api/*` の message 実接続。
+- `typescript/src/app/providers/ws-auth-bridge.tsx` の channel subscribe / cache 更新。
+- `typescript/src/widgets/chat/ui/*` の timeline/composer/paging/error 表示。
+- 関連 unit/component test 更新。
+
+## Done when
+- [ ] guild channel で send -> receive が UI 反映まで成立する。
+- [ ] WS 再接続後も active channel の購読が復元される。
+- [ ] 過去メッセージ読み込み導線が動作する。
+- [ ] `make validate` と `cd typescript && npm run typecheck` が通る。
+
+## Constraints
+- `LIN-829` の `Don't` に従い DM 実装を混在させない。
+- TypeScript / FSD ルールに従い、UI・query・api helper を分離する。
+- backend message contract は現状の `author_id` までを前提にし、frontend で最小補完する。


### PR DESCRIPTION
## 概要
- `LIN-829` の run memory を `docs/agent_runs/LIN-829/` 配下へ追加しました。
- `main` に残っていた不要な未コミット整形差分は別途破棄し、この PR では issue 単位の実装記録整理のみに限定しています。
- Linear と repo 内アーティファクトの対応を、既存の `docs/agent_runs/LIN-*` 運用に揃えます。

## 変更内容
- `docs/agent_runs/LIN-829/Prompt.md` を追加
- `docs/agent_runs/LIN-829/Plan.md` を追加
- `docs/agent_runs/LIN-829/Implement.md` を追加
- `docs/agent_runs/LIN-829/Documentation.md` を追加

## なぜ必要か
- `LIN-829` は実装本体が `main` にマージ済みですが、repo 内の run memory 配置が他 issue と揃っていませんでした。
- `docs/agent_runs/LIN-*` を基準に実装履歴を追える状態へ揃えることで、後続の traceability 確認を容易にします。

## Acceptance Criteria 対応
- `1 issue = 1 PR`:
  - `LIN-829` の run memory 整理のみに限定
- issue 単位の記録整備:
  - `docs/agent_runs/LIN-829/` に 4 ファイルを追加
- out-of-scope を混ぜない:
  - コード変更や別 issue の修正は含めない

## テスト・検証
- `git diff --name-only origin/main...HEAD`
  - `docs/agent_runs/LIN-829/` の 4 ファイルのみ差分であることを確認
- `git diff --check origin/main...HEAD`
  - 問題なし
- `make validate`
  - TypeScript lint 実行中に中断
  - docs-only PR に無関係な既存 TS ファイルの整形差分と `tsconfig.tsbuildinfo` が作業ツリーに発生したため、この PR に混ぜない方針で停止し差分を破棄

## Review / UI Checks
- self-review
  - blocking finding なし
- UI checks
  - 不要
  - 変更ファイルが `docs/agent_runs/LIN-829/**` のみで UI 影響なし
- runtime smoke
  - docs-only 変更のため skip

## 互換性・移行
- ADR-001 checklist:
  - event / schema / runtime contract の変更なし
  - additive documentation only
- breaking change なし
- migration なし

## Linear
- `LIN-829` [v1/メッセージ-04] FE timeline/composer実接続

## マージ方針
- base branch は `main` のため auto-merge は設定しない
- human review 待ち
