### PR TITLE
[v1/RM-05-04] 返信・ピン・リアクションの接続状態を整理する

### DIFF
--- a/docs/agent_runs/LIN-917/Documentation.md
+++ b/docs/agent_runs/LIN-917/Documentation.md
@@ -1,0 +1,43 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now: 実装と required validation の回収が完了
+- Next: PR 化して `LIN-917` を完了に進める
+
+## Decisions
+- reply は表示済みメッセージの参照表示のみを v1 Done とし、返信送信導線は未接続と明示する。
+- pin は persistence 完了済みだが一覧取得と pin/unpin 実行 UI は未接続として扱う。
+- reaction は表示済みの集計表示は維持し、追加/解除/詳細参加者表示は未接続として扱う。
+
+## How to run / demo
+- hover actions で reaction / reply を押すと未接続 toast が出ることを確認する
+- message context menu で reply / pin を押すと未接続 toast が出ることを確認する
+- pinned panel と reaction detail modal が fake data ではなく状態説明を表示することを確認する
+
+## Known issues / follow-ups
+- pin API / reaction API / reply create は後続 issue で接続が必要
+- pinned list の実データ取得は後続 issue で必要
+
+## Validation log
+- `2026-03-12`: `make setup`
+  - TypeScript 依存関係のセットアップは完了
+  - Rust `cargo fetch --locked` は完了
+  - Python setup は `python3.10+` 不在で失敗
+- `2026-03-12`: `cd typescript && npm run test -- message-context-menu message` は成功
+- `2026-03-12`: `cd typescript && npm run typecheck` は成功
+- `2026-03-12`: `make validate` は成功
+  - TypeScript: `format` / `fsd:check` / `eslint` / `prettier --check` / tests が通過
+  - Rust: `cargo fmt --check` / `cargo clippy --workspace --all-targets --all-features -- -D warnings` / `cargo test --workspace` が通過
+  - Python: `m black .` / `m ruff check . --fix` / `m unittest ...` は `m: not found` を出すが Makefile 上は ignored で継続
+- `2026-03-12`: `make rust-lint` は成功
+  - `cargo fmt --all --check`
+  - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+  - `cargo test --workspace`
+- `2026-03-12`: `make db-schema-check` は環境未整備で失敗
+  - `docker compose` 実行時に `NEXT_PUBLIC_FIREBASE_API_KEY is required` で停止
+
+## PR Draft
+- Title: `[v1/RM-05-04] 返信・ピン・リアクションの接続状態を整理する`
+- Summary:
+  - fake preview / mock detail をやめ、未接続操作を UI で明示
+  - reply / pin / reaction の v1 Done 範囲を docs と一致させる

--- a/docs/agent_runs/LIN-917/Implement.md
+++ b/docs/agent_runs/LIN-917/Implement.md
@@ -1,0 +1,6 @@
+# Implement.md (Runbook)
+
+- `Plan.md` の順で進める。順序変更時は `Documentation.md` に理由を残す。
+- 未接続機能は「あとで実装する」のではなく、現状が明確に伝わる UI へ直す。
+- fake data / mock display は本番導線から除去する。
+- 各 milestone 後にテストまたは型検査を実行し、失敗があれば先に直す。

--- a/docs/agent_runs/LIN-917/Plan.md
+++ b/docs/agent_runs/LIN-917/Plan.md
@@ -1,0 +1,32 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: validation か review で失敗したら修正してから進む。
+- Scope lock: `LIN-917` は reply / pin / reaction の接続状態整理に限定する。
+
+## Milestones
+### M1: 未接続 API と UI 導線を明示する
+- Acceptance criteria:
+  - [ ] concrete API client で pin / reaction 系メソッドが未実装のまま落ちない
+  - [ ] message hover / context menu から未接続操作が正しく案内される
+- Validation:
+  - `cd typescript && npm run test -- message-context-menu message`
+
+### M2: fake modal / panel 表示を状態説明へ置き換える
+- Acceptance criteria:
+  - [ ] pin confirm modal が fake preview を表示しない
+  - [ ] reaction detail modal が mock user 一覧を表示しない
+  - [ ] pinned panel が未接続状態を明示する
+- Validation:
+  - `cd typescript && npm run typecheck`
+
+### M3: 記録と全体検証を残す
+- Acceptance criteria:
+  - [ ] `docs/agent_runs/LIN-917/` が埋まっている
+  - [ ] `make setup` 後の required validation 結果を Documentation.md に残す
+- Validation:
+  - `make setup`
+  - `make validate`
+  - `make rust-lint`
+  - `cd typescript && npm run typecheck`
+  - `make db-schema-check`

--- a/docs/agent_runs/LIN-917/Prompt.md
+++ b/docs/agent_runs/LIN-917/Prompt.md
@@ -1,0 +1,25 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- reply / pin / reaction のうち、v1 で成立している範囲と未接続の範囲を UI と docs で一致させる。
+- fake preview や mock detail のような誤解を招く表示をなくす。
+- `LIN-892` 親完了判断に必要な状態整理を `LIN-917` に集約する。
+
+## Non-goals
+- reply create / pin API / reaction API 自体の新規実装
+- event schema や message REST/WS 契約の拡張
+- スレッド機能の実装
+
+## Deliverables
+- frontend の reply / pin / reaction 導線整理
+- `docs/agent_runs/LIN-917/` の memory 一式
+- PR 用の要約と検証記録
+
+## Done when
+- [ ] 未接続の操作が接続済みのように見えない
+- [ ] reply / pin / reaction の Done / 未接続が docs に残る
+
+## Constraints
+- Perf: 既存 timeline / message render の回帰を出さない
+- Security: 既存 authz / API 契約は変えない
+- Compatibility: additive 以外の契約変更はしない

--- a/typescript/src/features/context-menus/ui/message-context-menu.test.tsx
+++ b/typescript/src/features/context-menus/ui/message-context-menu.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, render, screen } from "@/test/test-utils";
+import { act, fireEvent, render, screen } from "@/test/test-utils";
 import { useAuthStore } from "@/shared/model/stores/auth-store";
 import { useUIStore } from "@/shared/model/stores/ui-store";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -142,5 +142,47 @@ describe("MessageContextMenu", () => {
     expect(screen.queryByRole("menuitem", { name: "メッセージを編集" })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "メッセージを削除" })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "メッセージを報告" })).toBeNull();
+  });
+
+  test("未接続の返信とピン留めで info toast を積む", () => {
+    render(
+      <MessageContextMenu
+        data={{
+          message: {
+            id: "5001",
+            channelId: "3001",
+            author: {
+              id: "9003",
+              username: "alice",
+              displayName: "Alice",
+              avatar: null,
+              status: "online",
+              customStatus: null,
+              bot: false,
+            },
+            content: "hello",
+            timestamp: "2026-03-10T10:00:00Z",
+            version: "1",
+            editedTimestamp: null,
+            isDeleted: false,
+            type: 0,
+            pinned: false,
+            mentionEveryone: false,
+            mentions: [],
+            attachments: [],
+            embeds: [],
+            reactions: [],
+            referencedMessage: null,
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "返信" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "ピン留め" }));
+
+    const messages = useUIStore.getState().toasts.map((toast) => toast.message);
+    expect(messages).toContain("返信送信は v1 では未接続です。");
+    expect(messages).toContain("ピン留め操作は v1 では未接続です。");
   });
 });

--- a/typescript/src/features/context-menus/ui/message-context-menu.tsx
+++ b/typescript/src/features/context-menus/ui/message-context-menu.tsx
@@ -33,6 +33,21 @@ export function MessageContextMenu({ data }: { data: { message: Message } }) {
     hideContextMenu();
   };
 
+  const handleReply = () => {
+    addToast({ message: "返信送信は v1 では未接続です。", type: "info" });
+    hideContextMenu();
+  };
+
+  const handleCreateThread = () => {
+    addToast({ message: "スレッド作成は準備中です", type: "info" });
+    hideContextMenu();
+  };
+
+  const handlePin = () => {
+    addToast({ message: "ピン留め操作は v1 では未接続です。", type: "info" });
+    hideContextMenu();
+  };
+
   const handleDelete = () => {
     hideContextMenu();
     deleteMessage.mutate(
@@ -54,15 +69,13 @@ export function MessageContextMenu({ data }: { data: { message: Message } }) {
 
   return (
     <ContextMenu>
-      <MenuItem onClick={hideContextMenu}>返信</MenuItem>
-      <MenuItem onClick={hideContextMenu}>スレッドを作成</MenuItem>
+      <MenuItem onClick={handleReply}>返信</MenuItem>
+      <MenuItem onClick={handleCreateThread}>スレッドを作成</MenuItem>
       <MenuSeparator />
       <MenuItem onClick={handleCopyText}>テキストをコピー</MenuItem>
       <MenuItem onClick={handleCopyLink}>メッセージリンクをコピー</MenuItem>
       <MenuSeparator />
-      <MenuItem onClick={hideContextMenu}>
-        {data.message.pinned ? "ピン留め解除" : "ピン留め"}
-      </MenuItem>
+      <MenuItem onClick={handlePin}>{data.message.pinned ? "ピン留め解除" : "ピン留め"}</MenuItem>
       <MenuSeparator />
       {canMutateMessage ? (
         <>

--- a/typescript/src/features/modals/ui/pin-confirm-modal.tsx
+++ b/typescript/src/features/modals/ui/pin-confirm-modal.tsx
@@ -2,7 +2,6 @@
 
 import { Modal, ModalHeader, ModalBody, ModalFooter } from "@/shared/ui/modal";
 import { Button } from "@/shared/ui/button";
-import { cn } from "@/shared/lib/cn";
 import { AlertTriangle, Pin } from "lucide-react";
 
 export function PinConfirmModal({
@@ -19,13 +18,8 @@ export function PinConfirmModal({
   onConfirm?: () => void;
 }) {
   const isPin = action === "pin";
-  const isNearLimit = currentPinCount >= 49;
+  const isNearLimit = currentPinCount >= 49 && currentPinCount < 50;
   const isAtLimit = currentPinCount >= 50;
-
-  const handleConfirm = () => {
-    onConfirm?.();
-    onClose();
-  };
 
   return (
     <Modal open onClose={onClose} className="max-w-[440px]">
@@ -33,19 +27,18 @@ export function PinConfirmModal({
         {isPin ? "このメッセージをピン留めしますか？" : "このメッセージのピン留めを解除しますか？"}
       </ModalHeader>
       <ModalBody>
-        {/* Message preview */}
-        <div className="rounded-md bg-discord-bg-secondary p-3">
+        <div className="rounded-md border border-discord-divider bg-discord-bg-secondary p-4">
           <div className="flex items-start gap-3">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-discord-brand-blurple text-xs font-bold text-white">
-              U
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-discord-bg-mod-hover text-discord-header-primary">
+              <Pin className="h-4 w-4" />
             </div>
             <div className="min-w-0 flex-1">
-              <div className="flex items-baseline gap-2">
-                <span className="text-sm font-medium text-discord-header-primary">ユーザー</span>
-                <span className="text-xs text-discord-text-muted">今日 12:00</span>
-              </div>
-              <p className="mt-1 text-sm text-discord-text-normal">
-                ピン留めされるメッセージのプレビュー
+              <p className="text-sm font-medium text-discord-header-primary">
+                ピン留め操作はまだ接続されていません
+              </p>
+              <p className="mt-1 text-sm leading-6 text-discord-text-muted">
+                `LIN-917` では pin persistence の完了済み状態と未接続 UI を整理しています。
+                {messageId ? ` 対象 message_id: ${messageId}` : ""}
               </p>
             </div>
           </div>
@@ -53,7 +46,7 @@ export function PinConfirmModal({
 
         {isPin && (
           <p className="mt-3 text-sm text-discord-text-muted">
-            このメッセージをこのチャンネルにピン留めします。チャンネルのメンバー全員がピン留めされたメッセージを確認できます。
+            一覧取得と pin/unpin 実行 API が未接続のため、この画面では状態確認のみを行います。
           </p>
         )}
 
@@ -73,17 +66,18 @@ export function PinConfirmModal({
       </ModalBody>
       <ModalFooter>
         <Button variant="link" onClick={onClose}>
-          キャンセル
+          閉じる
         </Button>
-        {isPin ? (
-          <Button onClick={handleConfirm} disabled={isAtLimit}>
-            ピン留め
-          </Button>
-        ) : (
-          <Button variant="danger" onClick={handleConfirm}>
-            解除
-          </Button>
-        )}
+        <Button
+          onClick={() => {
+            onConfirm?.();
+            onClose();
+          }}
+          disabled
+          variant={isPin ? "primary" : "danger"}
+        >
+          {isPin ? "未接続" : "未接続"}
+        </Button>
       </ModalFooter>
     </Modal>
   );

--- a/typescript/src/features/modals/ui/reaction-detail-modal.tsx
+++ b/typescript/src/features/modals/ui/reaction-detail-modal.tsx
@@ -1,91 +1,30 @@
 "use client";
 
-import { useState } from "react";
 import { Modal } from "@/shared/ui/modal";
-import { Avatar } from "@/shared/ui/avatar";
-import { cn } from "@/shared/lib/cn";
-
-type MockUser = {
-  id: string;
-  displayName: string;
-  avatar: string | null;
-};
-
-const mockReactionUsers: Record<string, MockUser[]> = {};
-
-const emojiTabs: { emoji: string; count: number }[] = [];
 
 export function ReactionDetailModal({
   onClose,
+  messageId,
+  emoji,
 }: {
   onClose: () => void;
   messageId?: string;
   emoji?: string;
 }) {
-  const [selectedEmoji, setSelectedEmoji] = useState<string | null>(null);
-  const totalCount = emojiTabs.reduce((sum, t) => sum + t.count, 0);
-
-  const activeEmoji = selectedEmoji;
-  const displayUsers = activeEmoji
-    ? (mockReactionUsers[activeEmoji] ?? [])
-    : (() => {
-        const seen = new Set<string>();
-        return Object.values(mockReactionUsers)
-          .flat()
-          .filter((u) => {
-            if (seen.has(u.id)) return false;
-            seen.add(u.id);
-            return true;
-          });
-      })();
-
   return (
     <Modal open onClose={onClose} className="max-w-[480px]">
-      <div className="flex h-[400px]">
-        {/* Left: emoji tabs */}
-        <div className="flex w-[140px] shrink-0 flex-col border-r border-discord-divider">
-          <button
-            onClick={() => setSelectedEmoji(null)}
-            className={cn(
-              "flex items-center gap-2 px-3 py-2 text-sm transition-colors",
-              selectedEmoji === null
-                ? "bg-discord-bg-mod-hover text-discord-text-normal"
-                : "text-discord-text-muted hover:bg-discord-bg-mod-hover hover:text-discord-text-normal",
-            )}
-          >
-            <span>すべて</span>
-            <span className="text-xs text-discord-text-muted">{totalCount}</span>
-          </button>
-          {emojiTabs.map((tab) => (
-            <button
-              key={tab.emoji}
-              onClick={() => setSelectedEmoji(tab.emoji)}
-              className={cn(
-                "flex items-center gap-2 px-3 py-2 text-sm transition-colors",
-                selectedEmoji === tab.emoji
-                  ? "bg-discord-bg-mod-hover text-discord-text-normal"
-                  : "text-discord-text-muted hover:bg-discord-bg-mod-hover hover:text-discord-text-normal",
-              )}
-            >
-              <span>{tab.emoji}</span>
-              <span className="text-xs text-discord-text-muted">{tab.count}</span>
-            </button>
-          ))}
-        </div>
-
-        {/* Right: user list */}
-        <div className="flex-1 overflow-y-auto p-3">
-          <div className="space-y-1">
-            {displayUsers.map((user) => (
-              <div
-                key={user.id}
-                className="flex items-center gap-3 rounded-md px-2 py-1.5 hover:bg-discord-bg-mod-hover"
-              >
-                <Avatar src={user.avatar ?? undefined} alt={user.displayName} size={32} />
-                <span className="text-sm text-discord-text-normal">{user.displayName}</span>
-              </div>
-            ))}
-          </div>
+      <div className="p-6">
+        <h3 className="text-base font-semibold text-discord-header-primary">
+          リアクション詳細は未接続です
+        </h3>
+        <p className="mt-3 text-sm leading-6 text-discord-text-muted">
+          v1 では reaction persistence は完了していますが、誰がどの絵文字を付けたかを取得する UI/API
+          接続はまだありません。
+        </p>
+        <div className="mt-4 rounded-md border border-discord-divider bg-discord-bg-secondary p-4 text-sm text-discord-text-muted">
+          {emoji ? `対象 emoji: ${emoji}` : "対象 emoji: 未指定"}
+          <br />
+          {messageId ? `対象 message_id: ${messageId}` : "対象 message_id: 未指定"}
         </div>
       </div>
     </Modal>

--- a/typescript/src/shared/api/guild-channel-api-client.test.ts
+++ b/typescript/src/shared/api/guild-channel-api-client.test.ts
@@ -1252,6 +1252,29 @@ describe("GuildChannelAPIClient", () => {
     expect(init.body).toBe(JSON.stringify({ expected_version: 2 }));
   });
 
+  test("unavailable pin and reaction methods return v1 placeholder contracts", async () => {
+    const client = new GuildChannelAPIClient();
+
+    await expect(client.getPinnedMessages("3001")).resolves.toEqual([]);
+
+    await expect(client.addReaction("3001", "5001", "👍")).rejects.toMatchObject({
+      code: "FEATURE_UNAVAILABLE",
+      status: 501,
+    });
+    await expect(client.removeReaction("3001", "5001", "👍")).rejects.toMatchObject({
+      code: "FEATURE_UNAVAILABLE",
+      status: 501,
+    });
+    await expect(client.pinMessage("3001", "5001")).rejects.toMatchObject({
+      code: "FEATURE_UNAVAILABLE",
+      status: 501,
+    });
+    await expect(client.unpinMessage("3001", "5001")).rejects.toMatchObject({
+      code: "FEATURE_UNAVAILABLE",
+      status: 501,
+    });
+  });
+
   test("toUpdateActionErrorText maps message conflict", () => {
     const error = new GuildChannelApiError("conflict", {
       code: "MESSAGE_CONFLICT",

--- a/typescript/src/shared/api/guild-channel-api-client.ts
+++ b/typescript/src/shared/api/guild-channel-api-client.ts
@@ -1498,6 +1498,61 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
     return mapMessageItem(response.message);
   }
 
+  /**
+   * ピン留め一覧は未接続のため空配列を返す。
+   */
+  getPinnedMessages(_channelId: string): Promise<Message[]> {
+    return Promise.resolve([]);
+  }
+
+  /**
+   * リアクション追加は v1 では未接続として扱う。
+   */
+  addReaction(_channelId: string, _messageId: string, _emoji: string): Promise<void> {
+    return Promise.reject(
+      new GuildChannelApiError("リアクション追加は v1 では未接続です。", {
+        status: 501,
+        code: "FEATURE_UNAVAILABLE",
+      }),
+    );
+  }
+
+  /**
+   * リアクション解除は v1 では未接続として扱う。
+   */
+  removeReaction(_channelId: string, _messageId: string, _emoji: string): Promise<void> {
+    return Promise.reject(
+      new GuildChannelApiError("リアクション解除は v1 では未接続です。", {
+        status: 501,
+        code: "FEATURE_UNAVAILABLE",
+      }),
+    );
+  }
+
+  /**
+   * ピン留めは v1 では未接続として扱う。
+   */
+  pinMessage(_channelId: string, _messageId: string): Promise<void> {
+    return Promise.reject(
+      new GuildChannelApiError("ピン留め操作は v1 では未接続です。", {
+        status: 501,
+        code: "FEATURE_UNAVAILABLE",
+      }),
+    );
+  }
+
+  /**
+   * ピン留め解除は v1 では未接続として扱う。
+   */
+  unpinMessage(_channelId: string, _messageId: string): Promise<void> {
+    return Promise.reject(
+      new GuildChannelApiError("ピン留め操作は v1 では未接続です。", {
+        status: 501,
+        code: "FEATURE_UNAVAILABLE",
+      }),
+    );
+  }
+
   async getMyProfile(): Promise<MyProfile> {
     const response = await this.getJson("/users/me/profile", MY_PROFILE_RESPONSE_SCHEMA);
     return mapMyProfile(response);

--- a/typescript/src/widgets/chat/ui/message/message-actions.tsx
+++ b/typescript/src/widgets/chat/ui/message/message-actions.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useRef } from "react";
 import { SmilePlus, Reply, Pencil, MessageSquare, MoreHorizontal, Trash2 } from "lucide-react";
 import { cn } from "@/shared/lib/cn";
 import { useUIStore } from "@/shared/model/stores/ui-store";
-import { EmojiPicker } from "@/features/pickers";
 import { PublishButton } from "./publish-button";
 import type { Message } from "@/shared/model/types";
 
@@ -21,13 +20,16 @@ export function MessageActions({
   onDelete?: () => void;
   isAnnouncement?: boolean;
 }) {
-  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const moreButtonRef = useRef<HTMLButtonElement>(null);
   const showContextMenu = useUIStore((s) => s.showContextMenu);
   const addToast = useUIStore((s) => s.addToast);
 
-  const handleReactionSelect = (emoji: string) => {
-    setShowEmojiPicker(false);
+  const handleReaction = () => {
+    addToast({ message: "リアクション追加は v1 では未接続です。", type: "info" });
+  };
+
+  const handleReply = () => {
+    addToast({ message: "返信送信は v1 では未接続です。", type: "info" });
   };
 
   const handleThread = () => {
@@ -49,28 +51,17 @@ export function MessageActions({
       )}
     >
       {/* Reaction button */}
-      <div className="relative">
-        <button
-          title="リアクションを追加"
-          onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-          className={cn(
-            "p-1.5 text-discord-interactive-normal",
-            "hover:bg-discord-bg-mod-hover hover:text-discord-interactive-hover",
-            "rounded transition-colors",
-          )}
-        >
-          <SmilePlus className="h-4 w-4" />
-        </button>
-        {showEmojiPicker && (
-          <div className="absolute bottom-full right-0 mb-1">
-            <EmojiPicker
-              mode="reaction"
-              onSelect={handleReactionSelect}
-              onClose={() => setShowEmojiPicker(false)}
-            />
-          </div>
+      <button
+        title="リアクションを追加"
+        onClick={handleReaction}
+        className={cn(
+          "p-1.5 text-discord-interactive-normal",
+          "hover:bg-discord-bg-mod-hover hover:text-discord-interactive-hover",
+          "rounded transition-colors",
         )}
-      </div>
+      >
+        <SmilePlus className="h-4 w-4" />
+      </button>
 
       {/* Edit button */}
       {onEdit && (
@@ -104,6 +95,7 @@ export function MessageActions({
       {/* Reply button */}
       <button
         title="返信"
+        onClick={handleReply}
         className={cn(
           "p-1.5 text-discord-interactive-normal",
           "hover:bg-discord-bg-mod-hover hover:text-discord-interactive-hover",

--- a/typescript/src/widgets/chat/ui/message/message.test.tsx
+++ b/typescript/src/widgets/chat/ui/message/message.test.tsx
@@ -120,4 +120,16 @@ describe("Message", () => {
     expect(screen.queryByTitle("編集")).toBeNull();
     expect(screen.queryByTitle("削除")).toBeNull();
   });
+
+  test("未接続のリアクション追加と返信で info toast を積む", () => {
+    const { container } = render(<Message message={buildMessage()} isGrouped={false} />);
+
+    fireEvent.mouseEnter(container.firstChild as Element);
+    fireEvent.click(screen.getByTitle("リアクションを追加"));
+    fireEvent.click(screen.getByTitle("返信"));
+
+    const messages = useUIStore.getState().toasts.map((toast) => toast.message);
+    expect(messages).toContain("リアクション追加は v1 では未接続です。");
+    expect(messages).toContain("返信送信は v1 では未接続です。");
+  });
 });

--- a/typescript/src/widgets/panels/ui/pinned-messages-panel.tsx
+++ b/typescript/src/widgets/panels/ui/pinned-messages-panel.tsx
@@ -1,112 +1,21 @@
 "use client";
 
-import { cn } from "@/shared/lib/cn";
-import { useGuildStore } from "@/shared/model/stores/guild-store";
-import { useUIStore } from "@/shared/model/stores/ui-store";
-import { usePinnedMessages } from "@/shared/api/queries";
-import { Avatar, Skeleton } from "@/shared/ui/ui-kit";
-import { EmptyState } from "@/shared/ui/empty-state";
-
-function formatTimestamp(timestamp: string) {
-  const date = new Date(timestamp);
-  return date.toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
+import { Pin } from "lucide-react";
 
 export function PinnedMessagesPanel() {
-  const channelId = useGuildStore((s) => s.activeChannelId);
-  const openModal = useUIStore((s) => s.openModal);
-  const { data: pinnedMessages, isLoading } = usePinnedMessages(channelId ?? "");
-
-  const pinCount = pinnedMessages?.length ?? 0;
-
-  if (isLoading) {
-    return (
-      <div className="space-y-3 p-4">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="flex gap-3 rounded-lg bg-discord-bg-tertiary p-3">
-            <Skeleton width={24} height={24} rounded />
-            <div className="flex-1 space-y-2">
-              <Skeleton width={120} height={14} />
-              <Skeleton width="100%" height={14} />
-              <Skeleton width="60%" height={14} />
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  if (!pinnedMessages?.length) {
-    return <EmptyState variant="no-pins" />;
-  }
-
   return (
-    <div className="flex flex-col">
-      {/* Pin count header */}
-      <div className="flex items-center justify-between border-b border-discord-divider px-4 py-2">
-        <span className="text-xs font-semibold text-discord-header-secondary">
-          {pinCount}/50 ピン留め
-        </span>
-      </div>
-
-      <div className="space-y-2 p-3">
-        {pinnedMessages.map((message) => (
-          <div
-            key={message.id}
-            className={cn(
-              "rounded-lg bg-discord-bg-tertiary p-3",
-              "hover:bg-discord-bg-mod-hover transition-colors",
-            )}
-          >
-            <div className="flex items-start gap-3">
-              <Avatar
-                src={message.author.avatar ?? undefined}
-                alt={message.author.displayName ?? message.author.username}
-                size={32}
-              />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-baseline gap-2">
-                  <span className="text-sm font-medium text-discord-header-primary">
-                    {message.author.displayName ?? message.author.username}
-                  </span>
-                  <span className="text-xs text-discord-text-muted">
-                    {formatTimestamp(message.timestamp)}
-                  </span>
-                </div>
-                <p className="mt-1 text-sm leading-relaxed text-discord-text-normal line-clamp-3">
-                  {message.content}
-                </p>
-                <div className="mt-2 flex items-center gap-3">
-                  <button
-                    className={cn("text-xs font-medium text-discord-text-link", "hover:underline")}
-                  >
-                    ジャンプ
-                  </button>
-                  <button
-                    className={cn(
-                      "text-xs font-medium text-discord-text-muted",
-                      "hover:text-discord-text-normal hover:underline",
-                    )}
-                    onClick={() =>
-                      openModal("pin-confirm", {
-                        messageId: message.id,
-                        action: "unpin",
-                      })
-                    }
-                  >
-                    ピン留め解除
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        ))}
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="max-w-sm rounded-xl border border-discord-divider bg-discord-bg-tertiary p-5 text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-discord-bg-mod-hover text-discord-header-primary">
+          <Pin className="h-5 w-5" />
+        </div>
+        <h3 className="mt-4 text-base font-semibold text-discord-header-primary">
+          ピン留め一覧は未接続です
+        </h3>
+        <p className="mt-2 text-sm leading-6 text-discord-text-muted">
+          v1 では pin persistence は整備済みですが、一覧取得と pin/unpin 操作の UI/API
+          接続はまだ入っていません。 このパネルは接続状態を明示するための案内表示です。
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要
- reply / pin / reaction のうち、v1 で未接続の導線を UI 上で明示するよう整理しました
- fake preview / mock detail / 擬似 pinned list をやめ、現状の接続状態が誤解なく分かる表示へ置き換えました
- `LIN-917` の run memory を追加し、v1 Done 範囲と検証記録を残しました

## 変更内容
- message hover actions と context menu の reply / pin / reaction 操作で info toast を表示するよう変更
- `GuildChannelAPIClient` に未接続 placeholder を追加し、pin / reaction 系 API を `FEATURE_UNAVAILABLE` として明示
- pin confirm modal / reaction detail modal / pinned messages panel を未接続状態の説明 UI に変更
- `docs/agent_runs/LIN-917/` に Prompt / Plan / Implement / Documentation を追加

## 検証
- `make validate`
- `make rust-lint`
- `cd typescript && npm run test -- message-context-menu message`
- `cd typescript && npm run typecheck`

## 未解決 / 補足
- `make db-schema-check` はローカル環境変数 `NEXT_PUBLIC_FIREBASE_API_KEY` 未設定のため未実行です
- Python 側の `m black .` / `m ruff ...` / `m unittest ...` は現行 Makefile 上で `m: not found` ですが ignored で継続します

## ADR-001 チェック
- event contract 変更なし
- backward compatibility 影響なし
- 互換性判断: UI 表示と client placeholder の整理のみで、既存 REST/WS 契約は変更していません

## Linear
- LIN-917
- 親: LIN-892
