### PR TITLE
LIN-932 v1/RM-11-03 永続化未接続の解消と protocol 互換性検証を完了する

### DIFF
--- a/docs/agent_runs/LIN-932/Documentation.md
+++ b/docs/agent_runs/LIN-932/Documentation.md
@@ -1,0 +1,31 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Completed: unresolved DM message persistence wiring and protocol compatibility evidence were fixed within `LIN-932` scope.
+- Next: no additional code work in `LIN-932`; broader event transport work remains out of scope.
+
+## Decisions
+- The concrete persistence gap was the DM message live path: it reused guild-text context lookup, so live runtime could not resolve DM channel metadata correctly.
+- Fix scope stayed minimal: add DM channel-context lookup to the message metadata repository, route DM create/list through dedicated usecase entrypoints, and keep the shared `MessageItemV1` contract unchanged.
+- Protocol compatibility evidence is repo-local snapshot coverage only; no schema expansion or event rename was introduced.
+- Snapshot fixtures were added for `protocol-events` and `protocol-ws` to detect additive-only regressions against the current contract surface.
+
+## How to run / demo
+- DM persistence path:
+- `cargo test -p linklynx_message_domain dm_ --manifest-path rust/Cargo.toml`
+- `cargo test -p linklynx_backend create_dm_message_uses_dm_usecase_path --manifest-path rust/Cargo.toml`
+- Protocol snapshot path:
+- `cargo test -p linklynx_protocol_events -p linklynx_protocol_ws --manifest-path rust/Cargo.toml`
+
+## Validation
+- Passed: `cargo test -p linklynx_message_domain dm_ --manifest-path rust/Cargo.toml`
+- Passed: `cargo test -p linklynx_backend create_dm_message_uses_dm_usecase_path --manifest-path rust/Cargo.toml`
+- Passed: `cargo test -p linklynx_protocol_events -p linklynx_protocol_ws --manifest-path rust/Cargo.toml`
+- Passed: `make rust-lint`
+- Passed: `cd typescript && npm run typecheck`
+- Blocked: `make validate`
+- Reason: Python `py-format` could not install `black==24.10.0` because package resolution/network access for that dependency failed in the local environment.
+
+## Known issues / follow-ups
+- Durable event transport/publisher wiring is still intentionally out of scope; this run fixes contract evidence, not event-stream runtime delivery.
+- TCP-bind WS fanout smoke remains ignored in this sandbox and is not used as the primary acceptance signal for this issue.

--- a/docs/agent_runs/LIN-932/Implement.md
+++ b/docs/agent_runs/LIN-932/Implement.md
@@ -1,0 +1,6 @@
+# Implement.md (Runbook)
+
+- Follow Plan.md as the single execution order. If order changes are needed, document the reason in Documentation.md and update it.
+- Keep diffs small and do not mix in out-of-scope improvements.
+- Run validation after each milestone and fix failures immediately before continuing.
+- Continuously update Documentation.md with decisions, progress, demo steps, and known issues.

--- a/docs/agent_runs/LIN-932/Plan.md
+++ b/docs/agent_runs/LIN-932/Plan.md
@@ -1,0 +1,24 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: if validation fails, repair it before moving to the next step.
+
+## Milestones
+### M1: 対象の未接続 persistence / repository を特定して接続する
+- Acceptance criteria:
+  - [ ] scope に合う runtime / repository の未接続が埋まる
+- Validation:
+  - `cargo test message --manifest-path rust/Cargo.toml`
+
+### M2: protocol snapshot / acceptance tests を追加する
+- Acceptance criteria:
+  - [ ] additive-only regression を検知できる
+  - [ ] 最小 acceptance path が test で固定される
+- Validation:
+  - `cargo test protocol --manifest-path rust/Cargo.toml`
+
+### M3: run record を更新する
+- Acceptance criteria:
+  - [ ] `Documentation.md` に決定と検証結果が残る
+- Validation:
+  - `make rust-lint`

--- a/docs/agent_runs/LIN-932/Prompt.md
+++ b/docs/agent_runs/LIN-932/Prompt.md
@@ -1,0 +1,24 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- `LIN-932` として未接続 persistence を埋め、protocol compatibility 検証を固定する。
+- additive-only snapshot test と最小受け入れ検証を追加する。
+
+## Non-goals
+- 新しい event 仕様の追加。
+- v1 範囲外の transport 改修。
+
+## Deliverables
+- persistence/repository wiring 修正
+- protocol snapshot / acceptance tests
+- run record
+
+## Done when
+- [ ] 対象 persistence の未接続が解消される
+- [ ] event / WS contract の additive-only 退行を検知できる
+- [ ] 最小受け入れテスト範囲が repo に固定される
+
+## Constraints
+- Perf: 既存 message path の追加コストを最小化する
+- Security: 既存 auth/authz fail-close 契約を崩さない
+- Compatibility: ADR-001 additive-only を守る

--- a/rust/apps/api/src/message/service.rs
+++ b/rust/apps/api/src/message/service.rs
@@ -307,7 +307,7 @@ impl MessageService for RuntimeMessageService {
         query: ListGuildChannelMessagesQueryV1,
     ) -> Result<ListGuildChannelMessagesResponseV1, MessageError> {
         self.usecase
-            .list_guild_channel_messages(channel_id, channel_id, query)
+            .list_dm_channel_messages(channel_id, query)
             .await
             .map_err(MessageError::from)
     }
@@ -330,7 +330,7 @@ impl MessageService for RuntimeMessageService {
         let idempotency = self.build_idempotency(idempotency_key, &request)?;
         let result = self
             .usecase
-            .create_guild_channel_message(CreateGuildChannelMessageCommand {
+            .create_dm_channel_message(CreateGuildChannelMessageCommand {
                 guild_id: channel_id,
                 channel_id,
                 author_id: principal_id.0,
@@ -567,6 +567,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingMessageUsecase {
         created: Mutex<Vec<CreateGuildChannelMessageCommand>>,
+        dm_created: Mutex<Vec<CreateGuildChannelMessageCommand>>,
     }
 
     #[async_trait]
@@ -582,9 +583,33 @@ mod tests {
             })
         }
 
+        async fn create_dm_channel_message(
+            &self,
+            command: CreateGuildChannelMessageCommand,
+        ) -> Result<linklynx_message_domain::CreateGuildChannelMessageResult, MessageUsecaseError> {
+            self.dm_created.lock().await.push(command.clone());
+            Ok(linklynx_message_domain::CreateGuildChannelMessageResult {
+                message: command.to_message_item(&command.proposed_identity),
+                should_publish: true,
+            })
+        }
+
         async fn list_guild_channel_messages(
             &self,
             _guild_id: i64,
+            _channel_id: i64,
+            _query: ListGuildChannelMessagesQueryV1,
+        ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
+            Ok(ListGuildChannelMessagesResponseV1 {
+                items: vec![],
+                next_before: None,
+                next_after: None,
+                has_more: false,
+            })
+        }
+
+        async fn list_dm_channel_messages(
+            &self,
             _channel_id: i64,
             _query: ListGuildChannelMessagesQueryV1,
         ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
@@ -654,9 +679,29 @@ mod tests {
             })
         }
 
+        async fn create_dm_channel_message(
+            &self,
+            command: CreateGuildChannelMessageCommand,
+        ) -> Result<linklynx_message_domain::CreateGuildChannelMessageResult, MessageUsecaseError> {
+            self.create_guild_channel_message(command).await
+        }
+
         async fn list_guild_channel_messages(
             &self,
             _guild_id: i64,
+            _channel_id: i64,
+            _query: ListGuildChannelMessagesQueryV1,
+        ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
+            Ok(ListGuildChannelMessagesResponseV1 {
+                items: vec![],
+                next_before: None,
+                next_after: None,
+                has_more: false,
+            })
+        }
+
+        async fn list_dm_channel_messages(
+            &self,
             _channel_id: i64,
             _query: ListGuildChannelMessagesQueryV1,
         ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
@@ -723,6 +768,30 @@ mod tests {
             created[0].proposed_identity.message_id,
             created[1].proposed_identity.message_id
         );
+    }
+
+    #[tokio::test]
+    async fn create_dm_message_uses_dm_usecase_path() {
+        let usecase = Arc::new(RecordingMessageUsecase::default());
+        let service = RuntimeMessageService::new_for_test(usecase.clone());
+
+        let execution = service
+            .create_dm_channel_message(
+                PrincipalId(9003),
+                55,
+                None,
+                CreateGuildChannelMessageRequestV1 {
+                    content: "hello dm".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(execution.response.message.channel_id, 55);
+        assert_eq!(usecase.created.lock().await.len(), 0);
+        let dm_created = usecase.dm_created.lock().await;
+        assert_eq!(dm_created.len(), 1);
+        assert_eq!(dm_created[0].channel_id, 55);
     }
 
     #[tokio::test]

--- a/rust/crates/contracts/protocol-events/snapshots/message_create_event_v1.json
+++ b/rust/crates/contracts/protocol-events/snapshots/message_create_event_v1.json
@@ -1,0 +1,17 @@
+{
+  "event_id": "evt-1",
+  "type": "MessageCreated",
+  "occurred_at": "2026-03-07T10:00:01Z",
+  "ordering_key": "channel:20",
+  "message": {
+    "message_id": 200,
+    "guild_id": 10,
+    "channel_id": 20,
+    "author_id": 30,
+    "content": "hello",
+    "created_at": "2026-03-07T10:00:00Z",
+    "version": 1,
+    "edited_at": null,
+    "is_deleted": false
+  }
+}

--- a/rust/crates/contracts/protocol-events/src/lib.rs
+++ b/rust/crates/contracts/protocol-events/src/lib.rs
@@ -84,6 +84,17 @@ mod tests {
     }
 
     #[test]
+    fn event_snapshot_matches_contract_fixture() {
+        let event = MessageCreateEventV1::new("evt-1", "2026-03-07T10:00:01Z", sample_message());
+        let serialized = serde_json::to_string_pretty(&event).unwrap();
+
+        assert_eq!(
+            serialized,
+            include_str!("../snapshots/message_create_event_v1.json").trim_end()
+        );
+    }
+
+    #[test]
     fn event_serialization_keeps_message_snapshot() {
         let event = MessageCreateEventV1::new("evt-1", "2026-03-07T10:00:01Z", sample_message());
 

--- a/rust/crates/contracts/protocol-ws/snapshots/dm_message_created_frame_v1.json
+++ b/rust/crates/contracts/protocol-ws/snapshots/dm_message_created_frame_v1.json
@@ -1,0 +1,17 @@
+{
+  "type": "dm.message.created",
+  "d": {
+    "channel_id": 20,
+    "message": {
+      "message_id": 100,
+      "guild_id": 10,
+      "channel_id": 20,
+      "author_id": 30,
+      "content": "hello",
+      "created_at": "2026-03-07T10:00:00Z",
+      "version": 1,
+      "edited_at": null,
+      "is_deleted": false
+    }
+  }
+}

--- a/rust/crates/contracts/protocol-ws/snapshots/message_created_frame_v1.json
+++ b/rust/crates/contracts/protocol-ws/snapshots/message_created_frame_v1.json
@@ -1,0 +1,18 @@
+{
+  "type": "message.created",
+  "d": {
+    "guild_id": 10,
+    "channel_id": 20,
+    "message": {
+      "message_id": 100,
+      "guild_id": 10,
+      "channel_id": 20,
+      "author_id": 30,
+      "content": "hello",
+      "created_at": "2026-03-07T10:00:00Z",
+      "version": 1,
+      "edited_at": null,
+      "is_deleted": false
+    }
+  }
+}

--- a/rust/crates/contracts/protocol-ws/snapshots/message_deleted_frame_v1.json
+++ b/rust/crates/contracts/protocol-ws/snapshots/message_deleted_frame_v1.json
@@ -1,0 +1,18 @@
+{
+  "type": "message.deleted",
+  "d": {
+    "guild_id": 10,
+    "channel_id": 20,
+    "message": {
+      "message_id": 100,
+      "guild_id": 10,
+      "channel_id": 20,
+      "author_id": 30,
+      "content": "",
+      "created_at": "2026-03-07T10:00:00Z",
+      "version": 2,
+      "edited_at": "2026-03-07T10:05:00Z",
+      "is_deleted": true
+    }
+  }
+}

--- a/rust/crates/contracts/protocol-ws/src/lib.rs
+++ b/rust/crates/contracts/protocol-ws/src/lib.rs
@@ -217,6 +217,21 @@ mod tests {
     }
 
     #[test]
+    fn created_frame_snapshot_matches_contract_fixture() {
+        let frame = ServerMessageFrameV1::Created(MessageEventFrameDataV1 {
+            guild_id: 10,
+            channel_id: 20,
+            message: sample_message(),
+        });
+        let serialized = serde_json::to_string_pretty(&frame).unwrap();
+
+        assert_eq!(
+            serialized,
+            include_str!("../snapshots/message_created_frame_v1.json").trim_end()
+        );
+    }
+
+    #[test]
     fn created_frame_keeps_message_snapshot() {
         let frame = ServerMessageFrameV1::Created(MessageEventFrameDataV1 {
             guild_id: 10,
@@ -259,6 +274,41 @@ mod tests {
         assert_eq!(value["type"], "message.deleted");
         assert_eq!(value["d"]["message"]["is_deleted"], true);
         assert_eq!(value["d"]["message"]["content"], "");
+    }
+
+    #[test]
+    fn deleted_frame_matches_snapshot() {
+        let frame = ServerMessageFrameV1::Deleted(MessageEventFrameDataV1 {
+            guild_id: 10,
+            channel_id: 20,
+            message: MessageItemV1 {
+                content: String::new(),
+                version: 2,
+                edited_at: Some("2026-03-07T10:05:00Z".to_owned()),
+                is_deleted: true,
+                ..sample_message()
+            },
+        });
+        let serialized = serde_json::to_string_pretty(&frame).unwrap();
+
+        assert_eq!(
+            serialized,
+            include_str!("../snapshots/message_deleted_frame_v1.json").trim_end()
+        );
+    }
+
+    #[test]
+    fn dm_created_frame_snapshot_matches_contract_fixture() {
+        let frame = ServerMessageFrameV1::DmCreated(DmMessageEventFrameDataV1 {
+            channel_id: 20,
+            message: sample_message(),
+        });
+        let serialized = serde_json::to_string_pretty(&frame).unwrap();
+
+        assert_eq!(
+            serialized,
+            include_str!("../snapshots/dm_message_created_frame_v1.json").trim_end()
+        );
     }
 
     #[test]

--- a/rust/crates/domains/message/src/ports.rs
+++ b/rust/crates/domains/message/src/ports.rs
@@ -68,6 +68,15 @@ pub trait MessageMetadataRepository: Send + Sync {
         channel_id: i64,
     ) -> Result<Option<GuildChannelContext>, MessageUsecaseError>;
 
+    /// DM channel context を取得する。
+    /// @param channel_id 対象 channel_id
+    /// @returns DM channel context。未存在時は `None`
+    /// @throws MessageUsecaseError 依存障害時
+    async fn get_dm_channel_context(
+        &self,
+        channel_id: i64,
+    ) -> Result<Option<GuildChannelContext>, MessageUsecaseError>;
+
     /// channel_last_message を monotonic に更新する。
     /// @param channel_id 対象 channel_id
     /// @param message_id 最新 message_id

--- a/rust/crates/domains/message/src/usecase.rs
+++ b/rust/crates/domains/message/src/usecase.rs
@@ -25,6 +25,15 @@ pub trait MessageUsecase: Send + Sync {
         command: CreateGuildChannelMessageCommand,
     ) -> Result<CreateGuildChannelMessageResult, MessageUsecaseError>;
 
+    /// DM message を create する。
+    /// @param command create command
+    /// @returns 保存済み message snapshot と publish 判定
+    /// @throws MessageUsecaseError validation / not found / dependency unavailable 時
+    async fn create_dm_channel_message(
+        &self,
+        command: CreateGuildChannelMessageCommand,
+    ) -> Result<CreateGuildChannelMessageResult, MessageUsecaseError>;
+
     /// guild channel message を edit する。
     /// @param command edit command
     /// @returns 更新済み message snapshot
@@ -52,6 +61,17 @@ pub trait MessageUsecase: Send + Sync {
     async fn list_guild_channel_messages(
         &self,
         guild_id: i64,
+        channel_id: i64,
+        query: ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError>;
+
+    /// DM message history を list する。
+    /// @param channel_id 対象 channel_id
+    /// @param query list query
+    /// @returns list response
+    /// @throws MessageUsecaseError validation / not found / dependency unavailable 時
+    async fn list_dm_channel_messages(
+        &self,
         channel_id: i64,
         query: ListGuildChannelMessagesQueryV1,
     ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError>;
@@ -108,6 +128,20 @@ impl LiveMessageUsecase {
             ));
         }
         Ok(context)
+    }
+
+    /// DM channel context を取得する。
+    /// @param channel_id 対象 channel_id
+    /// @returns channel context
+    /// @throws MessageUsecaseError channel 未存在時
+    async fn load_dm_channel_context(
+        &self,
+        channel_id: i64,
+    ) -> Result<GuildChannelContext, MessageUsecaseError> {
+        self.metadata_repository
+            .get_dm_channel_context(channel_id)
+            .await?
+            .ok_or_else(|| MessageUsecaseError::channel_not_found("message_channel_not_found"))
     }
 
     async fn append_message(
@@ -188,52 +222,20 @@ impl MessageUsecase for LiveMessageUsecase {
         let context = self
             .load_channel_context(command.guild_id, command.channel_id)
             .await?;
-        let Some(idempotency) = command.idempotency.as_ref() else {
-            let message = self
-                .append_message(context.channel_id, &command.proposed_identity, &command)
-                .await?;
-            return Ok(CreateGuildChannelMessageResult {
-                message,
-                should_publish: true,
-            });
-        };
+        create_message_with_context(self, context, command).await
+    }
 
-        let reservation = self
-            .idempotency_repository
-            .reserve_guild_channel_message_create(
-                command.author_id,
-                context.channel_id,
-                idempotency,
-                &command.proposed_identity,
-            )
-            .await?;
-        match reservation {
-            MessageCreateReserveResult::PayloadMismatch => Err(MessageUsecaseError::validation(
-                "message_idempotency_payload_mismatch",
-            )),
-            MessageCreateReserveResult::Reserved(reservation) => {
-                if reservation.state == MessageCreateReservationState::Completed {
-                    return Ok(CreateGuildChannelMessageResult {
-                        message: command.to_message_item(&reservation.identity),
-                        should_publish: false,
-                    });
-                }
-                let message = self
-                    .append_message(context.channel_id, &reservation.identity, &command)
-                    .await?;
-                self.idempotency_repository
-                    .mark_guild_channel_message_create_completed(
-                        command.author_id,
-                        context.channel_id,
-                        &idempotency.key,
-                    )
-                    .await?;
-                Ok(CreateGuildChannelMessageResult {
-                    message,
-                    should_publish: true,
-                })
-            }
-        }
+    /// DM message を create する。
+    /// @param command create command
+    /// @returns 保存済み message snapshot と publish 判定
+    /// @throws MessageUsecaseError validation / not found / dependency unavailable 時
+    async fn create_dm_channel_message(
+        &self,
+        command: CreateGuildChannelMessageCommand,
+    ) -> Result<CreateGuildChannelMessageResult, MessageUsecaseError> {
+        validate_create_request(&command.to_create_request())?;
+        let context = self.load_dm_channel_context(command.channel_id).await?;
+        create_message_with_context(self, context, command).await
     }
 
     /// guild channel message を edit する。
@@ -339,6 +341,83 @@ impl MessageUsecase for LiveMessageUsecase {
             .list_guild_channel_messages(&context, &normalized)
             .await
     }
+
+    /// DM message history を list する。
+    /// @param channel_id 対象 channel_id
+    /// @param query list query
+    /// @returns list response
+    /// @throws MessageUsecaseError validation / not found / dependency unavailable 時
+    async fn list_dm_channel_messages(
+        &self,
+        channel_id: i64,
+        query: ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
+        let normalized = normalize_list_query(&query)?;
+        let context = self.load_dm_channel_context(channel_id).await?;
+        self.body_store
+            .list_guild_channel_messages(&context, &normalized)
+            .await
+    }
+}
+
+/// 解決済み channel context で message create を実行する。
+/// @param usecase live usecase
+/// @param context 解決済み channel context
+/// @param command create command
+/// @returns 保存済み message snapshot と publish 判定
+/// @throws MessageUsecaseError validation / dependency unavailable 時
+async fn create_message_with_context(
+    usecase: &LiveMessageUsecase,
+    context: GuildChannelContext,
+    command: CreateGuildChannelMessageCommand,
+) -> Result<CreateGuildChannelMessageResult, MessageUsecaseError> {
+    let Some(idempotency) = command.idempotency.as_ref() else {
+        let message = usecase
+            .append_message(context.channel_id, &command.proposed_identity, &command)
+            .await?;
+        return Ok(CreateGuildChannelMessageResult {
+            message,
+            should_publish: true,
+        });
+    };
+
+    let reservation = usecase
+        .idempotency_repository
+        .reserve_guild_channel_message_create(
+            command.author_id,
+            context.channel_id,
+            idempotency,
+            &command.proposed_identity,
+        )
+        .await?;
+    match reservation {
+        MessageCreateReserveResult::PayloadMismatch => Err(MessageUsecaseError::validation(
+            "message_idempotency_payload_mismatch",
+        )),
+        MessageCreateReserveResult::Reserved(reservation) => {
+            if reservation.state == MessageCreateReservationState::Completed {
+                return Ok(CreateGuildChannelMessageResult {
+                    message: command.to_message_item(&reservation.identity),
+                    should_publish: false,
+                });
+            }
+            let message = usecase
+                .append_message(context.channel_id, &reservation.identity, &command)
+                .await?;
+            usecase
+                .idempotency_repository
+                .mark_guild_channel_message_create_completed(
+                    command.author_id,
+                    context.channel_id,
+                    &idempotency.key,
+                )
+                .await?;
+            Ok(CreateGuildChannelMessageResult {
+                message,
+                should_publish: true,
+            })
+        }
+    }
 }
 
 /// fail-close な unavailable message usecase を表現する。
@@ -380,6 +459,13 @@ impl MessageUsecase for UnavailableMessageUsecase {
     /// @param _command edit command
     /// @returns なし
     /// @throws MessageUsecaseError 常に unavailable
+    async fn create_dm_channel_message(
+        &self,
+        _command: CreateGuildChannelMessageCommand,
+    ) -> Result<CreateGuildChannelMessageResult, MessageUsecaseError> {
+        Err(self.unavailable_error())
+    }
+
     async fn edit_guild_channel_message(
         &self,
         _command: EditGuildChannelMessageCommand,
@@ -407,6 +493,14 @@ impl MessageUsecase for UnavailableMessageUsecase {
     async fn list_guild_channel_messages(
         &self,
         _guild_id: i64,
+        _channel_id: i64,
+        _query: ListGuildChannelMessagesQueryV1,
+    ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
+        Err(self.unavailable_error())
+    }
+
+    async fn list_dm_channel_messages(
+        &self,
         _channel_id: i64,
         _query: ListGuildChannelMessagesQueryV1,
     ) -> Result<ListGuildChannelMessagesResponseV1, MessageUsecaseError> {
@@ -511,6 +605,13 @@ mod tests {
     #[async_trait]
     impl MessageMetadataRepository for FakeMetadataRepository {
         async fn get_guild_channel_context(
+            &self,
+            _channel_id: i64,
+        ) -> Result<Option<GuildChannelContext>, MessageUsecaseError> {
+            Ok(self.context.clone())
+        }
+
+        async fn get_dm_channel_context(
             &self,
             _channel_id: i64,
         ) -> Result<Option<GuildChannelContext>, MessageUsecaseError> {
@@ -667,6 +768,77 @@ mod tests {
             &[(20, 120_111, "2026-03-08T10:00:00Z".to_owned())]
         );
         assert!(idempotency.completions.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_dm_uses_dm_channel_context() {
+        let body_store = Arc::new(FakeBodyStore::default());
+        let metadata = Arc::new(FakeMetadataRepository {
+            context: Some(GuildChannelContext {
+                channel_id: 55,
+                guild_id: 55,
+                created_at: "2026-03-01T00:00:00Z".to_owned(),
+                last_message_id: None,
+                last_message_at: None,
+            }),
+            upserts: Mutex::new(vec![]),
+        });
+        let usecase = LiveMessageUsecase::new(
+            body_store.clone(),
+            metadata.clone(),
+            Arc::new(FakeIdempotencyRepository::default()),
+        );
+
+        let stored = usecase
+            .create_dm_channel_message(CreateGuildChannelMessageCommand {
+                guild_id: 55,
+                channel_id: 55,
+                author_id: 30,
+                content: "hello dm".to_owned(),
+                proposed_identity: MessageIdentity {
+                    message_id: 120_444,
+                    created_at: "2026-03-08T13:00:00Z".to_owned(),
+                },
+                idempotency: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(stored.message.guild_id, 55);
+        assert_eq!(stored.message.channel_id, 55);
+        assert_eq!(body_store.appended.lock().await[0].channel_id, 55);
+        assert_eq!(
+            metadata.upserts.lock().await.as_slice(),
+            &[(55, 120_444, "2026-03-08T13:00:00Z".to_owned())]
+        );
+    }
+
+    #[tokio::test]
+    async fn list_dm_uses_dm_channel_context() {
+        let body_store = Arc::new(FakeBodyStore::default());
+        let usecase = LiveMessageUsecase::new(
+            body_store.clone(),
+            Arc::new(FakeMetadataRepository {
+                context: Some(GuildChannelContext {
+                    channel_id: 55,
+                    guild_id: 55,
+                    created_at: "2026-03-01T00:00:00Z".to_owned(),
+                    last_message_id: None,
+                    last_message_at: None,
+                }),
+                upserts: Mutex::new(vec![]),
+            }),
+            Arc::new(FakeIdempotencyRepository::default()),
+        );
+
+        let _ = usecase
+            .list_dm_channel_messages(55, ListGuildChannelMessagesQueryV1::default())
+            .await
+            .unwrap();
+
+        let listed_queries = body_store.listed_queries.lock().await;
+        assert_eq!(listed_queries.len(), 1);
+        assert_eq!(listed_queries[0].limit, Some(50));
     }
 
     #[tokio::test]

--- a/rust/crates/platform/postgres/message/src/lib.rs
+++ b/rust/crates/platform/postgres/message/src/lib.rs
@@ -31,6 +31,21 @@ const SELECT_CHANNEL_CONTEXT_SQL: &str = "
       ON clm.channel_id = c.id
     WHERE c.id = $1
       AND c.type = 'guild_text'";
+const SELECT_DM_CHANNEL_CONTEXT_SQL: &str = "
+    SELECT
+      c.id AS channel_id,
+      c.id AS guild_id,
+      to_char(c.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS created_at,
+      clm.last_message_id,
+      CASE
+        WHEN clm.last_message_at IS NULL THEN NULL
+        ELSE to_char(clm.last_message_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"')
+      END AS last_message_at
+    FROM channels c
+    LEFT JOIN channel_last_message clm
+      ON clm.channel_id = c.id
+    WHERE c.id = $1
+      AND c.type = 'dm'";
 const UPSERT_LAST_MESSAGE_SQL: &str = "
     INSERT INTO channel_last_message (channel_id, last_message_id, last_message_at)
     VALUES ($1, $2, CAST($3 AS text)::timestamptz)
@@ -316,6 +331,31 @@ impl MessageMetadataRepository for PostgresMessageMetadataRepository {
             .transpose()
     }
 
+    /// DM channel context を取得する。
+    /// @param channel_id 対象 channel_id
+    /// @returns DM channel context。未存在時は `None`
+    /// @throws MessageUsecaseError 依存障害時
+    async fn get_dm_channel_context(
+        &self,
+        channel_id: i64,
+    ) -> Result<Option<GuildChannelContext>, MessageUsecaseError> {
+        let client = self.select_client().await?;
+        let row = match client
+            .query_opt(SELECT_DM_CHANNEL_CONTEXT_SQL, &[&channel_id])
+            .await
+        {
+            Ok(row) => row,
+            Err(error) => {
+                self.invalidate_pool().await;
+                return Err(MessageUsecaseError::dependency_unavailable(format!(
+                    "message_metadata_dm_context_query_failed:{error}"
+                )));
+            }
+        };
+        row.map(|value| self.map_channel_context_row(value))
+            .transpose()
+    }
+
     /// channel_last_message を monotonic に更新する。
     /// @param channel_id 対象 channel_id
     /// @param message_id 最新 message_id
@@ -446,13 +486,19 @@ impl MessageCreateIdempotencyRepository for PostgresMessageMetadataRepository {
 mod tests {
     use super::{
         MARK_CREATE_RESERVATION_COMPLETED_SQL, SELECT_CHANNEL_CONTEXT_SQL,
-        UPSERT_CREATE_RESERVATION_SQL, UPSERT_LAST_MESSAGE_SQL,
+        SELECT_DM_CHANNEL_CONTEXT_SQL, UPSERT_CREATE_RESERVATION_SQL, UPSERT_LAST_MESSAGE_SQL,
     };
 
     #[test]
     fn select_channel_context_sql_scopes_to_guild_text_channels() {
         assert!(SELECT_CHANNEL_CONTEXT_SQL.contains("c.type = 'guild_text'"));
         assert!(SELECT_CHANNEL_CONTEXT_SQL.contains("LEFT JOIN channel_last_message"));
+    }
+
+    #[test]
+    fn select_dm_channel_context_sql_scopes_to_dm_channels() {
+        assert!(SELECT_DM_CHANNEL_CONTEXT_SQL.contains("c.type = 'dm'"));
+        assert!(SELECT_DM_CHANNEL_CONTEXT_SQL.contains("c.id AS guild_id"));
     }
 
     #[test]


### PR DESCRIPTION
## 概要
- DM message live path の persistence/repository 未接続を解消しました
- `MessageMetadataRepository` に DM channel context 実装を追加しました
- `RuntimeMessageService` の DM create/list を dedicated DM usecase へ接続しました
- `protocol-events / protocol-ws` に snapshot fixture を追加し、additive-only regression を検知できるようにしました

## 変更理由
- LIN-932 の目的は、未接続 persistence を埋めたうえで protocol compatibility の退行検知を repo に固定することです
- event schema 自体は増やさず、既存契約の接続漏れ修正と snapshot evidence の追加に留めました

## 受け入れ条件との対応
- 永続化未接続が残らない
  - DM message path が guild-text context 流用から DM context lookup へ切り替わる
- event 互換性退行を検知できる
  - `protocol-events / protocol-ws` に snapshot fixture 比較 test を追加
- 最小受け入れテスト範囲が固定される
  - DM create path の dedicated usecase 配線 test を追加

## テスト
- `CARGO_TARGET_DIR=/home/melswonder/Documents/LinkLynx-AI/rust/target make rust-lint`
- `CARGO_TARGET_DIR=/home/melswonder/Documents/LinkLynx-AI/rust/target cargo test create_dm_message_uses_dm_usecase_path --manifest-path rust/Cargo.toml`
- `CARGO_TARGET_DIR=/home/melswonder/Documents/LinkLynx-AI/rust/target cargo test -p linklynx_protocol_events --manifest-path rust/Cargo.toml`
- `CARGO_TARGET_DIR=/home/melswonder/Documents/LinkLynx-AI/rust/target cargo test -p linklynx_protocol_ws --manifest-path rust/Cargo.toml`

## ADR-001 チェック
- Compatibility check: PASS
  - 既存 field の削除・required 化・型変更・rename はなし
- Consumer impact check: PASS
  - 既存 consumer は同一 payload shape を継続利用
- Monitoring and rollback readiness: PASS
  - snapshot fixture 差分で契約退行を検知可能
- Documentation update scope: PASS
  - run record と protocol snapshot fixture を更新
- Review record: PASS
  - additive-only のまま protocol evidence を追加

## 互換性判断
- 今回の protocol 変更は schema 追加ではなく、既存 payload の snapshot 固定のみです
- したがって compatibility decision は patch 相当の evidence 強化であり、ADR-001 の additive-only 原則に抵触しません

## バリデーション補足
- `make validate` はローカル環境の Python 依存解決で `black==24.10.0` を取得できず失敗しました
- 本 PR のコード変更起因ではありません

## スコープ外
- durable event transport/publisher の runtime wiring
- 新しい event schema の追加

## Linear
- https://linear.app/linklynx-ai/issue/LIN-932/v1rm-11-03-永続化未接続の解消と-protocol-互換性検証を完了する
