### PR TITLE
LIN-977 AUTHZ_PROVIDERのデフォルトfail-open封じを実装

### DIFF
--- a/docs/AUTHZ.md
+++ b/docs/AUTHZ.md
@@ -147,6 +147,8 @@ v0 での認可関連 SoR:
 
 - `noop allow-all` は `LIN-602` で導入する「v1非リリース期間限定の実装例外」であり、恒久契約ではない。
 - 本例外は `AUTHZ_ALLOW_ALL_UNTIL` で期限管理し、撤去条件は `LIN-629` のRunbookで固定する。
+- `AUTHZ_PROVIDER` 未設定 / 空文字 / 不明値は temporary exception に含めず、fail-close（`503` / `AUTHZ_UNAVAILABLE`）とする。
+- `AUTHZ_PROVIDER=noop` は明示指定時にのみ一時例外として有効化し、`AUTHZ_ALLOW_ALL_UNTIL` が不正または期限切れなら fail-close とする。
 - SpiceDB移植後は本節の例外は削除対象であり、fail-close契約（4.1/4.2/4.3）を唯一の運用基準とする。
 - 運用手順の詳細は `docs/runbooks/authz-noop-allow-all-spicedb-handoff-runbook.md` を参照する。
 
@@ -156,7 +158,7 @@ v0 での認可関連 SoR:
 - `Authorizer` 境界を1箇所に集約して導入する。
 - REST保護ルートとWS（接続/再認証）に同じ境界を挿入する。
 - `AUTHZ_PROVIDER=noop|spicedb` を導入する。
-- 初期は noop allow-all を有効化し、関数内部に TODO で移植先を明記する。
+- runtime default は fail-close とし、noop allow-all は明示設定された非リリース例外としてのみ有効化する。
 - deny/unavailable のマッピングをテストで固定する。
 
 ## 6. Compatibility note

--- a/docs/agent_runs/LIN-977/Documentation.md
+++ b/docs/agent_runs/LIN-977/Documentation.md
@@ -1,0 +1,61 @@
+# Documentation
+
+## Current status
+- Now: LIN-977 の実装と主要検証は完了。
+- Next: review gate 結果を確認し、必要なら追修正する。
+
+## Decisions
+- `AUTHZ_PROVIDER` 未設定は fail-close とする。
+- `noop` は明示指定された一時例外としてのみ残す。
+- `AUTHZ_ALLOW_ALL_UNTIL` は runtime で期限切れを判定する。
+- `AUTHZ_PROVIDER=spicedb` の設定不備は暗黙 fallback せず fail-close に固定する。
+
+## How to run / demo
+- `cd rust && cargo test -p linklynx_backend runtime_provider_`
+- `make rust-lint`
+- `make validate`
+
+## Known issues / follow-ups
+- live runtime smoke は `make dev` ベースの compose 起動が必要で、今回の変更では未実施。
+- `make validate` 中の Python Makefile は既存の `m` コマンド参照不備により `format/test` を実行していないが、レシピ上は `Error 127 (ignored)` として扱われる。
+
+## Validation log
+- `cd rust && cargo test -p linklynx_backend runtime_provider_ -- --nocapture`
+  - pass
+  - `runtime_provider_missing_is_fail_closed`
+  - `runtime_provider_empty_is_fail_closed`
+  - `runtime_provider_unknown_is_fail_closed`
+  - `runtime_provider_noop_allows_only_before_expiry`
+  - `runtime_provider_noop_expired_is_fail_closed`
+  - `runtime_provider_noop_invalid_expiry_is_fail_closed`
+  - `runtime_provider_spicedb_invalid_config_is_fail_closed`
+- `cd rust && cargo fmt --all`
+  - pass
+- `make rust-lint`
+  - pass
+- `cd typescript && make setup`
+  - pass
+  - `node_modules` 不在を解消するために実施
+- `make validate`
+  - pass
+  - TypeScript format/lint/test と Rust format/lint/test は完走
+  - Python Makefile の `m` コマンド参照不備は既存状態のまま `ignored` 扱い
+- `cd typescript && pnpm typecheck`
+  - pass
+- `git diff --check`
+  - pass
+
+## Review gate
+- `reviewer_simple`
+  - pass
+  - blocking finding なし
+- `reviewer_ui_guard`
+  - UI 影響なし
+  - `reviewer_ui` skip
+
+## Runtime smoke
+- 非 trivial な backend 変更だが、`make dev` ベースの live smoke は未実施
+- skip rationale:
+  - 今回の差分は runtime provider の環境変数分岐と fail-close 制御に限定される
+  - `/protected/ping` などの live check には compose 起動と手動疎通が必要
+  - 代替として workspace Rust tests と targeted runtime tests で provider 切替の挙動を固定した

--- a/docs/agent_runs/LIN-977/Implement.md
+++ b/docs/agent_runs/LIN-977/Implement.md
@@ -1,0 +1,6 @@
+# Implement
+
+- Plan.md を唯一の実行順として扱う。順序変更が必要なら `Documentation.md` に理由を残す。
+- 差分は `rust/apps/api/src/authz/` と AuthZ docs 周辺に限定し、別 issue の改善を混ぜない。
+- milestone ごとに検証を実行し、失敗したら次へ進む前に修正する。
+- `Documentation.md` に判断理由、検証結果、smoke 実施可否を逐次記録する。

--- a/docs/agent_runs/LIN-977/Plan.md
+++ b/docs/agent_runs/LIN-977/Plan.md
@@ -1,0 +1,32 @@
+# Plan
+
+## Rules
+- Stop-and-fix: validation / review 失敗時は次工程へ進まない。
+- Scope lock: LIN-977 は AuthZ runtime default provider と期限管理に限定する。
+- Start mode: child issue start (`LIN-977` under `LIN-976`)。
+
+## Milestones
+### M1: runtime provider の fail-close default を実装する
+- Acceptance criteria:
+  - [ ] `AUTHZ_PROVIDER` 未設定 / 空文字 / unknown が fail-close になる
+  - [ ] `AUTHZ_PROVIDER=spicedb` 設定不備時の fail-close を維持する
+  - [ ] `AUTHZ_PROVIDER=noop` は明示指定時のみ allow-all を有効にする
+- Validation:
+  - `cd rust && cargo test -p linklynx-api authz::tests::runtime_provider_`
+
+### M2: noop 一時例外の期限管理を固定する
+- Acceptance criteria:
+  - [ ] `AUTHZ_ALLOW_ALL_UNTIL` 期限内のみ allow-all になる
+  - [ ] 不正値または期限切れ時は fail-close になる
+  - [ ] 理由コードと運用文書が更新されている
+- Validation:
+  - `cd rust && cargo test -p linklynx-api authz::tests::runtime_provider_noop_`
+
+### M3: ドキュメント更新と全体検証を完了する
+- Acceptance criteria:
+  - [ ] `docs/AUTHZ.md` と runbook が runtime 契約に一致する
+  - [ ] review gate の blocking finding がない
+  - [ ] 検証結果を `Documentation.md` に記録する
+- Validation:
+  - `make rust-lint`
+  - `make validate`

--- a/docs/agent_runs/LIN-977/Prompt.md
+++ b/docs/agent_runs/LIN-977/Prompt.md
@@ -1,0 +1,28 @@
+# Prompt
+
+## Goals
+- `AUTHZ_PROVIDER` 未設定時に `noop allow-all` が既定で有効になる fail-open を廃止する。
+- `AUTHZ_PROVIDER=spicedb` の設定不備や初期化失敗時に暗黙 fallback せず fail-close を維持する。
+- 一時例外の `noop` は明示指定時のみ有効化し、期限管理を runtime で強制する。
+
+## Non-goals
+- moderation endpoint や rate limit の実装変更。
+- SpiceDB model / tuple sync / metrics shape の拡張。
+- AuthZ deny / unavailable の transport contract 変更。
+
+## Deliverables
+- AuthZ runtime の provider 選択ロジック修正。
+- provider 未設定 / 空文字 / unknown / noop expiry を固定する Rust テスト。
+- `docs/AUTHZ.md` と handoff runbook の契約更新。
+- LIN-977 run memory と検証ログ。
+
+## Done when
+- [ ] `AUTHZ_PROVIDER` 未設定または空文字で fail-close になる
+- [ ] `AUTHZ_PROVIDER=spicedb` の設定不備時に fail-close になる
+- [ ] `AUTHZ_PROVIDER=noop` は有効期限内のみ allow-all になる
+- [ ] 対象 Rust tests と品質ゲート結果が記録されている
+
+## Constraints
+- Perf: provider 判定に高コスト処理を入れない。
+- Security: ADR-004 fail-close baseline を破らない。
+- Compatibility: `403/503`, `AUTHZ_DENIED`, `AUTHZ_UNAVAILABLE`, WS close code は維持する。

--- a/docs/runbooks/authz-noop-allow-all-spicedb-handoff-runbook.md
+++ b/docs/runbooks/authz-noop-allow-all-spicedb-handoff-runbook.md
@@ -1,7 +1,7 @@
 # AuthZ noop allow-all Exception and SpiceDB Handoff Runbook
 
 - Status: Draft
-- Last updated: 2026-03-04
+- Last updated: 2026-03-13
 - Owner scope: v1 pre-release AuthZ exception management and SpiceDB cutover handoff
 - References:
   - [ADR-004 AuthZ Fail-Close Policy and Cache Strategy](../adr/ADR-004-authz-fail-close-and-cache-strategy.md)
@@ -27,16 +27,19 @@ Out of scope:
 
 ### 2.1 Runtime defaults
 
-- `AUTHZ_PROVIDER=noop` (default)
-- `AUTHZ_ALLOW_ALL_UNTIL=2026-06-30` (UTC date baseline)
+- `AUTHZ_PROVIDER` unset / empty / unknown => fail-close (`AUTHZ_UNAVAILABLE`)
+- `AUTHZ_PROVIDER=noop` enables the temporary allow-all exception only when explicitly set
+- `AUTHZ_ALLOW_ALL_UNTIL=2026-06-30` (UTC date baseline for explicit `noop`)
 - `AUTHZ_PROVIDER=spicedb` uses active SpiceDB authorizer path and fail-close semantics.
 - implicit fallback from `spicedb` to `noop allow-all` is prohibited.
+- if `AUTHZ_PROVIDER=noop` and `AUTHZ_ALLOW_ALL_UNTIL` is invalid or earlier than the current UTC date, runtime must fail-close.
 
 ### 2.2 Risk statement
 
 - `noop allow-all` is a fail-open exception against ADR-004 fail-close baseline.
 - This exception is permitted only in v1 non-release period.
 - Production release with allow-all active is prohibited.
+- Runtime expiry enforcement is mandatory; on and after **2026-07-01 UTC**, the baseline `2026-06-30` date must no longer activate `noop` unless a dated extension is recorded.
 
 ### 2.3 Required TODO and code boundary
 

--- a/rust/apps/api/src/authz/runtime.rs
+++ b/rust/apps/api/src/authz/runtime.rs
@@ -1,4 +1,3 @@
-const DEFAULT_AUTHZ_PROVIDER: &str = "noop";
 const DEFAULT_ALLOW_ALL_UNTIL: &str = "2026-06-30";
 const DEFAULT_SPICEDB_ENDPOINT: &str = "http://localhost:50051";
 const DEFAULT_SPICEDB_CHECK_ENDPOINT: &str = "http://localhost:8443";
@@ -94,10 +93,17 @@ pub fn build_runtime_authorizer() -> Arc<dyn Authorizer> {
         AuthzAction::Post,
         AuthzAction::Manage,
     ];
-    let provider = env::var("AUTHZ_PROVIDER")
-        .unwrap_or_else(|_| DEFAULT_AUTHZ_PROVIDER.to_owned())
-        .trim()
-        .to_ascii_lowercase();
+    let provider = match parse_runtime_provider_from_env() {
+        Ok(provider) => provider,
+        Err(reason) => {
+            warn!(
+                reason = %reason,
+                supported_action_count = supported_actions.len(),
+                "AUTHZ_PROVIDER is missing or invalid; fail-close authorizer is active"
+            );
+            return Arc::new(FailClosedAuthorizer::new(reason));
+        }
+    };
 
     let allow_all_until = env::var("AUTHZ_ALLOW_ALL_UNTIL")
         .unwrap_or_else(|_| DEFAULT_ALLOW_ALL_UNTIL.to_owned())
@@ -106,6 +112,16 @@ pub fn build_runtime_authorizer() -> Arc<dyn Authorizer> {
 
     match provider.as_str() {
         "noop" => {
+            if let Err(reason) = validate_noop_allow_all_until(&allow_all_until) {
+                warn!(
+                    provider = "noop",
+                    allow_all_until = %allow_all_until,
+                    reason = %reason,
+                    supported_action_count = supported_actions.len(),
+                    "AuthZ noop allow-all is inactive; fail-close authorizer is active"
+                );
+                return Arc::new(FailClosedAuthorizer::new(reason));
+            }
             warn!(
                 provider = "noop",
                 allow_all_until = %allow_all_until,
@@ -216,6 +232,67 @@ pub fn build_runtime_authorizer() -> Arc<dyn Authorizer> {
             )))
         }
     }
+}
+
+/// 実行時の認可プロバイダー設定を読み取る。
+/// @param なし
+/// @returns 正規化済み provider 名
+/// @throws String 未設定または空文字列時
+fn parse_runtime_provider_from_env() -> Result<String, String> {
+    match env::var("AUTHZ_PROVIDER") {
+        Ok(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                return Err("authz_provider_empty".to_owned());
+            }
+            Ok(trimmed.to_ascii_lowercase())
+        }
+        Err(_) => Err("authz_provider_missing".to_owned()),
+    }
+}
+
+/// noop allow-all 例外の期限を検証する。
+/// @param allow_all_until `YYYY-MM-DD` 形式の UTC 日付
+/// @returns 期限内なら `Ok(())`
+/// @throws String 形式不正または期限切れ時
+fn validate_noop_allow_all_until(allow_all_until: &str) -> Result<(), String> {
+    let expiry_date = parse_utc_date(allow_all_until)
+        .map_err(|reason| format!("noop_allow_all_until_invalid:{reason}"))?;
+    let today = time::OffsetDateTime::now_utc().date();
+    if today > expiry_date {
+        return Err(format!("noop_allow_all_expired:{allow_all_until}"));
+    }
+    Ok(())
+}
+
+/// `YYYY-MM-DD` 形式の日付文字列を UTC 日付として解釈する。
+/// @param value 解析対象の日付文字列
+/// @returns 解析済み UTC 日付
+/// @throws String 形式または値が不正な場合
+fn parse_utc_date(value: &str) -> Result<time::Date, String> {
+    let mut parts = value.split('-');
+    let year = parts
+        .next()
+        .ok_or_else(|| "expected YYYY-MM-DD".to_owned())?
+        .parse::<i32>()
+        .map_err(|error| format!("invalid year ({error})"))?;
+    let month = parts
+        .next()
+        .ok_or_else(|| "expected YYYY-MM-DD".to_owned())?
+        .parse::<u8>()
+        .map_err(|error| format!("invalid month ({error})"))?;
+    let day = parts
+        .next()
+        .ok_or_else(|| "expected YYYY-MM-DD".to_owned())?
+        .parse::<u8>()
+        .map_err(|error| format!("invalid day ({error})"))?;
+    if parts.next().is_some() {
+        return Err("expected YYYY-MM-DD".to_owned());
+    }
+
+    let month = time::Month::try_from(month).map_err(|error| format!("invalid month ({error})"))?;
+    time::Date::from_calendar_date(year, month, day)
+        .map_err(|error| format!("invalid calendar date ({error})"))
 }
 
 /// 必須環境変数を非空文字列として読み取る。

--- a/rust/apps/api/src/authz/tests.rs
+++ b/rust/apps/api/src/authz/tests.rs
@@ -111,11 +111,47 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn runtime_provider_default_uses_noop_allow() {
+    async fn runtime_provider_missing_is_fail_closed() {
         let _guard = env_lock().lock().await;
         let mut scoped = ScopedEnv::new();
         scoped.unset("AUTHZ_PROVIDER");
-        scoped.set("AUTHZ_ALLOW_ALL_UNTIL", "2026-06-30");
+
+        let authorizer = build_runtime_authorizer();
+        let input = AuthzCheckInput {
+            principal_id: PrincipalId(1001),
+            resource: AuthzResource::Session,
+            action: AuthzAction::Connect,
+        };
+
+        let error = authorizer.check(&input).await.unwrap_err();
+        assert_eq!(error.kind, AuthzErrorKind::DependencyUnavailable);
+        assert_eq!(error.reason, "authz_provider_missing");
+    }
+
+    #[tokio::test]
+    async fn runtime_provider_empty_is_fail_closed() {
+        let _guard = env_lock().lock().await;
+        let mut scoped = ScopedEnv::new();
+        scoped.set("AUTHZ_PROVIDER", "   ");
+
+        let authorizer = build_runtime_authorizer();
+        let input = AuthzCheckInput {
+            principal_id: PrincipalId(1001),
+            resource: AuthzResource::Session,
+            action: AuthzAction::Connect,
+        };
+
+        let error = authorizer.check(&input).await.unwrap_err();
+        assert_eq!(error.kind, AuthzErrorKind::DependencyUnavailable);
+        assert_eq!(error.reason, "authz_provider_empty");
+    }
+
+    #[tokio::test]
+    async fn runtime_provider_noop_allows_only_before_expiry() {
+        let _guard = env_lock().lock().await;
+        let mut scoped = ScopedEnv::new();
+        scoped.set("AUTHZ_PROVIDER", "noop");
+        scoped.set("AUTHZ_ALLOW_ALL_UNTIL", "2999-12-31");
 
         let authorizer = build_runtime_authorizer();
         let input = AuthzCheckInput {
@@ -125,6 +161,48 @@ mod tests {
         };
 
         assert!(authorizer.check(&input).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn runtime_provider_noop_expired_is_fail_closed() {
+        let _guard = env_lock().lock().await;
+        let mut scoped = ScopedEnv::new();
+        scoped.set("AUTHZ_PROVIDER", "noop");
+        scoped.set("AUTHZ_ALLOW_ALL_UNTIL", "2026-03-12");
+
+        let authorizer = build_runtime_authorizer();
+        let input = AuthzCheckInput {
+            principal_id: PrincipalId(1001),
+            resource: AuthzResource::Session,
+            action: AuthzAction::Connect,
+        };
+
+        let error = authorizer.check(&input).await.unwrap_err();
+        assert_eq!(error.kind, AuthzErrorKind::DependencyUnavailable);
+        assert_eq!(error.reason, "noop_allow_all_expired:2026-03-12");
+    }
+
+    #[tokio::test]
+    async fn runtime_provider_noop_invalid_expiry_is_fail_closed() {
+        let _guard = env_lock().lock().await;
+        let mut scoped = ScopedEnv::new();
+        scoped.set("AUTHZ_PROVIDER", "noop");
+        scoped.set("AUTHZ_ALLOW_ALL_UNTIL", "2026/06/30");
+
+        let authorizer = build_runtime_authorizer();
+        let input = AuthzCheckInput {
+            principal_id: PrincipalId(1001),
+            resource: AuthzResource::Session,
+            action: AuthzAction::Connect,
+        };
+
+        let error = authorizer.check(&input).await.unwrap_err();
+        assert_eq!(error.kind, AuthzErrorKind::DependencyUnavailable);
+        assert!(
+            error.reason.starts_with("noop_allow_all_until_invalid:"),
+            "unexpected reason: {}",
+            error.reason
+        );
     }
 
     #[tokio::test]
@@ -175,6 +253,33 @@ mod tests {
         assert!(
             error.contains("SPICEDB_PRESHARED_KEY is required"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_provider_spicedb_invalid_config_is_fail_closed() {
+        let _guard = env_lock().lock().await;
+        let mut scoped = ScopedEnv::new();
+        scoped.set("AUTHZ_PROVIDER", "spicedb");
+        scoped.set("SPICEDB_ENDPOINT", "http://localhost:50051");
+        scoped.set("SPICEDB_CHECK_ENDPOINT", "http://localhost:8443");
+        scoped.unset("SPICEDB_PRESHARED_KEY");
+
+        let authorizer = build_runtime_authorizer();
+        let input = AuthzCheckInput {
+            principal_id: PrincipalId(1001),
+            resource: AuthzResource::Session,
+            action: AuthzAction::Connect,
+        };
+
+        let error = authorizer.check(&input).await.unwrap_err();
+        assert_eq!(error.kind, AuthzErrorKind::DependencyUnavailable);
+        assert!(
+            error
+                .reason
+                .starts_with("spicedb_runtime_config_invalid:SPICEDB_PRESHARED_KEY is required"),
+            "unexpected reason: {}",
+            error.reason
         );
     }
 


### PR DESCRIPTION
## 概要
- `AUTHZ_PROVIDER` 未設定時に `noop allow-all` が既定選択される fail-open を廃止しました。
- `AUTHZ_PROVIDER=noop` は明示指定時のみ有効化し、`AUTHZ_ALLOW_ALL_UNTIL` の不正値・期限切れでは fail-close に落ちるようにしました。
- AuthZ 契約文書と handoff runbook を runtime baseline に合わせて更新しました。

## 変更内容
- AuthZ runtime で `AUTHZ_PROVIDER` 未設定 / 空文字を fail-close (`AUTHZ_UNAVAILABLE`) に変更
- `AUTHZ_PROVIDER=spicedb` の設定不備・初期化失敗時の fail-close を維持
- `AUTHZ_PROVIDER=noop` の有効期限判定を runtime に追加
- missing / empty / unknown / noop expiry / spicedb misconfig の回帰テストを追加
- `docs/agent_runs/LIN-977/` に run memory を追加

## 受け入れ条件との対応
- `AUTHZ_PROVIDER` 未設定時に `noop` が起動時に選択されないこと
  - runtime default を fail-close に変更し、回帰テストを追加
- `AUTHZ_PROVIDER=spicedb` かつ `SPICEDB_*` 設定不備時に fail-close authorizer が有効になること
  - runtime test を追加
- `AUTHZ_PROVIDER` 不明値時に 503 相当の制御が起き、理由がログ/エラー理由に残ること
  - 既存 fail-close 経路を維持し、unknown/missing/empty/noop expiry の reason を固定

## テスト
- `cd rust && cargo test -p linklynx_backend runtime_provider_ -- --nocapture`
  - pass
- `make rust-lint`
  - pass
- `make validate`
  - pass
  - TypeScript / Rust は完走
  - Python は既存 `python/Makefile` の `m` コマンド参照不備により `Error 127 (ignored)` のまま
- `cd typescript && pnpm typecheck`
  - pass
- `git diff --check`
  - pass

## Review
- `reviewer_simple`
  - pass（blocking finding なし）
- `reviewer_ui_guard`
  - UI 影響なし
  - `reviewer_ui` skip

## Runtime smoke
- 未実施
- 理由: 今回の差分は runtime provider 分岐と fail-close 制御に限定され、live smoke には `make dev` ベースの compose 起動と手動疎通が必要なため
- 代替: targeted runtime tests と workspace validation で provider 切替挙動を固定

## 互換性・運用影響
- 破壊的な API shape 変更はありません。
- `AUTHZ_PROVIDER` 未設定で起動していた環境は fail-close に変わるため、明示的な設定が必須になります。
- event contract は非対象のため ADR-001 チェックは対象外です。

## リンク
- Linear: https://linear.app/linklynx-ai/issue/LIN-977
