### PR TITLE
LIN-978 モデレーション PATCH を実処理へ接続

### DIFF
--- a/docs/agent_runs/LIN-978/Documentation.md
+++ b/docs/agent_runs/LIN-978/Documentation.md
@@ -1,0 +1,46 @@
+# Documentation
+
+## Current status
+- Now: LIN-978 の実装と主要検証は完了。
+- Next: PR 向けに最終検証と evidence を整理する。
+
+## Decisions
+- `PATCH /v1/moderation/guilds/{guild_id}/members/{member_id}` は v1 最小として `mute` のみ扱う。
+- request body は `reason` と `expires_at` を受ける。
+- 対象 member は guild membership で存在確認する。
+- guild 自体が存在しない場合は `guild_not_found`、guild は存在するが対象 member が未所属の場合は `member_not_found` を返す。
+
+## How to run / demo
+- `cd rust && cargo test -p linklynx_backend moderation -- --nocapture`
+- `make rust-lint`
+
+## Known issues / follow-ups
+- `ban` / `unmute` は本 issue では扱わない。
+
+## Validation log
+- `cd rust && cargo test -p linklynx_backend moderation -- --nocapture`
+  - pass
+  - PATCH success / 404 / 503 / AuthZ / rate-limit 回帰を含む
+- `cargo fmt --all`
+  - pass
+- `make rust-lint`
+  - pass
+  - workspace clippy / workspace tests を完走
+- `git diff --check`
+  - pass
+- `MODERATION_POSTGRES_INTEGRATION=1 cargo test -p linklynx_backend moderation::tests::ensure_target_member_exists -- --nocapture`
+  - not run
+  - optional integration gate として追加済みだが、この run では `MODERATION_POSTGRES_INTEGRATION` を有効化していない
+
+## Review gate
+- `reviewer_simple`
+  - pass
+  - no blocking findings
+  - follow-up 指摘だった `guild_not_found` / `member_not_found` のドキュメント差分と Postgres integration coverage を反映済み
+
+## Runtime smoke
+- 未実施
+- skip rationale:
+  - 今回の差分は backend の moderation PATCH 接続とテスト更新に限定される
+  - live smoke には `make dev` ベースの compose 起動と手動 API 疎通が必要
+  - 代替として moderation targeted tests と workspace lint/test を実施した

--- a/docs/agent_runs/LIN-978/Implement.md
+++ b/docs/agent_runs/LIN-978/Implement.md
@@ -1,0 +1,6 @@
+# Implement
+
+- Plan.md を唯一の実行順として扱う。順序変更時は `Documentation.md` に理由を残す。
+- 差分は moderation PATCH 接続と関連テストに限定し、別 issue の拡張を混ぜない。
+- milestone ごとに検証を実行し、失敗したら先へ進む前に直す。
+- `Documentation.md` に判断理由、検証結果、review / smoke の状況を更新する。

--- a/docs/agent_runs/LIN-978/Plan.md
+++ b/docs/agent_runs/LIN-978/Plan.md
@@ -1,0 +1,31 @@
+# Plan
+
+## Rules
+- Stop-and-fix: validation / review 失敗時は次工程へ進まない。
+- Scope lock: LIN-978 は v1 moderation PATCH の実処理接続に限定する。
+- Start mode: child issue start (`LIN-978` under `LIN-976`)。
+
+## Milestones
+### M1: PATCH handler を moderation service に接続する
+- Acceptance criteria:
+  - [ ] v1 PATCH がスタブではなく `create_mute` を呼ぶ
+  - [ ] request body から reason / expires_at を受け取る
+  - [ ] structured log に principal_id / guild_id / member_id / action が残る
+- Validation:
+  - `cd rust && cargo test -p linklynx_backend moderation -- --nocapture`
+
+### M2: target member not found / dependency unavailable を固定する
+- Acceptance criteria:
+  - [ ] 対象 member 未存在で `404`
+  - [ ] service unavailable で `503`
+  - [ ] role-based allow / deny の既存回帰が維持される
+- Validation:
+  - `cd rust && cargo test -p linklynx_backend moderation -- --nocapture`
+
+### M3: 全体検証と review gate を通す
+- Acceptance criteria:
+  - [ ] `make rust-lint` が通る
+  - [ ] review gate の blocking finding がない
+  - [ ] 検証結果を `Documentation.md` に記録する
+- Validation:
+  - `make rust-lint`

--- a/docs/agent_runs/LIN-978/Prompt.md
+++ b/docs/agent_runs/LIN-978/Prompt.md
@@ -1,0 +1,28 @@
+# Prompt
+
+## Goals
+- `PATCH /v1/moderation/guilds/{guild_id}/members/{member_id}` をスタブ応答から実処理へ接続する。
+- AuthZ deny / target not found / dependency unavailable の結果を既存 moderation contract に従って返す。
+- 実行者 / guild / 対象 member / action を監査しやすい形で残す。
+
+## Non-goals
+- `ban` や永続的な unmute API の追加。
+- moderation domain の大規模再設計。
+- rate limit policy や AuthZ matrix 自体の変更。
+
+## Deliverables
+- v1 moderation PATCH handler の実装。
+- target member 存在確認を含む moderation service / Postgres 振る舞いの更新。
+- PATCH 成功 / 404 / 503 の回帰テスト。
+- LIN-978 run memory と検証ログ。
+
+## Done when
+- [ ] PATCH が `create_mute` 実処理へ接続される
+- [ ] target member 未存在時に `404` になる
+- [ ] 依存障害時に `503` になる
+- [ ] structured log と検証結果が残る
+
+## Constraints
+- Perf: 既存 moderation read/write path に不要な複雑性を追加しない。
+- Security: fail-close と high-risk route の保護を崩さない。
+- Compatibility: 既存 moderation error code / status mapping を維持する。

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -210,16 +210,6 @@ struct OpenOrCreateDmRequest {
     recipient_id: i64,
 }
 
-#[derive(Debug, Serialize)]
-struct ModerationActionResponse {
-    ok: bool,
-    request_id: String,
-    principal_id: i64,
-    guild_id: i64,
-    member_id: i64,
-    action: String,
-}
-
 /// 認証済みエンドポイントの疎通応答を返す。
 /// @param auth_context 認証文脈
 /// @returns 認証済み応答
@@ -958,23 +948,82 @@ async fn open_or_create_dm(
     }
 }
 
-/// モデレーション操作の最小応答を返す。
+/// モデレーション対象メンバーへミュート操作を適用する。
+/// @param state アプリケーション状態
 /// @param path guild_id と member_id を含むパス
 /// @param auth_context 認証文脈
-/// @returns モデレーション最小応答
+/// @param payload ミュート入力
+/// @returns モデレーション結果レスポンス
 /// @throws なし
 async fn moderate_guild_member(
+    State(state): State<AppState>,
     axum::extract::Path((guild_id, member_id)): axum::extract::Path<(i64, i64)>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Json<ModerationActionResponse> {
-    Json(ModerationActionResponse {
-        ok: true,
-        request_id: auth_context.request_id,
-        principal_id: auth_context.principal_id.0,
-        guild_id,
+    payload: Result<Json<PatchModerationMemberRequest>, JsonRejection>,
+) -> Response {
+    let request_id = auth_context.request_id.clone();
+    let guild_id = match parse_moderation_guild_id(&guild_id.to_string()) {
+        Ok(value) => value,
+        Err(error) => return moderation_error_response(&error, request_id),
+    };
+    let target_user_id = match moderation::normalize_positive_id(
         member_id,
-        action: "moderate_member".to_owned(),
-    })
+        "target_user_id_must_be_positive",
+    ) {
+        Ok(value) => value,
+        Err(error) => return moderation_error_response(&error, request_id),
+    };
+    let payload = match parse_moderation_json_payload(payload) {
+        Ok(value) => value,
+        Err(error) => return moderation_error_response(&error, request_id),
+    };
+
+    tracing::info!(
+        request_id = %auth_context.request_id,
+        principal_id = auth_context.principal_id.0,
+        guild_id,
+        member_id = target_user_id,
+        action = "mute",
+        "moderation member patch request accepted"
+    );
+
+    let input = moderation::CreateModerationMuteInput {
+        guild_id,
+        target_user_id,
+        reason: payload.reason,
+        expires_at: payload.expires_at,
+    };
+
+    match state
+        .moderation_service
+        .create_mute(auth_context.principal_id, input)
+        .await
+    {
+        Ok(mute) => {
+            tracing::info!(
+                request_id = %auth_context.request_id,
+                principal_id = auth_context.principal_id.0,
+                guild_id,
+                member_id = target_user_id,
+                action = "mute",
+                "moderation member patch completed"
+            );
+            (StatusCode::OK, Json(ModerationMuteResponse { mute })).into_response()
+        }
+        Err(error) => {
+            tracing::warn!(
+                request_id = %auth_context.request_id,
+                principal_id = auth_context.principal_id.0,
+                guild_id,
+                member_id = target_user_id,
+                action = "mute",
+                error_kind = ?error.kind,
+                reason = %error.reason,
+                "moderation member patch failed"
+            );
+            moderation_error_response(&error, request_id)
+        }
+    }
 }
 
 /// 認証メトリクスを返す。
@@ -1438,6 +1487,12 @@ struct CreateModerationReportRequest {
 #[derive(Debug, Deserialize)]
 struct CreateModerationMuteRequest {
     target_user_id: i64,
+    reason: String,
+    expires_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PatchModerationMemberRequest {
     reason: String,
     expires_at: Option<String>,
 }

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -49,6 +49,7 @@ mod tests {
     use moderation::{
         CreateModerationMuteInput, CreateModerationReportInput, ModerationError, ModerationReport,
         ModerationReportStatus, ModerationService, ModerationTargetType,
+        UnavailableModerationService,
     };
     use profile::ProfileTheme;
     use profile::{
@@ -1605,12 +1606,20 @@ mod tests {
             if input.guild_id != 2001 {
                 return Err(ModerationError::not_found("guild_not_found"));
             }
-            if principal_id.0 != 1001 {
+            if principal_id.0 != 1001 && principal_id.0 != 9001 && principal_id.0 != 9002 {
                 return Err(ModerationError::forbidden("moderation_role_required"));
             }
             if input.target_user_id <= 0 {
                 return Err(ModerationError::validation(
                     "target_user_id_must_be_positive",
+                ));
+            }
+            if input.target_user_id == 4040 {
+                return Err(ModerationError::not_found("member_not_found"));
+            }
+            if input.target_user_id == 5003 {
+                return Err(ModerationError::dependency_unavailable(
+                    "moderation_store_temporarily_unavailable",
                 ));
             }
             let reason = input.reason.trim();
@@ -1857,6 +1866,7 @@ mod tests {
             Arc::new(StaticAllowAllAuthorizer),
             Arc::new(StaticProfileService),
             Arc::new(StaticInviteService),
+            Arc::new(StaticModerationService),
         )
         .await;
         app_with_state(state)
@@ -1869,6 +1879,7 @@ mod tests {
             Arc::new(StaticProfileMediaService),
             Arc::new(StaticInviteService),
             Arc::new(StaticScyllaHealthReporter { report }),
+            Arc::new(StaticModerationService),
         )
         .await;
         app_with_state(state)
@@ -1879,6 +1890,21 @@ mod tests {
             authorizer,
             Arc::new(StaticProfileService),
             Arc::new(StaticInviteService),
+            Arc::new(StaticModerationService),
+        )
+        .await;
+        app_with_state(state)
+    }
+
+    async fn app_for_test_with_authorizer_and_moderation_service(
+        authorizer: Arc<dyn Authorizer>,
+        moderation_service: Arc<dyn ModerationService>,
+    ) -> Router {
+        let state = state_for_test_with_authorizer_and_profile_and_invite(
+            authorizer,
+            Arc::new(StaticProfileService),
+            Arc::new(StaticInviteService),
+            moderation_service,
         )
         .await;
         app_with_state(state)
@@ -1897,6 +1923,7 @@ mod tests {
             authorizer,
             Arc::new(StaticProfileService),
             Arc::new(StaticInviteService),
+            Arc::new(StaticModerationService),
         )
         .await
     }
@@ -1916,6 +1943,7 @@ mod tests {
             }),
             Arc::new(StaticMessageService),
             Arc::new(StaticGuildChannelService),
+            Arc::new(StaticModerationService),
         )
         .await
     }
@@ -1924,6 +1952,7 @@ mod tests {
         authorizer: Arc<dyn Authorizer>,
         profile_service: Arc<dyn ProfileService>,
         invite_service: Arc<dyn InviteService>,
+        moderation_service: Arc<dyn ModerationService>,
     ) -> AppState {
         state_for_test_with_authorizer_profile_media_invite_scylla_and_message(
             authorizer,
@@ -1934,6 +1963,7 @@ mod tests {
                 report: ScyllaHealthReport::ready(),
             }),
             Arc::new(StaticMessageService),
+            moderation_service,
         )
         .await
     }
@@ -1944,6 +1974,7 @@ mod tests {
         profile_media_service: Arc<dyn ProfileMediaService>,
         invite_service: Arc<dyn InviteService>,
         scylla_health_reporter: Arc<dyn ScyllaHealthReporter>,
+        moderation_service: Arc<dyn ModerationService>,
     ) -> AppState {
         state_for_test_with_authorizer_profile_media_invite_scylla_and_message(
             authorizer,
@@ -1952,6 +1983,7 @@ mod tests {
             invite_service,
             scylla_health_reporter,
             Arc::new(StaticMessageService),
+            moderation_service,
         )
         .await
     }
@@ -1963,6 +1995,7 @@ mod tests {
         invite_service: Arc<dyn InviteService>,
         scylla_health_reporter: Arc<dyn ScyllaHealthReporter>,
         message_service: Arc<dyn MessageService>,
+        moderation_service: Arc<dyn ModerationService>,
     ) -> AppState {
         state_for_test_with_authorizer_profile_invite_scylla_message_and_guild_channel(
             authorizer,
@@ -1972,10 +2005,12 @@ mod tests {
             scylla_health_reporter,
             message_service,
             Arc::new(StaticGuildChannelService),
+            moderation_service,
         )
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn state_for_test_with_authorizer_profile_invite_scylla_message_and_guild_channel(
         authorizer: Arc<dyn Authorizer>,
         profile_service: Arc<dyn ProfileService>,
@@ -1984,6 +2019,7 @@ mod tests {
         scylla_health_reporter: Arc<dyn ScyllaHealthReporter>,
         message_service: Arc<dyn MessageService>,
         guild_channel_service: Arc<dyn GuildChannelService>,
+        moderation_service: Arc<dyn ModerationService>,
     ) -> AppState {
         state_for_test_with_authorizer_token_verifier_profile_invite_scylla_message_and_guild_channel(
             authorizer,
@@ -1994,6 +2030,7 @@ mod tests {
             scylla_health_reporter,
             message_service,
             guild_channel_service,
+            moderation_service,
         )
         .await
     }
@@ -2008,6 +2045,7 @@ mod tests {
         scylla_health_reporter: Arc<dyn ScyllaHealthReporter>,
         message_service: Arc<dyn MessageService>,
         guild_channel_service: Arc<dyn GuildChannelService>,
+        moderation_service: Arc<dyn ModerationService>,
     ) -> AppState {
         let metrics = Arc::new(AuthMetrics::default());
 
@@ -2041,7 +2079,7 @@ mod tests {
             invite_service,
             message_service,
             message_realtime_hub: Arc::new(MessageRealtimeHub::default()),
-            moderation_service: Arc::new(StaticModerationService),
+            moderation_service,
             profile_service,
             profile_media_service,
             user_directory_service: Arc::new(StaticUserDirectoryService),
@@ -2076,6 +2114,7 @@ mod tests {
             authorizer,
             profile_service,
             Arc::new(StaticInviteService),
+            Arc::new(StaticModerationService),
         )
         .await;
         app_with_state(state)
@@ -2094,6 +2133,7 @@ mod tests {
                 report: ScyllaHealthReport::ready(),
             }),
             message_service,
+            Arc::new(StaticModerationService),
         )
         .await;
         app_with_state(state)
@@ -2114,6 +2154,7 @@ mod tests {
             }),
             message_service,
             guild_channel_service,
+            Arc::new(StaticModerationService),
         )
         .await;
         app_with_state(state)
@@ -2132,6 +2173,7 @@ mod tests {
             Arc::new(StaticScyllaHealthReporter {
                 report: ScyllaHealthReport::ready(),
             }),
+            Arc::new(StaticModerationService),
         )
         .await;
         app_with_state(state)
@@ -2142,6 +2184,7 @@ mod tests {
             Arc::new(StaticAllowAllAuthorizer),
             Arc::new(StaticProfileService),
             invite_service,
+            Arc::new(StaticModerationService),
         )
         .await;
         app_with_state(state)
@@ -4684,6 +4727,91 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn patch_moderation_member_returns_updated_mute() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/v1/moderation/guilds/2001/members/1002")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"reason":"abuse","expires_at":"2026-04-01T00:00:00Z"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["mute"]["mute_id"], 5001);
+        assert_eq!(json["mute"]["target_user_id"], 1002);
+        assert_eq!(json["mute"]["created_by"], 1001);
+    }
+
+    #[tokio::test]
+    async fn patch_moderation_member_returns_not_found_for_unknown_member() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/v1/moderation/guilds/2001/members/4040")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"reason":"abuse"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "MODERATION_NOT_FOUND");
+    }
+
+    #[tokio::test]
+    async fn patch_moderation_member_returns_unavailable_when_service_fails_close() {
+        let app = app_for_test_with_authorizer_and_moderation_service(
+            Arc::new(StaticAllowAllAuthorizer),
+            Arc::new(UnavailableModerationService::new(
+                "moderation_store_temporarily_unavailable",
+            )),
+        )
+        .await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri("/v1/moderation/guilds/2001/members/1002")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"reason":"abuse"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "AUTHZ_UNAVAILABLE");
+    }
+
+    #[tokio::test]
     async fn ws_ticket_endpoint_returns_ticket_for_authenticated_request() {
         let app = app_for_test().await;
         let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
@@ -5963,7 +6091,8 @@ mod tests {
                     .method("PATCH")
                     .uri("/v1/moderation/guilds/10/members/9003")
                     .header("authorization", format!("Bearer {member_token}"))
-                    .body(Body::empty())
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"reason":"abuse"}"#))
                     .unwrap(),
             )
             .await
@@ -5975,9 +6104,10 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("PATCH")
-                    .uri("/v1/moderation/guilds/10/members/9003")
+                    .uri("/v1/moderation/guilds/2001/members/1002")
                     .header("authorization", format!("Bearer {admin_token}"))
-                    .body(Body::empty())
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"reason":"abuse"}"#))
                     .unwrap(),
             )
             .await
@@ -7159,7 +7289,8 @@ mod tests {
                     .uri("/v1/moderation/guilds/10/members/9003")
                     .header("authorization", format!("Bearer {token}"))
                     .header("x-request-id", "moderation-authz-unavailable-test")
-                    .body(Body::empty())
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"reason":"abuse"}"#))
                     .unwrap(),
             )
             .await
@@ -7222,7 +7353,8 @@ mod tests {
                     .method("PATCH")
                     .uri("/v1/moderation/guilds/10/members/9003")
                     .header("authorization", format!("Bearer {token}"))
-                    .body(Body::empty())
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"reason":"abuse"}"#))
                     .unwrap(),
             )
             .await

--- a/rust/apps/api/src/moderation/postgres.rs
+++ b/rust/apps/api/src/moderation/postgres.rs
@@ -323,6 +323,29 @@ impl PostgresModerationService {
         }
     }
 
+    /// 対象メンバーが guild に所属しているか確認する。
+    /// @param client Postgresクライアント
+    /// @param guild_id 対象guild_id
+    /// @param target_user_id 対象user_id
+    /// @returns なし
+    /// @throws ModerationError 未存在/依存障害時
+    async fn ensure_target_member_exists(
+        &self,
+        client: &tokio_postgres::Client,
+        guild_id: i64,
+        target_user_id: i64,
+    ) -> Result<(), ModerationError> {
+        if self.is_guild_member(client, guild_id, target_user_id).await? {
+            return Ok(());
+        }
+
+        if !self.has_guild(client, guild_id).await? {
+            return Err(ModerationError::not_found("guild_not_found"));
+        }
+
+        Err(ModerationError::not_found("member_not_found"))
+    }
+
     /// owner/admin ロール有無を確認する。
     /// @param client Postgresクライアント
     /// @param guild_id 対象guild_id
@@ -648,6 +671,8 @@ impl ModerationService for PostgresModerationService {
         let client = self.select_client().await?;
 
         self.ensure_moderator_access(&client, input.guild_id, principal_id)
+            .await?;
+        self.ensure_target_member_exists(&client, input.guild_id, target_user_id)
             .await?;
 
         let row = match client

--- a/rust/apps/api/src/moderation/tests.rs
+++ b/rust/apps/api/src/moderation/tests.rs
@@ -1,6 +1,84 @@
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{
+        env,
+        sync::atomic::{AtomicI64, Ordering},
+    };
+
+    use tokio_postgres::NoTls;
+
+    static NEXT_TEST_ID: AtomicI64 = AtomicI64::new(980_000);
+
+    fn next_test_id_block(width: i64) -> i64 {
+        NEXT_TEST_ID.fetch_add(width, Ordering::Relaxed)
+    }
+
+    fn integration_test_enabled() -> bool {
+        env::var("MODERATION_POSTGRES_INTEGRATION")
+            .ok()
+            .map(|value| {
+                matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false)
+    }
+
+    async fn connect_integration_database() -> Option<(String, tokio_postgres::Client)> {
+        if !integration_test_enabled() {
+            return None;
+        }
+
+        let database_url = env::var("DATABASE_URL")
+            .expect("MODERATION_POSTGRES_INTEGRATION requires DATABASE_URL to be set");
+        let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+            .await
+            .expect("failed to connect integration postgres");
+        tokio::spawn(async move {
+            if let Err(error) = connection.await {
+                panic!("moderation integration postgres connection failed: {error}");
+            }
+        });
+
+        Some((database_url, client))
+    }
+
+    async fn seed_user(client: &tokio_postgres::Client, user_id: i64, label: &str) {
+        client
+            .execute(
+                "INSERT INTO users (id, email, display_name, theme)
+                 VALUES ($1, $2, $3, 'dark')
+                 ON CONFLICT (id)
+                 DO UPDATE SET
+                   email = EXCLUDED.email,
+                   display_name = EXCLUDED.display_name,
+                   theme = EXCLUDED.theme",
+                &[
+                    &user_id,
+                    &format!("{label}-{user_id}@example.com"),
+                    &format!("{label}-{user_id}"),
+                ],
+            )
+            .await
+            .expect("failed to seed user");
+    }
+
+    async fn seed_guild(client: &tokio_postgres::Client, guild_id: i64, owner_id: i64) {
+        client
+            .execute(
+                "INSERT INTO guilds (id, name, owner_id)
+                 VALUES ($1, $2, $3)
+                 ON CONFLICT (id)
+                 DO UPDATE SET
+                   name = EXCLUDED.name,
+                   owner_id = EXCLUDED.owner_id",
+                &[&guild_id, &format!("Guild {guild_id}"), &owner_id],
+            )
+            .await
+            .expect("failed to seed guild");
+    }
 
     #[test]
     fn moderation_error_forbidden_maps_to_authz_contract() {
@@ -68,6 +146,58 @@ mod tests {
                 kind: ModerationErrorKind::Validation,
                 reason,
             }) if reason == "report_id_must_be_positive"
+        ));
+    }
+
+    #[tokio::test]
+    async fn ensure_target_member_exists_returns_guild_not_found_for_missing_guild() {
+        let Some((database_url, client)) = connect_integration_database().await else {
+            return;
+        };
+
+        let service = PostgresModerationService::new(database_url, true);
+        let base_id = next_test_id_block(10);
+        let target_user_id = base_id + 1;
+        seed_user(&client, target_user_id, "moderation-target").await;
+
+        let result = service
+            .ensure_target_member_exists(&client, base_id + 2, target_user_id)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ModerationError {
+                kind: ModerationErrorKind::NotFound,
+                reason,
+            }) if reason == "guild_not_found"
+        ));
+    }
+
+    #[tokio::test]
+    async fn ensure_target_member_exists_returns_member_not_found_for_non_member() {
+        let Some((database_url, client)) = connect_integration_database().await else {
+            return;
+        };
+
+        let service = PostgresModerationService::new(database_url, true);
+        let base_id = next_test_id_block(10);
+        let owner_id = base_id;
+        let target_user_id = base_id + 1;
+        let guild_id = base_id + 2;
+        seed_user(&client, owner_id, "moderation-owner").await;
+        seed_user(&client, target_user_id, "moderation-target").await;
+        seed_guild(&client, guild_id, owner_id).await;
+
+        let result = service
+            .ensure_target_member_exists(&client, guild_id, target_user_id)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ModerationError {
+                kind: ModerationErrorKind::NotFound,
+                reason,
+            }) if reason == "member_not_found"
         ));
     }
 }


### PR DESCRIPTION
## 概要
- `PATCH /v1/moderation/guilds/{guild_id}/members/{member_id}` をスタブ応答から `create_mute` 実処理へ接続
- `reason` / `expires_at` を受け取り、success / not found / unavailable を既存 moderation contract で返すよう更新
- target member 存在確認の Postgres 分岐テストと run memory を追加

## 変更内容
- handler で guild/member/payload を検証し、structured log を残したうえで `moderation_service.create_mute` を呼ぶよう変更
- Postgres moderation service に target member 存在確認を追加し、guild 未存在時は `guild_not_found`、guild 存在かつ未所属時は `member_not_found` を返すよう整理
- main route tests に PATCH success / 404 / 503 回帰を追加し、moderation tests に Postgres integration 向け helper coverage を追加
- `docs/agent_runs/LIN-978/` に Prompt / Plan / Implement / Documentation を記録

## 受け入れ条件
- [x] PATCH が `create_mute` 実処理へ接続される
- [x] target member 未存在時に `404` を返す
- [x] 依存障害時に `503` を返す
- [x] structured log と検証結果を残す

## 検証
- [x] `cd rust && cargo test -p linklynx_backend moderation -- --nocapture`
- [x] `make rust-lint`
- [x] `make validate`
- [x] `git diff --check`
- [ ] `MODERATION_POSTGRES_INTEGRATION=1 cargo test -p linklynx_backend moderation::tests::ensure_target_member_exists -- --nocapture`
  - optional integration gate を追加済みだが、この run では環境変数未設定のため未実施

## Review
- [x] `reviewer_simple`
  - blocking finding なし

## Runtime smoke
- 未実施
- 理由: backend の moderation PATCH 接続とテスト更新に限定した差分で、代替として targeted tests と workspace validation を実施済み

## Linear
- https://linear.app/linklynx-ai/issue/LIN-978
