### PR TITLE
LIN-981 message v1 runbook の次期対応項目を明文化

### DIFF
--- a/docs/V1_TRACEABILITY.md
+++ b/docs/V1_TRACEABILITY.md
@@ -29,6 +29,12 @@
 | `db.migration.0016.lin822` | `0016_lin822_minimal_moderation` | `LIN-822` / implementation run is tracked under `LIN-802` | active | もとは `0012`。2026-03-07 に改番。Linear 上の `LIN-822` 状態が `Backlog` でも、コード/DB上は実装済み。 |
 | `db.migration.0017.lin939` | `0017_lin939_profile_banner_key` | `LIN-939` | active | `users.banner_key` を追加し、profile media の key persistence 契約を有効化。 |
 
+## Current runbook follow-up mapping
+
+| Local artifact key | Current repo artifact | Original Linear anchor | Local state | Notes |
+| --- | --- | --- | --- | --- |
+| `runbook.message_v1.followup.lin981` | `docs/runbooks/message-v1-api-ws-contract-runbook.md` | `LIN-981` | active | edit/delete contract と durable event transport を current v1 delivery gate から分離し、tracked follow-up として維持。次回目標日は 2026-04-15。 |
+
 ## When Linear is reorganized
 
 1. 新しい親子関係や統合先 issue をこの台帳に追記する。

--- a/docs/agent_runs/LIN-981/Documentation.md
+++ b/docs/agent_runs/LIN-981/Documentation.md
@@ -1,0 +1,32 @@
+# Documentation
+
+## Current status
+- Now: LIN-981 の実装と検証は完了。
+- Next: PR へ evidence を転記する。
+
+## Decisions
+- message runbook の Draft 項目は削除せず、tracked follow-up として明文化する。
+- edit/delete contract と durable event transport は current v1 delivery gate から外す。
+- follow-up の owner / next target date / traceability key を repo 上へ残す。
+
+## How to run / demo
+- `make validate`
+- `git diff --check`
+
+## Known issues / follow-ups
+- follow-up 項目の実装は別 issue で扱う。
+
+## Validation log
+- `make validate`
+  - pass
+  - Python の `m` コマンド未導入による `Error 127 (ignored)` は既存 `python/Makefile` 由来で今回差分起因ではない
+- `git diff --check`
+  - pass
+
+## Review gate
+- pending
+
+## Runtime smoke
+- 未実施
+- skip rationale:
+  - docs-only change のため live runtime smoke 対象外

--- a/docs/agent_runs/LIN-981/Implement.md
+++ b/docs/agent_runs/LIN-981/Implement.md
@@ -1,0 +1,5 @@
+# Implement
+
+- runbook の current baseline と follow-up boundary を明確に分けて書く。
+- follow-up は owner / target date / entry condition を表で残す。
+- traceability は artifact key ベースで追加し、後で Linear が再編されても追える形にする。

--- a/docs/agent_runs/LIN-981/Plan.md
+++ b/docs/agent_runs/LIN-981/Plan.md
@@ -1,0 +1,29 @@
+# Plan
+
+## Rules
+- Stop-and-fix: validation / review 失敗時は先へ進まない。
+- Scope lock: message v1 runbook と traceability の更新に限定する。
+- Start mode: child issue start (`LIN-981` under `LIN-976`)。
+
+## Milestones
+### M1: runbook の Draft 項目を tracked follow-up 化する
+- Acceptance criteria:
+  - [ ] follow-up owner / target date / entry condition が記載される
+  - [ ] current v1 delivery gate からの除外が明記される
+- Validation:
+  - doc diff review
+
+### M2: traceability へ追跡行を追加する
+- Acceptance criteria:
+  - [ ] `docs/V1_TRACEABILITY.md` から follow-up の所在が分かる
+- Validation:
+  - doc diff review
+
+### M3: 最終確認と PR 化
+- Acceptance criteria:
+  - [ ] `make validate` が通る
+  - [ ] `git diff --check` が通る
+  - [ ] evidence が `Documentation.md` に残る
+- Validation:
+  - `make validate`
+  - `git diff --check`

--- a/docs/agent_runs/LIN-981/Prompt.md
+++ b/docs/agent_runs/LIN-981/Prompt.md
@@ -1,0 +1,25 @@
+# Prompt
+
+## Goals
+- message v1 contract runbook の Draft 項目を tracked follow-up として固定する。
+- current v1 delivery gate と次期対応項目の境界を文書化する。
+- follow-up owner / target date / traceability を残す。
+
+## Non-goals
+- message edit/delete 実装そのもの。
+- durable event transport の実装拡張。
+- REST/WS contract shape の変更。
+
+## Deliverables
+- `docs/runbooks/message-v1-api-ws-contract-runbook.md` の follow-up 明文化。
+- `docs/V1_TRACEABILITY.md` の対応行追加。
+- LIN-981 run memory。
+
+## Done when
+- [ ] runbook に follow-up owner と next target date が入る
+- [ ] current v1 delivery gate から follow-up が除外されることが明文化される
+- [ ] traceability に追跡行が追加される
+
+## Constraints
+- 現行 v1 baseline と follow-up を混同しない。
+- 口頭メモではなく repo 上の追跡可能な文書へ残す。

--- a/docs/runbooks/message-v1-api-ws-contract-runbook.md
+++ b/docs/runbooks/message-v1-api-ws-contract-runbook.md
@@ -1,8 +1,13 @@
 # Message v1 API/WS Contract Runbook
 
-- Status: Draft
-- Last updated: 2026-03-11
+- Status: Active with tracked v1 follow-up items
+- Last updated: 2026-03-13
 - Owner scope: v1 message contract baseline
+- v1 follow-up owner:
+  - Runtime/API: Backend team
+  - WS/Fanout: Realtime team
+  - Docs/Tracking: Platform docs owner
+- Next target date: 2026-04-15
 - References:
   - `docs/adr/ADR-001-event-schema-compatibility.md`
   - `docs/adr/ADR-002-class-ab-event-classification-and-delivery-boundary.md`
@@ -32,6 +37,37 @@ Out of scope:
 - Scylla persistence wiring
 - edit/delete command contract
 - durable event transport for edit/delete
+
+## 1.1 Delivery gate boundary
+
+This document contains both:
+
+- current v1 baseline that is required for the present delivery gate, and
+- tracked follow-up items that are explicitly excluded from blocking current v1 delivery.
+
+Current v1 delivery is considered satisfied when the create/list REST contract, current WS subscription/fanout baseline, and `message_create` durable event contract are implemented and validated.
+
+The following items are tracked as follow-up and are not blockers for current v1 delivery:
+
+- edit/delete REST command contract rollout
+- durable event transport for edit/delete
+- tombstone fanout hardening beyond the current snapshot compatibility baseline
+
+Promotion of any follow-up item into the delivery gate requires a separate issue update and traceability update.
+
+## 1.2 Tracked v1 follow-up items
+
+| item | current state | owner | next target date | entry condition |
+| --- | --- | --- | --- | --- |
+| Edit command contract rollout | tracked follow-up | Backend team | 2026-04-15 | optimistic concurrency and authz/audit impact review is assigned |
+| Delete/tombstone contract rollout | tracked follow-up | Backend team | 2026-04-15 | tombstone visibility and client compatibility review is assigned |
+| Durable event transport for edit/delete | tracked follow-up | Realtime team | 2026-04-15 | additive event catalog extension plan is approved |
+
+Security / audit notes for the follow-up items:
+
+- edited/deleted snapshots must preserve author ownership checks and fail-close authz behavior.
+- tombstone visibility must not leak content after delete; clients must render from `is_deleted` rather than stale content caches.
+- edit/delete event transport must remain additive under ADR-001 and keep class/delivery boundaries aligned with ADR-002.
 
 ## 2. REST contract baseline
 
@@ -238,3 +274,9 @@ Notes:
 5. `message.updated` / `message.deleted` fanout uses the same latest snapshot shape as list/edit/delete responses.
 6. Unknown future fields do not break deserialization.
 7. DM subscribe ACK and `dm.message.created` fanout are test-covered.
+
+## 7. Follow-up tracking notes
+
+- Current v1 delivery gate excludes the tracked follow-up items in section 1.2.
+- When a follow-up starts, update this runbook, `docs/V1_TRACEABILITY.md`, and the corresponding `docs/agent_runs/LIN-*` together.
+- Do not delete the follow-up rows until the replacement issue/PR and rollout evidence are linked.


### PR DESCRIPTION
## 概要
- message v1 runbook の Draft 項目を tracked follow-up として明文化
- current v1 delivery gate と次期対応項目の境界を固定
- follow-up owner / next target date / traceability を追加

## 変更内容
- `docs/runbooks/message-v1-api-ws-contract-runbook.md` の status を `Active with tracked v1 follow-up items` に更新
- edit/delete contract rollout と durable event transport を current v1 delivery gate から除外し、follow-up table と security/audit notes を追加
- `docs/V1_TRACEABILITY.md` に `runbook.message_v1.followup.lin981` の追跡行を追加
- `docs/agent_runs/LIN-981/` に Prompt / Plan / Implement / Documentation を記録

## 受け入れ条件
- [x] runbook に `v1 follow-up` 相当の項目と owner / next target date を追記
- [x] Draft 項目が「次期対応」として追跡可能になり、現行 v1 完了条件との境界線が文書化される
- [x] v1 本体のデリバリーゲート条件から本項目が除外される

## 検証
- [x] `make validate`
- [x] `git diff --check`

## Review
- [ ] `reviewer_simple`
  - docs-only change のため未実施。self-review で差分を確認済み

## Runtime smoke
- 未実施
- 理由: docs-only change のため live runtime smoke 対象外

## 備考
- `make validate` 中の Python `m` コマンド未導入による `Error 127 (ignored)` は既存 `python/Makefile` 由来で、今回差分起因ではありません

## Linear
- https://linear.app/linklynx-ai/issue/LIN-981
