### PR TITLE
LIN-987 profile media signed URL に abuse guard を追加

### DIFF
--- a/database/contracts/lin939_profile_media_gcs_contract.md
+++ b/database/contracts/lin939_profile_media_gcs_contract.md
@@ -58,6 +58,7 @@ v0/tenant/default/user/{user_id}/profile/{avatar|banner}/asset/{asset_id}/{filen
 3. `POST /users/me/profile/media/upload-url` issues a key and signed upload URL, but does not persist the key.
 4. `PATCH /users/me/profile` is the only API that persists `avatar_key` / `banner_key`.
 5. `GET /users/me/profile/media/{target}/download-url` resolves the currently persisted key for the caller and issues a short-lived download URL.
+6. An uploaded object that never reaches a successful `PATCH /users/me/profile` is treated as an orphan candidate and must be cleaned up via the profile media runbook while preserving LIN-590 recoverability.
 
 ## 4. Signed URL policy
 
@@ -70,8 +71,16 @@ v0/tenant/default/user/{user_id}/profile/{avatar|banner}/asset/{asset_id}/{filen
 
 1. Upload uses direct `PUT`.
 2. Signed URLs are generated on demand and are never reused after expiration.
-3. Public-read fallback is prohibited.
-4. If bucket configuration or signer credentials are unavailable, the API must fail closed with service-unavailable semantics.
+3. Upload signed URL binds the requested `content_type` and exact `content_length` (`size_bytes`) to the issued contract.
+4. Public-read fallback is prohibited.
+5. If bucket configuration or signer credentials are unavailable, the API must fail closed with service-unavailable semantics.
+
+### 4.3 Allowed MIME and size limits
+
+| target | allowed MIME types | max upload size |
+| --- | --- | --- |
+| `avatar` | `image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/avif` | `2 MiB` |
+| `banner` | `image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/avif` | `6 MiB` |
 
 ## 5. API contract summary
 
@@ -82,7 +91,10 @@ v0/tenant/default/user/{user_id}/profile/{avatar|banner}/asset/{asset_id}/{filen
   - `target`
   - `filename`
   - `content_type`
+  - `size_bytes`
   - known image extensions must stay consistent with the requested `content_type`
+  - `content_type` must stay within the fixed allowlist; `image/svg+xml` and other non-allowlisted formats are rejected before URL issuance
+  - `size_bytes` must stay within the target-specific maximum
 - Response:
   - `object_key`
   - `upload_url`
@@ -101,7 +113,7 @@ v0/tenant/default/user/{user_id}/profile/{avatar|banner}/asset/{asset_id}/{filen
 ## 6. Error contract
 
 - `VALIDATION_ERROR`
-  - invalid `target`, `filename`, `content_type`, or invalid persisted object key format
+  - invalid `target`, `filename`, `content_type`, `size_bytes`, or invalid persisted object key format
 - `PROFILE_MEDIA_NOT_FOUND`
   - caller has no persisted key for the requested target
 - `PROFILE_MEDIA_UNAVAILABLE`

--- a/docs/agent_runs/LIN-987/Documentation.md
+++ b/docs/agent_runs/LIN-987/Documentation.md
@@ -1,0 +1,69 @@
+# Documentation
+
+## Current status
+- Now: MIME allowlist / size guard、TypeScript client 契約、AVIF crop fallback 修正、docs、validation、review gate まで完了。
+- Next: commit / push / PR 作成 / Linear 更新。
+
+## Decisions
+- backend は profile media upload URL 発行時に allowlist 外 MIME を拒否し、`size_bytes` を target ごとの上限で fail-close する。
+- signed upload contract は `content-type` に加えて exact `content-length` も署名し、frontend は `sizeBytes` を送る。
+- browser の `File.type` が空でも valid image upload を壊さないよう、frontend は filename 拡張子から MIME を補完する。
+- crop modal は requested MIME ではなく `canvas.toBlob()` が返した `blob.type` を優先し、AVIF encode が PNG へ downgrade された場合も filename / MIME / upload contract を一致させる。
+- orphan upload cleanup は新しい sweeper を追加せず、contract / runbook の運用 baseline 明文化で扱う。
+
+## How to run / demo
+- `cd rust && cargo test -p linklynx_backend profile_media_ -- --nocapture`
+- `cd rust && cargo test -p linklynx_backend issue_my_profile_media_upload_url_returns_contract -- --nocapture`
+- `cd typescript && pnpm exec vitest run src/shared/ui/image-crop-modal.test.tsx src/features/settings/model/profile-media.test.ts`
+- `cd typescript && npm run typecheck`
+- `make rust-lint`
+- `make validate`
+- manual demo:
+  - settings の profile で avatar または banner に PNG/JPEG/WebP/AVIF を選択する
+  - crop を適用して保存する
+  - upload URL request が `filename` / `content_type` / `size_bytes` を含み、AVIF fallback 時は `.png` + `image/png` に揃うことを確認する
+
+## Validation log
+- `cd rust && cargo test -p linklynx_backend issue_my_profile_media_upload_url_returns_contract -- --nocapture`
+  - pass
+- `cd rust && cargo test -p linklynx_backend profile_media_ -- --nocapture`
+  - pass
+  - MIME allowlist、size 上限、signed header 契約の回帰 16 件が通過
+- `cd typescript && pnpm test -- src/shared/api/guild-channel-api-client.test.ts`
+  - pass
+  - vitest は関連 suite 325 件を実行し、upload contract request body の `size_bytes` 追加を含めて通過
+- `cd typescript && pnpm exec vitest run src/shared/ui/image-crop-modal.test.tsx src/features/settings/model/profile-media.test.ts`
+  - pass
+  - crop output の AVIF 維持と AVIF -> PNG fallback の双方を回帰化
+- `cd typescript && npm run typecheck`
+  - pass
+- `make rust-lint`
+  - pass
+- `make validate`
+  - pass
+  - TypeScript / Rust / Python validate まで完走
+- `git diff --check`
+  - pass
+
+## Review gate
+- `reviewer`
+  - pass
+  - AVIF crop path の filename/MIME mismatch と `blob.type` fallback を修正後、blocking finding なし
+- `reviewer_ui_guard`
+  - pass
+  - frontend UI-impact ありと判定
+- `reviewer_ui`
+  - no blocking findings
+  - reviewer sandbox では `tsconfig.tsbuildinfo` / Vite temp file の `EPERM` で typecheck/test を再実行できなかったが、同じ worktree 上でこちらの `npm run typecheck` と `make validate` は通過済み
+  - non-blocking として、real settings screen の AVIF full-flow integration test は未追加という指摘あり
+
+## Runtime smoke
+- skipped
+- rationale:
+  - live profile media issuance には `PROFILE_GCS_BUCKET` と signer credential (`GOOGLE_APPLICATION_CREDENTIALS` もしくは attached service account) が必要
+  - この環境では該当 env が未設定で、runbook 上の live upload/download smoke を完走できない
+  - 代替証跡として Rust/TypeScript の automated validation と contract/runbook 更新を採用
+
+## Known issues / follow-ups
+- `user-profile.test.tsx` は crop modal を mock しているため、real settings screen の AVIF crop -> upload full-flow は unit coverage 止まり。non-blocking follow-up とする。
+- live GCS bucket / signer credential が用意できたら、runbook Procedure A に沿った upload/download runtime smoke を追加で回す。

--- a/docs/agent_runs/LIN-987/Implement.md
+++ b/docs/agent_runs/LIN-987/Implement.md
@@ -1,0 +1,7 @@
+# Implement.md (Runbook)
+
+- Follow Plan.md as the single execution order. If order changes, record the reason in Documentation.md.
+- Keep diffs scoped to profile media signed URL abuse guard, related client contract updates, tests, and required docs only.
+- Do not mix CDN/public-read changes, Terraform bucket provisioning, or unrelated profile UI refactors into this issue.
+- Re-run targeted validation after each milestone and fix failures before moving on.
+- Continuously update Documentation.md with decisions, demo steps, validation results, and remaining risks.

--- a/docs/agent_runs/LIN-987/Plan.md
+++ b/docs/agent_runs/LIN-987/Plan.md
@@ -1,0 +1,24 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: validation failure は次へ進む前に修正する。
+
+## Milestones
+### M1: profile media upload contract に MIME / size guard を追加する
+- Acceptance criteria:
+  - [ ] backend が allowlist 外 MIME を拒否する
+  - [ ] upload request に size 契約が入り、target ごとの上限を超える要求を拒否する
+  - [ ] TypeScript client が更新後 contract に追従する
+- Validation:
+  - `cd rust && cargo test -p linklynx_backend profile_media_ -- --nocapture`
+  - `cd rust && cargo test -p linklynx_backend issue_my_profile_media_upload_url_ -- --nocapture`
+
+### M2: contract / runbook / review evidence を固める
+- Acceptance criteria:
+  - [ ] LIN-939 contract と profile media runbook が MIME / size / orphan cleanup baseline を説明する
+  - [ ] run memory に validation / smoke / review 結果が残る
+- Validation:
+  - `make rust-lint`
+  - `git diff --check`
+  - `make validate`
+  - `cd typescript && npm run typecheck`

--- a/docs/agent_runs/LIN-987/Prompt.md
+++ b/docs/agent_runs/LIN-987/Prompt.md
@@ -1,0 +1,28 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- profile media signed upload URL 発行で MIME allowlist を明示し、`image/svg+xml` など script/embed リスクのある形式を拒否する。
+- profile media upload にサイズ上限を導入し、frontend の既存 `2MB/6MB` 制約と backend / contract を整合させる。
+- orphan upload / failed save 後の cleanup と観測ポイントを contract / runbook で明文化する。
+
+## Non-goals
+- profile media を public-read や CDN 配信へ切り替えない。
+- avatar/banner persistence の DB schema を変えない。
+- crop UI や profile settings 全体の UX 改修を行わない。
+
+## Deliverables
+- Rust profile media upload/download 実装の abuse guard 追加
+- 必要な TypeScript API client / upload 呼び出しの整合
+- regression tests
+- contract / runbook / run memory 更新
+
+## Done when
+- [ ] SVG など不許可 MIME が upload URL 発行前に拒否される
+- [ ] target ごとのサイズ上限が API / runtime / docs で一貫する
+- [ ] orphan upload cleanup の運用方針と観測点が明文化される
+- [ ] valid な PNG/JPEG/WebP/AVIF upload / download が既存 UI を壊さず通る
+
+## Constraints
+- Security: signed URL は private bucket + fail-close のまま維持する
+- Compatibility: current profile media key persistence contract (`PATCH /users/me/profile`) は維持する
+- Scope: cleanup は運用 baseline の明文化を中心にし、新しい async sweeper を必須にしない

--- a/docs/runbooks/profile-media-gcs-operations-runbook.md
+++ b/docs/runbooks/profile-media-gcs-operations-runbook.md
@@ -1,7 +1,7 @@
 # Profile Media GCS Operations Runbook
 
 - Status: Draft
-- Last updated: 2026-03-08
+- Last updated: 2026-03-15
 - Owner scope: v0 profile avatar/banner binary operations baseline
 - References:
   - `database/contracts/lin939_profile_media_gcs_contract.md`
@@ -38,6 +38,9 @@ Out of scope:
 | Object key pattern | `v0/tenant/default/user/{user_id}/profile/{avatar\|banner}/asset/{asset_id}/{filename}` |
 | Upload method | `PUT` |
 | Object visibility | private only |
+| Allowed MIME | `image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/avif` |
+| Avatar max upload size | `2 MiB` |
+| Banner max upload size | `6 MiB` |
 
 ## 3. Environment prerequisites
 
@@ -73,13 +76,13 @@ Out of scope:
 
 - Authenticated user exists.
 - Runtime env is configured.
-- Requested `target`, `filename`, and `content_type` pass validation.
+- Requested `target`, `filename`, `content_type`, and `size_bytes` pass validation.
 
 ### 4.2 Steps
 
-1. Call `POST /users/me/profile/media/upload-url`.
+1. Call `POST /users/me/profile/media/upload-url` with `target`, `filename`, `content_type`, and `size_bytes`.
 2. Confirm response contains `object_key`, `upload_url`, `method=PUT`, `required_headers`, and `expires_at`.
-3. Upload the binary via signed `PUT`.
+3. Upload the binary via signed `PUT` with the same `content_type` and byte size used at issuance.
 4. Persist the returned `object_key` through `PATCH /users/me/profile`.
 5. Call `GET /users/me/profile/media/{target}/download-url`.
 6. Confirm the returned `object_key` matches the persisted key.
@@ -89,6 +92,7 @@ Out of scope:
 - Object upload succeeds.
 - Persisted key matches the downloaded target.
 - Download URL is reissued on demand and remains short-lived.
+- Upload request stays within the MIME allowlist and target-specific size limit.
 
 ## 5. Procedure B: Missing key triage
 
@@ -129,8 +133,27 @@ Out of scope:
 3. Do not attempt to reuse the expired URL.
 4. If expiration repeats abnormally, inspect client clock skew and retry timing.
 
-## 8. Change management notes
+## 8. Procedure E: Orphan upload cleanup
+
+### 8.1 Trigger
+
+- Signed `PUT` succeeded, but `PATCH /users/me/profile` failed or was abandoned and the uploaded `object_key` was never persisted.
+
+### 8.2 Steps
+
+1. Use the upload issuance `request_id`, `principal_id`, `target`, and `object_key` from API logs to identify the candidate object.
+2. Confirm `users.avatar_key` / `users.banner_key` does not reference the object key.
+3. If the key is still unpersisted, delete the object through the standard private-bucket path and rely on bucket versioning for LIN-590 recovery.
+4. Record the cleanup timestamp, object key, principal, and incident/request reference.
+
+### 8.3 Close conditions
+
+- The unpersisted object is removed from the live object namespace.
+- Cleanup evidence (`request_id`, `object_key`, `principal_id`, timestamp) is recorded.
+
+## 9. Change management notes
 
 1. Bucket split between avatar/banner is out of scope for v0 and requires a new contract update.
 2. TTL changes must stay aligned with LIN-590 or be explicitly superseded.
 3. Runtime/API changes must preserve `key persistence + signed URL reissue` as the display contract for LIN-886.
+4. MIME allowlist or target size-limit changes require both contract and runbook updates.

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -1525,6 +1525,7 @@ struct ProfileMediaUploadUrlRequest {
     target: String,
     filename: String,
     content_type: String,
+    size_bytes: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1848,6 +1849,7 @@ fn parse_profile_media_upload_payload(
         target: profile::ProfileMediaTarget::parse(payload.target.as_str())?,
         filename: payload.filename,
         content_type: payload.content_type,
+        size_bytes: payload.size_bytes,
     })
 }
 
@@ -2900,13 +2902,26 @@ async fn issue_my_profile_media_upload_url(
         Ok(value) => value,
         Err(error) => return profile_error_response(&error, request_id),
     };
+    let requested_size_bytes = input.size_bytes;
+    let requested_content_type = input.content_type.clone();
 
     match state
         .profile_media_service
         .issue_upload_url(auth_context.principal_id, input)
         .await
     {
-        Ok(upload) => Json(ProfileMediaUploadUrlResponse { upload }).into_response(),
+        Ok(upload) => {
+            tracing::info!(
+                request_id = %request_id,
+                principal_id = auth_context.principal_id.0,
+                target = %upload.target.as_key_segment(),
+                object_key = %upload.object_key,
+                content_type = %requested_content_type,
+                size_bytes = requested_size_bytes,
+                "profile media upload url issued"
+            );
+            Json(ProfileMediaUploadUrlResponse { upload }).into_response()
+        }
         Err(error) => profile_error_response(&error, request_id),
     }
 }
@@ -2933,7 +2948,16 @@ async fn get_my_profile_media_download_url(
         .issue_download_url(auth_context.principal_id, target)
         .await
     {
-        Ok(media) => Json(ProfileMediaDownloadUrlResponse { media }).into_response(),
+        Ok(media) => {
+            tracing::info!(
+                request_id = %request_id,
+                principal_id = auth_context.principal_id.0,
+                target = %media.target.as_key_segment(),
+                object_key = %media.object_key,
+                "profile media download url issued"
+            );
+            Json(ProfileMediaDownloadUrlResponse { media }).into_response()
+        }
         Err(error) => profile_error_response(&error, request_id),
     }
 }

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -6444,7 +6444,7 @@ mod tests {
                     .header("authorization", format!("Bearer {token}"))
                     .header("content-type", "application/json")
                     .body(Body::from(
-                        r#"{"target":"avatar","filename":"avatar.png","content_type":"image/png"}"#,
+                        r#"{"target":"avatar","filename":"avatar.png","content_type":"image/png","size_bytes":1048576}"#,
                     ))
                     .unwrap(),
             )

--- a/rust/apps/api/src/profile/media.rs
+++ b/rust/apps/api/src/profile/media.rs
@@ -3,6 +3,8 @@ const PROFILE_MEDIA_TENANT_SEGMENT: &str = "default";
 const PROFILE_MEDIA_SIGNED_URL_TTL_SECONDS: i64 = 300;
 const PROFILE_MEDIA_MAX_FILENAME_CHARS: usize = 255;
 const PROFILE_MEDIA_MAX_CONTENT_TYPE_CHARS: usize = 255;
+const PROFILE_MEDIA_AVATAR_MAX_SIZE_BYTES: u64 = 2 * 1024 * 1024;
+const PROFILE_MEDIA_BANNER_MAX_SIZE_BYTES: u64 = 6 * 1024 * 1024;
 const GCS_SIGNED_URL_HOST: &str = "storage.googleapis.com";
 const GCP_METADATA_EMAIL_URL: &str =
     "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email";
@@ -50,6 +52,7 @@ pub struct ProfileMediaUploadInput {
     pub target: ProfileMediaTarget,
     pub filename: String,
     pub content_type: String,
+    pub size_bytes: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -277,10 +280,16 @@ impl GcsSignedUrlSigner {
     ) -> Result<ProfileMediaUpload, ProfileError> {
         let normalized_filename = sanitize_profile_media_filename(&input.filename)?;
         let normalized_content_type = normalize_profile_media_content_type(&input.content_type)?;
+        validate_profile_media_size_bytes(input.target, input.size_bytes)?;
         validate_profile_media_content_type_filename_match(
             &normalized_content_type,
             &normalized_filename,
         )?;
+        let content_length = input.size_bytes.to_string();
+        let signed_headers = [
+            ("content-length", content_length.as_str()),
+            ("content-type", normalized_content_type.as_str()),
+        ];
         let asset_id = uuid::Uuid::new_v4().to_string();
         let object_key = format!(
             "v0/tenant/{}/user/{}/profile/{}/asset/{}/{}",
@@ -291,11 +300,7 @@ impl GcsSignedUrlSigner {
             normalized_filename,
         );
         let signed = self
-            .signed_url(
-            "PUT",
-            &object_key,
-            Some(("content-type", normalized_content_type.as_str())),
-            )
+            .signed_url("PUT", &object_key, &signed_headers)
             .await?;
 
         let mut required_headers = std::collections::BTreeMap::new();
@@ -321,7 +326,7 @@ impl GcsSignedUrlSigner {
         target: ProfileMediaTarget,
         object_key: String,
     ) -> Result<ProfileMediaDownload, ProfileError> {
-        let signed = self.signed_url("GET", &object_key, None).await?;
+        let signed = self.signed_url("GET", &object_key, &[]).await?;
         Ok(ProfileMediaDownload {
             target,
             object_key,
@@ -340,7 +345,7 @@ impl GcsSignedUrlSigner {
         &self,
         method: &str,
         object_key: &str,
-        content_type: Option<(&str, &str)>,
+        signed_headers: &[(&str, &str)],
     ) -> Result<SignedUrlArtifact, ProfileError> {
         let now = time::OffsetDateTime::now_utc();
         let datestamp = format!(
@@ -381,7 +386,7 @@ impl GcsSignedUrlSigner {
         ];
 
         let mut canonical_headers = vec![("host".to_owned(), GCS_SIGNED_URL_HOST.to_owned())];
-        if let Some((header_name, header_value)) = content_type {
+        for &(header_name, header_value) in signed_headers {
             canonical_headers.push((header_name.to_owned(), header_value.to_owned()));
         }
         canonical_headers.sort_by(|left, right| left.0.cmp(&right.0));
@@ -525,6 +530,12 @@ fn normalize_profile_media_content_type(raw_content_type: &str) -> Result<String
     {
         return Err(ProfileError::validation("profile_media_content_type_invalid"));
     }
+    if !matches!(
+        normalized.as_str(),
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "image/avif"
+    ) {
+        return Err(ProfileError::validation("profile_media_content_type_not_allowed"));
+    }
 
     Ok(normalized)
 }
@@ -560,6 +571,36 @@ fn validate_profile_media_content_type_filename_match(
     }
 
     Ok(())
+}
+
+/// profile media size を target ごとの上限で検証する。
+/// @param target 画像種別
+/// @param size_bytes 要求サイズ(bytes)
+/// @returns 上限内なら `Ok(())`
+/// @throws ProfileError サイズ未設定または上限超過時
+fn validate_profile_media_size_bytes(
+    target: ProfileMediaTarget,
+    size_bytes: u64,
+) -> Result<(), ProfileError> {
+    if size_bytes == 0 {
+        return Err(ProfileError::validation("profile_media_size_invalid"));
+    }
+    if size_bytes > profile_media_max_size_bytes(target) {
+        return Err(ProfileError::validation("profile_media_size_too_large"));
+    }
+
+    Ok(())
+}
+
+/// profile media target ごとのサイズ上限を返す。
+/// @param target 画像種別
+/// @returns 最大サイズ(bytes)
+/// @throws なし
+fn profile_media_max_size_bytes(target: ProfileMediaTarget) -> u64 {
+    match target {
+        ProfileMediaTarget::Avatar => PROFILE_MEDIA_AVATAR_MAX_SIZE_BYTES,
+        ProfileMediaTarget::Banner => PROFILE_MEDIA_BANNER_MAX_SIZE_BYTES,
+    }
 }
 
 #[derive(Deserialize)]

--- a/rust/apps/api/src/profile/tests.rs
+++ b/rust/apps/api/src/profile/tests.rs
@@ -290,6 +290,18 @@ mod tests {
     }
 
     #[test]
+    fn normalize_profile_media_content_type_rejects_unallowed_svg() {
+        let result = normalize_profile_media_content_type("image/svg+xml");
+        assert!(matches!(
+            result,
+            Err(ProfileError {
+                kind: ProfileErrorKind::Validation,
+                reason,
+            }) if reason == "profile_media_content_type_not_allowed"
+        ));
+    }
+
+    #[test]
     fn validate_profile_media_content_type_filename_match_rejects_known_mismatch() {
         let result = validate_profile_media_content_type_filename_match("image/png", "avatar.jpg");
         assert!(matches!(
@@ -303,9 +315,35 @@ mod tests {
 
     #[test]
     fn validate_profile_media_content_type_filename_match_allows_unknown_extension() {
-        let result =
-            validate_profile_media_content_type_filename_match("image/svg+xml", "avatar.svg");
+        let result = validate_profile_media_content_type_filename_match("image/png", "avatar.bin");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_profile_media_size_bytes_rejects_oversized_avatar() {
+        let result = validate_profile_media_size_bytes(
+            ProfileMediaTarget::Avatar,
+            PROFILE_MEDIA_AVATAR_MAX_SIZE_BYTES + 1,
+        );
+        assert!(matches!(
+            result,
+            Err(ProfileError {
+                kind: ProfileErrorKind::Validation,
+                reason,
+            }) if reason == "profile_media_size_too_large"
+        ));
+    }
+
+    #[test]
+    fn validate_profile_media_size_bytes_rejects_zero_size() {
+        let result = validate_profile_media_size_bytes(ProfileMediaTarget::Banner, 0);
+        assert!(matches!(
+            result,
+            Err(ProfileError {
+                kind: ProfileErrorKind::Validation,
+                reason,
+            }) if reason == "profile_media_size_invalid"
+        ));
     }
 
     #[test]
@@ -360,11 +398,27 @@ iYQwLAtAPWEfPJcpkZ60iaDeUtuTrckLBIMfINHXC6+ltIfxFa4VdNTyLkKen9Tt
                     target: ProfileMediaTarget::Banner,
                     filename: "banner image.png".to_owned(),
                     content_type: "image/png".to_owned(),
+                    size_bytes: 1_048_576,
                 },
             ))
             .unwrap();
         assert!(upload.object_key.contains("/profile/banner/asset/"));
         assert!(upload.upload_url.contains("X-Goog-Signature="));
+        assert!(
+            upload.upload_url.contains("X%2DGoog%2DSignedHeaders="),
+            "{}",
+            upload.upload_url
+        );
+        assert!(
+            upload.upload_url.contains("content%2Dlength"),
+            "{}",
+            upload.upload_url
+        );
+        assert!(
+            upload.upload_url.contains("content%2Dtype"),
+            "{}",
+            upload.upload_url
+        );
         assert!(upload.required_headers.contains_key("content-type"));
     }
 }

--- a/typescript/src/features/settings/model/profile-media.test.ts
+++ b/typescript/src/features/settings/model/profile-media.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { uploadProfileMediaFile } from "./profile-media";
+
+const createMyProfileMediaUploadUrlMock = vi.fn();
+
+vi.mock("@/shared/api/api-client", () => ({
+  getAPIClient: () => ({
+    createMyProfileMediaUploadUrl: createMyProfileMediaUploadUrlMock,
+  }),
+}));
+
+describe("uploadProfileMediaFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+      }),
+    );
+    createMyProfileMediaUploadUrlMock.mockResolvedValue({
+      objectKey: "profiles/u-1/avatar/avatar-cropped.avif",
+      uploadUrl: "https://storage.example/upload",
+      method: "PUT",
+      requiredHeaders: {},
+      expiresAt: "2026-03-15T00:00:00Z",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("uses matching avif filename and mime for upload url issuance", async () => {
+    const file = new File(["cropped"], "avatar-cropped.avif", { type: "image/avif" });
+    Object.defineProperty(file, "size", {
+      configurable: true,
+      value: 1_024,
+    });
+
+    const objectKey = await uploadProfileMediaFile("avatar", file);
+
+    expect(objectKey).toBe("profiles/u-1/avatar/avatar-cropped.avif");
+    expect(createMyProfileMediaUploadUrlMock).toHaveBeenCalledWith({
+      target: "avatar",
+      filename: "avatar-cropped.avif",
+      contentType: "image/avif",
+      sizeBytes: 1_024,
+    });
+
+    const [, request] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(request.body).toBe(file);
+    expect(request.headers).toBeInstanceOf(Headers);
+    expect((request.headers as Headers).get("content-type")).toBe("image/avif");
+  });
+});

--- a/typescript/src/features/settings/model/profile-media.ts
+++ b/typescript/src/features/settings/model/profile-media.ts
@@ -8,6 +8,30 @@ function buildUploadHeaders(headers: Record<string, string>): Headers {
   return nextHeaders;
 }
 
+function resolveProfileMediaContentType(file: File): string {
+  const trimmedType = file.type.trim();
+  if (trimmedType.length > 0) {
+    return trimmedType;
+  }
+
+  const extension = file.name.trim().split(".").pop()?.toLowerCase();
+  switch (extension) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "gif":
+      return "image/gif";
+    case "webp":
+      return "image/webp";
+    case "avif":
+      return "image/avif";
+    default:
+      return "application/octet-stream";
+  }
+}
+
 /**
  * プロフィール media を signed URL 経由でアップロードし、保存用 object key を返す。
  */
@@ -16,15 +40,17 @@ export async function uploadProfileMediaFile(
   file: File,
 ): Promise<string> {
   const api = getAPIClient();
+  const contentType = resolveProfileMediaContentType(file);
   const upload = await api.createMyProfileMediaUploadUrl({
     target,
     filename: file.name,
-    contentType: file.type,
+    contentType,
+    sizeBytes: file.size,
   });
   const headers = buildUploadHeaders(upload.requiredHeaders);
 
-  if (headers.has("content-type") === false && file.type.trim().length > 0) {
-    headers.set("content-type", file.type);
+  if (headers.has("content-type") === false && contentType.trim().length > 0) {
+    headers.set("content-type", contentType);
   }
 
   const response = await fetch(upload.uploadUrl, {

--- a/typescript/src/shared/api/api-client.ts
+++ b/typescript/src/shared/api/api-client.ts
@@ -69,6 +69,7 @@ export type CreateMyProfileMediaUploadUrlInput = {
   target: ProfileMediaTarget;
   filename: string;
   contentType: string;
+  sizeBytes: number;
 };
 
 export type MyProfileMediaUpload = {

--- a/typescript/src/shared/api/guild-channel-api-client.test.ts
+++ b/typescript/src/shared/api/guild-channel-api-client.test.ts
@@ -1009,6 +1009,7 @@ describe("GuildChannelAPIClient", () => {
       target: "avatar",
       filename: "avatar.png",
       contentType: "image/png",
+      sizeBytes: 1_048_576,
     });
 
     expect(upload).toEqual({
@@ -1030,6 +1031,7 @@ describe("GuildChannelAPIClient", () => {
         target: "avatar",
         filename: "avatar.png",
         content_type: "image/png",
+        size_bytes: 1_048_576,
       }),
     );
   });

--- a/typescript/src/shared/api/guild-channel-api-client.ts
+++ b/typescript/src/shared/api/guild-channel-api-client.ts
@@ -1825,6 +1825,7 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
         target: input.target,
         filename: input.filename,
         content_type: input.contentType,
+        size_bytes: input.sizeBytes,
       },
       schema: PROFILE_MEDIA_UPLOAD_RESPONSE_SCHEMA,
       expectedStatus: 200,

--- a/typescript/src/shared/api/my-profile-media.ts
+++ b/typescript/src/shared/api/my-profile-media.ts
@@ -10,6 +10,30 @@ type ProfileMediaApi = Pick<
   "createMyProfileMediaUploadUrl" | "getMyProfileMediaDownloadUrl"
 >;
 
+function resolveProfileMediaContentType(file: File): string {
+  const trimmedType = file.type.trim();
+  if (trimmedType.length > 0) {
+    return trimmedType;
+  }
+
+  const extension = file.name.trim().split(".").pop()?.toLowerCase();
+  switch (extension) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "gif":
+      return "image/gif";
+    case "webp":
+      return "image/webp";
+    case "avif":
+      return "image/avif";
+    default:
+      return "application/octet-stream";
+  }
+}
+
 function buildUploadFilename(target: ProfileMediaTarget, file: File): string {
   const trimmed = file.name.trim();
   if (trimmed.length > 0) {
@@ -27,11 +51,12 @@ export async function uploadMyProfileMedia(
   target: ProfileMediaTarget,
   file: File,
 ): Promise<string> {
-  const contentType = file.type.trim().length > 0 ? file.type : "application/octet-stream";
+  const contentType = resolveProfileMediaContentType(file);
   const upload = await api.createMyProfileMediaUploadUrl({
     target,
     filename: buildUploadFilename(target, file),
     contentType,
+    sizeBytes: file.size,
   });
   const headers = new Headers(upload.requiredHeaders);
   if (!headers.has("content-type")) {

--- a/typescript/src/shared/ui/image-crop-modal.test.tsx
+++ b/typescript/src/shared/ui/image-crop-modal.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { ImageCropModal } from "./image-crop-modal";
+
+describe("ImageCropModal", () => {
+  const toBlobMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "URL",
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => "blob:cropped-avif"),
+      }),
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      scale: vi.fn(),
+      translate: vi.fn(),
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation(toBlobMock);
+    Object.defineProperty(HTMLImageElement.prototype, "decode", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(undefined),
+    });
+    Object.defineProperty(HTMLImageElement.prototype, "complete", {
+      configurable: true,
+      get: () => true,
+    });
+    Object.defineProperty(HTMLImageElement.prototype, "naturalWidth", {
+      configurable: true,
+      get: () => 400,
+    });
+    Object.defineProperty(HTMLImageElement.prototype, "naturalHeight", {
+      configurable: true,
+      get: () => 400,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  test("keeps avif filename and mime aligned for cropped output", async () => {
+    const user = userEvent.setup();
+    const onCrop = vi.fn();
+    toBlobMock.mockImplementation((callback, type) => {
+      callback(new Blob(["cropped"], { type: type ?? "image/png" }));
+    });
+
+    render(
+      <ImageCropModal
+        imageUrl="blob:source"
+        sourceFile={new File(["source"], "avatar.avif", { type: "image/avif" })}
+        shape="circle"
+        onCrop={onCrop}
+        onClose={() => undefined}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "適用" }));
+
+    await waitFor(() => {
+      expect(onCrop).toHaveBeenCalledTimes(1);
+    });
+
+    const result = onCrop.mock.calls[0][0] as { file: File; url: string };
+    expect(result.file.name).toBe("avatar-cropped.avif");
+    expect(result.file.type).toBe("image/avif");
+    expect(result.url).toBe("blob:cropped-avif");
+  });
+
+  test("falls back to the actual blob mime when canvas encoding downgrades avif", async () => {
+    const user = userEvent.setup();
+    const onCrop = vi.fn();
+    toBlobMock.mockImplementation((callback) => {
+      callback(new Blob(["cropped"], { type: "image/png" }));
+    });
+
+    render(
+      <ImageCropModal
+        imageUrl="blob:source"
+        sourceFile={new File(["source"], "avatar.avif", { type: "image/avif" })}
+        shape="circle"
+        onCrop={onCrop}
+        onClose={() => undefined}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "適用" }));
+
+    await waitFor(() => {
+      expect(onCrop).toHaveBeenCalledTimes(1);
+    });
+
+    const result = onCrop.mock.calls[0][0] as { file: File; url: string };
+    expect(result.file.name).toBe("avatar-cropped.png");
+    expect(result.file.type).toBe("image/png");
+  });
+});

--- a/typescript/src/shared/ui/image-crop-modal.tsx
+++ b/typescript/src/shared/ui/image-crop-modal.tsx
@@ -24,8 +24,19 @@ function resolveCropMimeType(file: File): string {
   return file.type.startsWith("image/") ? file.type : "image/png";
 }
 
+function resolveCroppedBlobMimeType(blob: Blob, requestedType: string): string {
+  const normalizedBlobType = blob.type.trim().toLowerCase();
+  if (normalizedBlobType.startsWith("image/")) {
+    return normalizedBlobType;
+  }
+
+  return requestedType;
+}
+
 function resolveCropExtension(type: string): string {
   switch (type) {
+    case "image/avif":
+      return "avif";
     case "image/jpeg":
       return "jpg";
     case "image/webp":
@@ -145,10 +156,11 @@ export function ImageCropModal({
         onCrop({ file: sourceFile, url: imageUrl });
         return;
       }
+      const outputMimeType = resolveCroppedBlobMimeType(blob, mimeType);
 
       onCrop({
-        file: new File([blob], buildCroppedFileName(sourceFile, mimeType), {
-          type: mimeType,
+        file: new File([blob], buildCroppedFileName(sourceFile, outputMimeType), {
+          type: outputMimeType,
         }),
         url: URL.createObjectURL(blob),
       });


### PR DESCRIPTION
## 概要
- profile media signed upload URL 発行で MIME allowlist と target ごとの size guard を追加しました
- signed upload contract に exact `content-length` (`size_bytes`) を含め、frontend client も `sizeBytes` 送信に追従させました
- crop modal が `canvas.toBlob()` の実際の `blob.type` を使って filename / MIME を揃えるよう修正し、AVIF encode fallback でも upload contract が壊れないようにしました
- LIN-939 contract / profile media runbook / run memory に orphan upload cleanup baseline と新しい制約を反映しました

## 変更理由
- `image/svg+xml` など script/embed リスクのある形式を signed URL 発行前に拒否したいためです
- oversized upload を backend で fail-close し、既存 frontend の `2 MiB / 6 MiB` 制約と整合させるためです
- browser / canvas encoder の fallback で filename / MIME がずれると backend validation と衝突するため、実際の blob 出力を正として扱う必要がありました
- orphan upload cleanup の運用境界を contract / runbook に明文化して、LIN-590 recoverability baseline と揃えるためです

## 受け入れ条件
- [x] SVG など不許可 MIME を upload URL 発行前に拒否する
- [x] `size_bytes` 契約と target 上限を backend / frontend / docs で一貫させる
- [x] orphan upload cleanup の運用 baseline を contract / runbook に明文化する
- [x] valid な PNG / JPEG / WebP / AVIF upload path を壊さない
  - AVIF encode 成功時は `.avif` + `image/avif` を維持
  - AVIF encode fallback 時は `blob.type` に合わせて `.png` + `image/png` へ downgrade する

## 検証
- `cd rust && cargo test -p linklynx_backend issue_my_profile_media_upload_url_returns_contract -- --nocapture`
- `cd rust && cargo test -p linklynx_backend profile_media_ -- --nocapture`
- `cd typescript && pnpm test -- src/shared/api/guild-channel-api-client.test.ts`
- `cd typescript && pnpm exec vitest run src/shared/ui/image-crop-modal.test.tsx src/features/settings/model/profile-media.test.ts`
- `cd typescript && npm run typecheck`
- `make rust-lint`
- `make validate`
- `git diff --check`

## Review
- `reviewer`: pass
- `reviewer_ui_guard`: frontend UI changeあり
- `reviewer_ui`: no blocking findings
  - reviewer sandbox では `tsconfig.tsbuildinfo` / Vite temp file の `EPERM` により `pnpm typecheck` / `pnpm test` を再実行できませんでしたが、同一 worktree 上では pass を確認済みです

## Runtime smoke
- skip
- live profile media smoke には `PROFILE_GCS_BUCKET` と signer credential (`GOOGLE_APPLICATION_CREDENTIALS` または attached service account) が必要ですが、この環境では未設定のため Procedure A の live upload/download smoke は未実施です

## 互換性 / 影響
- API request contract に `size_bytes` を追加しました
- event contract 変更はありません。ADR-001 チェック: 対象外です
- compatibility rationale:
  - backend / frontend / docs を同一 PR で更新し、new request field と MIME / size baseline を同時に反映しました
  - event schema や realtime wire shape の breaking change はありません

## Linear
- https://linear.app/linklynx-ai/issue/LIN-987/v1-p2-profile-media-signed-url-に-abuse-guard-を追加する
