### PR TITLE
LIN-959 プロフィール画像のサイズ制約と案内を追加する

### DIFF
--- a/docs/agent_runs/LIN-959/Documentation.md
+++ b/docs/agent_runs/LIN-959/Documentation.md
@@ -1,0 +1,20 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now: TypeScript 実装と対象テストは完了。サイズ超過の事前 reject と案内文を追加した。
+
+## Decisions
+- Avatar limit is `2MB`; banner limit is `6MB`.
+- Oversized files are rejected before crop modal open and before upload/save.
+
+## How to run / demo
+- settings profile で avatar / banner のファイル選択ボタンを押す
+- 入力下に avatar `2MB` / banner `6MB` の案内文が表示されることを確認する
+- 上限超過ファイルを選ぶと crop modal が開かず、エラー表示されることを確認する
+- 上限内ファイルでは既存の crop / preview / save 導線が維持されることを確認する
+- 実行済み検証:
+  - `cd typescript && pnpm test -- src/features/settings/ui/user/user-profile.test.tsx src/features/settings/lib/profile-image.test.ts`
+  - `cd typescript && pnpm typecheck`
+
+## Known issues / follow-ups
+- `pnpm test` 実行中の `act(...)` warning は既存テスト群でも発生しており、今回の変更で新設した failure ではない

--- a/docs/agent_runs/LIN-959/Implement.md
+++ b/docs/agent_runs/LIN-959/Implement.md
@@ -1,0 +1,5 @@
+# Implement.md (Runbook)
+
+- Keep the diff scoped to `LIN-959`.
+- Reuse the existing `LIN-909` upload/crop/save flow without changing its contracts.
+- Update `Documentation.md` with validation and review evidence before opening the PR.

--- a/docs/agent_runs/LIN-959/Plan.md
+++ b/docs/agent_runs/LIN-959/Plan.md
@@ -1,0 +1,14 @@
+# Plan.md (Milestones + validations)
+
+## Milestones
+### M1: Add size validation helper
+- Add avatar/banner size constants and hint/error helpers in `features/settings/lib`.
+
+### M2: Wire profile UI guard
+- Show the size hints in profile settings.
+- Block oversized file selection before crop/upload/save and show an inline error.
+
+### M3: Validate and record evidence
+- `cd typescript && pnpm test -- src/features/settings/ui/user/user-profile.test.tsx src/features/settings/lib/profile-image.test.ts`
+- `cd typescript && pnpm typecheck`
+- Run reviewer gates and create one PR for `LIN-959`.

--- a/docs/agent_runs/LIN-959/Prompt.md
+++ b/docs/agent_runs/LIN-959/Prompt.md
@@ -1,0 +1,23 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- Add avatar/banner file size guidance in the profile settings UI.
+- Reject oversized avatar/banner selections before crop, upload, or patch runs.
+
+## Non-goals
+- No backend, DB, or upload contract changes.
+- No image compression or optimization pipeline changes.
+
+## Deliverables
+- Size hint text for avatar and banner inputs.
+- Frontend validation helper for avatar/banner file size limits.
+- Regression tests for valid selection flow and oversized-file rejection.
+
+## Done when
+- [ ] UI shows avatar/banner size limits.
+- [ ] Oversized files are blocked before crop/upload/save.
+- [ ] Existing valid crop/preview/save flow remains intact.
+
+## Constraints
+- Build on top of `LIN-909` branch state.
+- Keep scope to `LIN-959` only.

--- a/typescript/src/features/settings/lib/profile-image.test.ts
+++ b/typescript/src/features/settings/lib/profile-image.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import {
+  PROFILE_IMAGE_SIZE_LIMIT_BYTES,
+  getProfileImageSizeHint,
+  validateProfileImageFile,
+} from "./profile-image";
+
+describe("profile-image", () => {
+  test("returns size hints for avatar and banner", () => {
+    expect(getProfileImageSizeHint("avatar")).toBe("アバター画像は 2MB まで選択できます。");
+    expect(getProfileImageSizeHint("banner")).toBe("バナー画像は 6MB まで選択できます。");
+  });
+
+  test("accepts files within the configured limit", () => {
+    expect(
+      validateProfileImageFile("avatar", { size: PROFILE_IMAGE_SIZE_LIMIT_BYTES.avatar }),
+    ).toBeNull();
+    expect(
+      validateProfileImageFile("banner", { size: PROFILE_IMAGE_SIZE_LIMIT_BYTES.banner }),
+    ).toBeNull();
+  });
+
+  test("rejects files larger than the configured limit", () => {
+    expect(
+      validateProfileImageFile("avatar", { size: PROFILE_IMAGE_SIZE_LIMIT_BYTES.avatar + 1 }),
+    ).toBe("アバター画像は 2MB 以下のファイルを選択してください。");
+    expect(
+      validateProfileImageFile("banner", { size: PROFILE_IMAGE_SIZE_LIMIT_BYTES.banner + 1 }),
+    ).toBe("バナー画像は 6MB 以下のファイルを選択してください。");
+  });
+});

--- a/typescript/src/features/settings/lib/profile-image.ts
+++ b/typescript/src/features/settings/lib/profile-image.ts
@@ -1,0 +1,38 @@
+import type { ProfileMediaTarget } from "@/shared/api/api-client";
+
+export const PROFILE_IMAGE_SIZE_LIMIT_BYTES = {
+  avatar: 2 * 1024 * 1024,
+  banner: 6 * 1024 * 1024,
+} as const satisfies Record<ProfileMediaTarget, number>;
+
+function formatFileSize(bytes: number): string {
+  const megabytes = bytes / (1024 * 1024);
+  if (Number.isInteger(megabytes)) {
+    return `${megabytes}MB`;
+  }
+
+  return `${megabytes.toFixed(1)}MB`;
+}
+
+/**
+ * プロフィール画像サイズ制約の案内文を返す。
+ */
+export function getProfileImageSizeHint(target: ProfileMediaTarget): string {
+  const label = target === "avatar" ? "アバター" : "バナー";
+  return `${label}画像は ${formatFileSize(PROFILE_IMAGE_SIZE_LIMIT_BYTES[target])} まで選択できます。`;
+}
+
+/**
+ * プロフィール画像のサイズ制約を検証し、違反時は表示用メッセージを返す。
+ */
+export function validateProfileImageFile(
+  target: ProfileMediaTarget,
+  file: Pick<File, "size">,
+): string | null {
+  if (file.size <= PROFILE_IMAGE_SIZE_LIMIT_BYTES[target]) {
+    return null;
+  }
+
+  const label = target === "avatar" ? "アバター" : "バナー";
+  return `${label}画像は ${formatFileSize(PROFILE_IMAGE_SIZE_LIMIT_BYTES[target])} 以下のファイルを選択してください。`;
+}

--- a/typescript/src/features/settings/ui/user/user-profile.test.tsx
+++ b/typescript/src/features/settings/ui/user/user-profile.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { act, render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { PROFILE_IMAGE_SIZE_LIMIT_BYTES } from "../../lib/profile-image";
 import { GuildChannelApiError } from "@/shared/api/guild-channel-api-client";
 import { useAuthStore } from "@/shared/model/stores/auth-store";
 
@@ -36,6 +37,9 @@ const useUpdateMyProfileMock = vi.hoisted(() =>
 const uploadProfileMediaFileMock = vi.hoisted(() =>
   vi.fn<(target: "avatar" | "banner", file: File) => Promise<string>>(),
 );
+const croppedImageResultOverrideMock = vi.hoisted(
+  () => vi.fn<() => { file: File; url: string } | null>(),
+);
 
 vi.mock("@/shared/api/mutations", () => ({
   useUpdateMyProfile: useUpdateMyProfileMock,
@@ -63,7 +67,13 @@ vi.mock("@/shared/ui/image-crop-modal", () => ({
     onClose: () => void;
   }) => (
     <div>
-      <button type="button" onClick={() => onCrop({ file: sourceFile, url: imageUrl })}>
+      <button
+        type="button"
+        onClick={() => {
+          const override = croppedImageResultOverrideMock();
+          onCrop(override ?? { file: sourceFile, url: imageUrl });
+        }}
+      >
         適用
       </button>
       <button type="button" onClick={onClose}>
@@ -75,9 +85,18 @@ vi.mock("@/shared/ui/image-crop-modal", () => ({
 
 import { UserProfile } from "./user-profile";
 
+function setFileSize(file: File, size: number): File {
+  Object.defineProperty(file, "size", {
+    configurable: true,
+    value: size,
+  });
+  return file;
+}
+
 describe("UserProfile", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    croppedImageResultOverrideMock.mockReturnValue(null);
     vi.stubGlobal(
       "URL",
       Object.assign(URL, {
@@ -328,5 +347,50 @@ describe("UserProfile", () => {
         bannerKey: "profiles/u-1/banner/new-banner.png",
       });
     });
+  });
+
+  test("blocks oversized avatar selection before crop or save", async () => {
+    const user = userEvent.setup();
+    render(<UserProfile />);
+
+    const oversizedFile = setFileSize(
+      new File(["avatar"], "large-avatar.png", { type: "image/png" }),
+      PROFILE_IMAGE_SIZE_LIMIT_BYTES.avatar + 1,
+    );
+
+    await user.upload(screen.getByLabelText("アバター画像ファイル"), oversizedFile);
+
+    expect(
+      screen.getByText("アバター画像は 2MB 以下のファイルを選択してください。"),
+    ).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "適用" })).toBeNull();
+    expect(uploadProfileMediaFileMock).not.toHaveBeenCalled();
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  test("blocks oversized cropped avatar before save", async () => {
+    const user = userEvent.setup();
+    croppedImageResultOverrideMock.mockReturnValue({
+      file: setFileSize(
+        new File(["cropped-avatar"], "cropped-avatar.png", { type: "image/png" }),
+        PROFILE_IMAGE_SIZE_LIMIT_BYTES.avatar + 1,
+      ),
+      url: "blob:cropped-avatar.png",
+    });
+
+    render(<UserProfile />);
+
+    await user.upload(
+      screen.getByLabelText("アバター画像ファイル"),
+      new File(["avatar"], "avatar.png", { type: "image/png" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "適用" }));
+
+    expect(
+      screen.getByText("アバター画像は 2MB 以下のファイルを選択してください。"),
+    ).not.toBeNull();
+    expect(uploadProfileMediaFileMock).not.toHaveBeenCalled();
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
   });
 });

--- a/typescript/src/features/settings/ui/user/user-profile.tsx
+++ b/typescript/src/features/settings/ui/user/user-profile.tsx
@@ -13,6 +13,7 @@ import { Textarea } from "@/shared/ui/textarea";
 import { useAuthStore } from "@/shared/model/stores/auth-store";
 import { cn } from "@/shared/lib/cn";
 import { uploadProfileMediaFile } from "@/features/settings/model/profile-media";
+import { getProfileImageSizeHint, validateProfileImageFile } from "../../lib/profile-image";
 
 const BIO_MAX = 190;
 const BIO_WARN = 180;
@@ -71,6 +72,10 @@ export function UserProfile() {
   const [themeColor, setThemeColor] = useState("#5865F2");
   const [saveMessage, setSaveMessage] = useState<{
     type: "success" | "error";
+    text: string;
+  } | null>(null);
+  const [selectionMessage, setSelectionMessage] = useState<{
+    type: "error";
     text: string;
   } | null>(null);
   const [cropImage, setCropImage] = useState<CropImageState | null>(null);
@@ -157,7 +162,17 @@ export function UserProfile() {
   }, [myProfile?.bannerKey, pendingBannerFile, resolvedBannerUrl]);
 
   const handleFileSelect = (file: File, target: "avatar" | "banner") => {
+    const validationError = validateProfileImageFile(target, file);
+    if (validationError !== null) {
+      setSelectionMessage({
+        type: "error",
+        text: validationError,
+      });
+      return;
+    }
+
     const url = URL.createObjectURL(file);
+    setSelectionMessage(null);
     setCropImage((currentValue) => {
       if (currentValue !== null) {
         revokeObjectUrlIfNeeded(currentValue.url);
@@ -177,6 +192,22 @@ export function UserProfile() {
       return;
     }
 
+    const validationError = validateProfileImageFile(cropImage.target, croppedImage.file);
+    if (validationError !== null) {
+      setSelectionMessage({
+        type: "error",
+        text: validationError,
+      });
+      revokeObjectUrlIfNeeded(croppedImage.url);
+      setCropImage((currentValue) => {
+        if (currentValue !== null) {
+          revokeObjectUrlIfNeeded(currentValue.url);
+        }
+        return null;
+      });
+      return;
+    }
+
     if (cropImage.target === "avatar") {
       setPendingAvatarFile(croppedImage.file);
       replaceObjectUrl(setAvatarPreviewUrl, croppedImage.url);
@@ -185,6 +216,7 @@ export function UserProfile() {
       replaceObjectUrl(setBannerPreviewUrl, croppedImage.url);
     }
 
+    setSelectionMessage(null);
     setSaveMessage(null);
     setCropImage((currentValue) => {
       if (currentValue !== null) {
@@ -287,6 +319,9 @@ export function UserProfile() {
             <Button variant="secondary" size="sm" onClick={() => avatarInputRef.current?.click()}>
               アバターを変更
             </Button>
+            <p className="mt-2 text-xs text-discord-text-muted">
+              {getProfileImageSizeHint("avatar")}
+            </p>
             <input
               ref={avatarInputRef}
               type="file"
@@ -310,6 +345,9 @@ export function UserProfile() {
             <Button variant="secondary" size="sm" onClick={() => bannerInputRef.current?.click()}>
               バナーを変更
             </Button>
+            <p className="mt-2 text-xs text-discord-text-muted">
+              {getProfileImageSizeHint("banner")}
+            </p>
             <input
               ref={bannerInputRef}
               type="file"
@@ -367,6 +405,12 @@ export function UserProfile() {
               className="h-10 w-16 cursor-pointer rounded border-none bg-transparent"
             />
           </div>
+
+          {selectionMessage?.type === "error" && (
+            <div role="alert" className="rounded bg-discord-bg-tertiary px-3 py-2">
+              <p className="text-sm text-discord-status-dnd">{selectionMessage.text}</p>
+            </div>
+          )}
 
           <div className="space-y-2">
             <Button


### PR DESCRIPTION
## 概要

プロフィール画像のサイズ制約と案内を追加します。LIN-909 の保存反映導線を前提に、過大画像を保存前に止める最小ガードを入れます。

## 変更内容

- avatar 2MB / banner 6MB のサイズ制約ヘルパーを追加
- プロフィール画面でサイズ上限の案内文を表示
- 上限超過の選択時は crop 前にエラー表示して処理を止める
- crop 後に生成された画像も再検証し、上限超過なら upload / patch に進ませない
- 回帰テストを追加

## 受け入れ条件との対応

- [x] avatar / banner それぞれで許容サイズ上限が UI 上で明示される
- [x] 上限超過画像は保存前にエラー表示され、upload / patch が走らない
- [x] 上限内画像では既存の crop / preview / save 導線を維持する
- [x] 回帰テストでサイズ超過と通常保存の両方を担保する

## テスト

- `cd typescript && pnpm test -- src/features/settings/ui/user/user-profile.test.tsx src/features/settings/lib/profile-image.test.ts`
- `cd typescript && pnpm typecheck`

## レビュー補足

- `reviewer_simple`: blocker なし
- `reviewer_ui`: blocker なし
- `pnpm lint` はレビュー窓内では完了確認を取れていない

## 関連

- Linear: LIN-959
- Depends on: LIN-909
