### PR TITLE
LIN-979 モデレーション境界のログと文書を再整合

### DIFF
--- a/docs/AUTHZ_API_MATRIX.md
+++ b/docs/AUTHZ_API_MATRIX.md
@@ -109,7 +109,7 @@
 | REST | `GET /v1/dms/:channel_id` | AuthN済み `principal_id` | `AuthzResource::Channel { channel_id }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
 | REST | `GET /v1/dms/:channel_id/messages` | AuthN済み `principal_id` | `AuthzResource::Channel { channel_id }` | `View` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
 | REST | `POST /v1/dms/:channel_id/messages` | AuthN済み `principal_id` | `AuthzResource::Channel { channel_id }` | `Post` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
-| REST | `PATCH /v1/moderation/guilds/:guild_id/members/:member_id` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE` |
+| REST | `PATCH /v1/moderation/guilds/:guild_id/members/:member_id` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | deny=`403/AUTHZ_DENIED`, unavailable=`503/AUTHZ_UNAVAILABLE`。rate limit は `RestRateLimitAction::ModerationAction` を適用し、Dragonfly degraded 時は `429` fail-close |
 | WS | `/ws` handshake | AuthN済み `principal_id` | `AuthzResource::Session` | `Connect` | deny=`1008`, unavailable=`1011` |
 | WS | `auth.reauthenticate` | AuthN済み `principal_id` | `AuthzResource::Session` | `Connect` | deny=`1008`, unavailable=`1011` |
 | WS | stream text/binary message | AuthN済み `principal_id` | `AuthzResource::RestPath { path: "/ws/stream" }` | `View` | deny=`1008`, unavailable=`1011` |
@@ -140,3 +140,4 @@
 - `LIN-925` は permission snapshot 契約と取得I/F の固定までを扱う。snapshot を使った FE ActionGuard 反映は `LIN-926` で扱う。
 - `LIN-862` 以降は本マトリクスを入力に SpiceDB スキーマ・Tuple写像を設計する。
 - `LIN-868` では本マトリクスの allow/deny/unavailable 回帰をCIで検知できるよう統合テストを維持する。
+- `LIN-979` で moderation high-risk route の拒否/制限ログへ `reason`、`principal_id`、`guild_id`（必要に応じて `channel_id`）を残す実装へ再整合した。

--- a/docs/agent_runs/LIN-979/Documentation.md
+++ b/docs/agent_runs/LIN-979/Documentation.md
@@ -1,0 +1,43 @@
+# Documentation
+
+## Current status
+- Now: LIN-979 の実装と検証は完了。
+- Next: reviewer gate の最終結果を反映して PR を作成する。
+
+## Decisions
+- moderation / permission-snapshot / DM を横断する reject log scope は REST path から抽出する。
+- moderation PATCH は AuthZ 上 `Guild + Manage`、rate-limit 上 `ModerationAction` の high-risk fail-close として扱う。
+- reject log は `reason`、`principal_id`、`guild_id` を必須にし、取得できる場合は `channel_id` も残す。
+
+## How to run / demo
+- `cd rust && cargo test -p linklynx_backend moderation -- --nocapture`
+- `cd rust && cargo test -p linklynx_backend rest_request_scope_maps_moderation_permission_snapshot_and_dm_paths -- --nocapture`
+- `make rust-lint`
+
+## Known issues / follow-ups
+- moderation PATCH の実処理接続自体は `LIN-978` の責務。
+- runtime smoke は API 実装変更が middleware/logging 中心のため、今回は skip 候補。
+
+## Validation log
+- `cd rust && cargo test -p linklynx_backend moderation -- --nocapture`
+  - pass
+  - moderation route の AuthZ / rate-limit / scope helper 回帰を含む
+- `cd rust && cargo test -p linklynx_backend rest_request_scope_maps_moderation_permission_snapshot_and_dm_paths -- --nocapture`
+  - pass
+- `make rust-lint`
+  - pass
+- `make validate`
+  - pass
+  - Python の `m` コマンド未導入による `Error 127 (ignored)` は既存 `python/Makefile` 由来で今回差分起因ではない
+- `git diff --check`
+  - pass
+
+## Review gate
+- `reviewer_simple`
+  - pending
+
+## Runtime smoke
+- 未実施
+- skip rationale:
+  - 差分は shared REST middleware の logging scope と文書更新に限定される
+  - 代替として moderation targeted tests と workspace validation を実施した

--- a/docs/agent_runs/LIN-979/Implement.md
+++ b/docs/agent_runs/LIN-979/Implement.md
@@ -1,0 +1,6 @@
+# Implement
+
+- `Plan.md` の milestone 順に進め、shared middleware のみを最小変更で更新する。
+- log scope は既存 path parser を再利用し、reject log へ `guild_id` / `channel_id` を載せる。
+- 文書は current implementation を説明する粒度に留め、将来構想は書かない。
+- 検証結果と reviewer 結果は `Documentation.md` に集約する。

--- a/docs/agent_runs/LIN-979/Plan.md
+++ b/docs/agent_runs/LIN-979/Plan.md
@@ -1,0 +1,30 @@
+# Plan
+
+## Rules
+- Stop-and-fix: validation / review 失敗時は先へ進まない。
+- Scope lock: moderation boundary の再整合に限定し、実処理接続や permission-snapshot の新挙動は入れない。
+- Start mode: child issue start (`LIN-979` under `LIN-976`)。
+
+## Milestones
+### M1: request scope と reject log を再整合する
+- Acceptance criteria:
+  - [ ] REST middleware の rate-limit / authz reject log に `guild_id` / `channel_id` が補完される
+  - [ ] moderation path で `guild_id` が抽出される
+- Validation:
+  - `cd rust && cargo test -p linklynx_backend rest_authz_resource_maps_invite_dm_and_moderation_paths rest_request_scope_maps_moderation_permission_snapshot_and_dm_paths -- --nocapture`
+
+### M2: matrix と runbook を current implementation に合わせる
+- Acceptance criteria:
+  - [ ] moderation PATCH の AuthZ/resource/action と fail-close rate limit が文書で明示される
+  - [ ] required reject log fields が runbook に入る
+- Validation:
+  - doc diff review
+
+### M3: 全体検証と review gate を通す
+- Acceptance criteria:
+  - [ ] `make rust-lint` が通る
+  - [ ] `make validate` が通る
+  - [ ] reviewer gate に blocking finding がない
+- Validation:
+  - `make rust-lint`
+  - `make validate`

--- a/docs/agent_runs/LIN-979/Prompt.md
+++ b/docs/agent_runs/LIN-979/Prompt.md
@@ -1,0 +1,26 @@
+# Prompt
+
+## Goals
+- moderation v1 route の AuthZ matrix / Dragonfly rate-limit 境界を実装と文書で再整合する。
+- `PATCH /v1/moderation/guilds/{guild_id}/members/{member_id}` の拒否/制限ログに追跡可能な scope を残す。
+- moderation と permission-snapshot を含む request scope 抽出をテストで固定する。
+
+## Non-goals
+- moderation PATCH の実処理接続そのもの。
+- Dragonfly provider 実装や threshold の再設計。
+- 新しい rate-limit action や AuthZ action の追加。
+
+## Deliverables
+- REST middleware の reject log scope 追加。
+- request scope / moderation matrix の回帰テスト。
+- `docs/AUTHZ_API_MATRIX.md` と Dragonfly runbook の整合更新。
+- LIN-979 run memory。
+
+## Done when
+- [ ] moderation route の AuthZ/resource/action と request scope がテストで固定される
+- [ ] moderation fail-close rate limit の理由コードと required log fields が文書化される
+- [ ] reject log に `reason` / `principal_id` / `guild_id` が残る実装になる
+
+## Constraints
+- ADR-004 fail-close と ADR-005 hybrid policy を崩さない。
+- scope は moderation / permission snapshot / shared REST middleware に限定する。

--- a/docs/runbooks/dragonfly-ratelimit-operations-runbook.md
+++ b/docs/runbooks/dragonfly-ratelimit-operations-runbook.md
@@ -46,6 +46,16 @@ Out of scope:
 | `POST /v1/guilds/{guild_id}/channels/{channel_id}/messages` | `core write path` | degraded fail-open (L1 only) |
 | `POST /v1/dms/{channel_id}/messages` | `core write path` | degraded fail-open (L1 only) |
 
+## 3.1 Implementation alignment
+
+| route surface | rate-limit action | deny / limited reason | required reject log fields |
+| --- | --- | --- | --- |
+| `GET /v1/guilds/{guild_id}/invites/{invite_code}` | `InviteAccess` | `rate_limit_exceeded` / `dragonfly_degraded_fail_close` | `request_id`, `reason`, `principal_id?`, `guild_id`, `resource`, `action`, `decision_source` |
+| `POST /v1/invites/{invite_code}/join` | `InviteAccess` | `rate_limit_exceeded` / `dragonfly_degraded_fail_close` | `request_id`, `reason`, `principal_id`, `resource`, `action`, `decision_source` |
+| `PATCH /v1/moderation/guilds/{guild_id}/members/{member_id}` | `ModerationAction` | `rate_limit_exceeded` / `dragonfly_degraded_fail_close` | `request_id`, `reason`, `principal_id`, `guild_id`, `resource`, `action`, `decision_source` |
+| `POST /v1/guilds/{guild_id}/channels/{channel_id}/messages` | `MessageCreate` | `rate_limit_exceeded` only after L1 exhaustion | `request_id`, `reason`, `principal_id`, `guild_id`, `channel_id`, `resource`, `action`, `decision_source` |
+| `POST /v1/dms/{channel_id}/messages` | `MessageCreate` | `rate_limit_exceeded` only after L1 exhaustion | `request_id`, `reason`, `principal_id`, `channel_id`, `resource`, `action`, `decision_source` |
+
 ## 4. Exposure boundary
 
 - No public or protected REST endpoint is exposed to mutate degraded state.

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -2736,6 +2736,7 @@ async fn rest_auth_middleware(
     let request_id = request_id_from_headers(request.headers());
     let request_method = request.method().clone();
     let request_path = request.uri().path().to_owned();
+    let request_scope = rest_request_scope_from_path(&request_path);
 
     let token = match bearer_token_from_headers(request.headers()) {
         Ok(token) => token,
@@ -2803,6 +2804,8 @@ async fn rest_auth_middleware(
                 principal_id = authenticated.principal_id.0,
                 error_class = error_class,
                 reason = reason,
+                guild_id = request_scope.guild_id,
+                channel_id = request_scope.channel_id,
                 resource = %request_path,
                 action = decision.action().label(),
                 operation_class = ?decision.operation_class(),
@@ -2839,6 +2842,8 @@ async fn rest_auth_middleware(
             principal_id = authenticated.principal_id.0,
             error_class = %error.log_class(),
             reason = %error.reason,
+            guild_id = request_scope.guild_id,
+            channel_id = request_scope.channel_id,
             resource = %request_path,
             action = action_label,
             decision_source = "authorizer",
@@ -2911,6 +2916,54 @@ fn rest_authz_resource_from_path(path: &str) -> AuthzResource {
     }
     AuthzResource::RestPath {
         path: path.to_owned(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RestRequestScope {
+    guild_id: Option<i64>,
+    channel_id: Option<i64>,
+}
+
+/// RESTパスから監査用の scope 情報を抽出する。
+/// @param path リクエストパス
+/// @returns guild/channel scope
+/// @throws なし
+fn rest_request_scope_from_path(path: &str) -> RestRequestScope {
+    if let Some((guild_id, channel_id)) = parse_guild_channel_path(path) {
+        return RestRequestScope {
+            guild_id: Some(guild_id),
+            channel_id: Some(channel_id),
+        };
+    }
+    if let Some(channel_id) = parse_dm_channel_path(path) {
+        return RestRequestScope {
+            guild_id: None,
+            channel_id: Some(channel_id),
+        };
+    }
+    if let Some(guild_id) = parse_guild_invite_path(path) {
+        return RestRequestScope {
+            guild_id: Some(guild_id),
+            channel_id: None,
+        };
+    }
+    if let Some(guild_id) = parse_moderation_guild_path(path) {
+        return RestRequestScope {
+            guild_id: Some(guild_id),
+            channel_id: None,
+        };
+    }
+    if let Some(guild_id) = parse_guild_path(path) {
+        return RestRequestScope {
+            guild_id: Some(guild_id),
+            channel_id: None,
+        };
+    }
+
+    RestRequestScope {
+        guild_id: None,
+        channel_id: None,
     }
 }
 

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -7321,6 +7321,31 @@ mod tests {
     }
 
     #[test]
+    fn rest_request_scope_maps_moderation_permission_snapshot_and_dm_paths() {
+        assert_eq!(
+            rest_request_scope_from_path("/v1/moderation/guilds/10/members/9003"),
+            RestRequestScope {
+                guild_id: Some(10),
+                channel_id: None,
+            }
+        );
+        assert_eq!(
+            rest_request_scope_from_path("/guilds/10/permission-snapshot"),
+            RestRequestScope {
+                guild_id: Some(10),
+                channel_id: None,
+            }
+        );
+        assert_eq!(
+            rest_request_scope_from_path("/v1/dms/55/messages"),
+            RestRequestScope {
+                guild_id: None,
+                channel_id: Some(55),
+            }
+        );
+    }
+
+    #[test]
     fn rest_authz_action_maps_internal_cache_invalidation_post_to_view() {
         assert!(matches!(
             rest_authz_action_for_request(&Method::POST, "/internal/authz/cache/invalidate"),


### PR DESCRIPTION
## 概要
- moderation / permission-snapshot / DM の request scope を REST path から抽出し、reject log に `guild_id` / `channel_id` を補完
- moderation PATCH の AuthZ matrix と Dragonfly rate-limit runbook を current implementation に合わせて更新
- moderation boundary の回帰テストと run memory を追加

## 変更内容
- `rest_auth_middleware` の rate-limit / authz reject log に request scope を追加し、moderation route で `reason` / `principal_id` / `guild_id` を追跡できるようにした
- `rest_request_scope_from_path` を追加し、moderation・permission-snapshot・DM path の scope 抽出を unit test で固定
- `docs/AUTHZ_API_MATRIX.md` に moderation PATCH の `Guild + Manage` / `ModerationAction` fail-close 契約を追記
- `docs/runbooks/dragonfly-ratelimit-operations-runbook.md` に route ごとの rate-limit action / reason / required reject log fields の突合表を追加
- `docs/agent_runs/LIN-979/` に Prompt / Plan / Implement / Documentation を記録

## 受け入れ条件
- [x] moderation ルートで AuthZ matrix の action/resource 判定がテストで担保される
- [x] moderation ルートのレート制限が high-risk 設定（fail-close）と一致する
- [x] 拒否/制限時ログに `reason`、`principal_id`、`guild_id` が残る実装になっている

## 検証
- [x] `cd rust && cargo test -p linklynx_backend moderation -- --nocapture`
- [x] `cd rust && cargo test -p linklynx_backend rest_request_scope_maps_moderation_permission_snapshot_and_dm_paths -- --nocapture`
- [x] `make rust-lint`
- [x] `make validate`
- [x] `git diff --check`

## Review
- [ ] `reviewer_simple`
  - この run では subagent 応答を回収できず pending
  - 差分自体の local validation / self-review では blocking issue は未検出

## Runtime smoke
- 未実施
- 理由: shared REST middleware の logging scope と文書更新が中心の差分で、代替として moderation targeted tests と workspace validation を実施済み

## 備考
- `make validate` 中の Python `m` コマンド未導入による `Error 127 (ignored)` は既存 `python/Makefile` 由来で、今回差分起因ではありません

## Linear
- https://linear.app/linklynx-ai/issue/LIN-979
