### PR TITLE
docs: LIN-796 の実装確認メモを更新

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -1,23 +1,25 @@
 # Documentation
 
 ## Current status
-- Now: `LIN-829` の frontend message timeline/composer 実接続と review fix まで反映済み。
-- Next: 依存導入済み環境で typecheck / Vitest を再実行して最終確認する。
+- `LIN-796` の親要件に相当する invite verify / join / FE 導線は現行 `main` に存在する。
+- このワークツリー `codex/lin-796` は `origin/main` と差分が無く、追加の product code 実装差分は確認できなかった。
 
 ## Decisions
-- 対象 issue は `LIN-829`。
-- guild text channel のみ対象。DM 実装は今回含めない。
-- backend 契約拡張は行わない。
-- message REST/WS の `i64` ID は frontend 境界で string として保持する。
-- reconnect 後の取りこぼし補償は active channel history の再取得で行う。
-- own-message 判定は `principal_id` ベースで行う。
+- 今回の実装は root memory files の是正に限定する。
+- `LIN-796` の追加差分は、具体的な欠落要件または再現不具合が提示された場合にのみ着手する。
+- invite join の `AuthN required / AuthZ excluded` 契約は ADR-004 を維持する。
+- invite access の high-risk fail-close policy は ADR-005 を維持する。
 
-## Validation plan
-- `make validate`
-- `cd typescript && npm run typecheck`
-- 必要に応じて関連 Vitest を個別実行
+## Validation
+- Pass:
+  - `cargo test -p linklynx_backend invite::tests:: -- --nocapture`
+- Blocked by environment:
+  - `cd typescript && npm run test -- --run src/app/invite/[code]/page.test.tsx src/app/invite/[code]/invite-page-client.test.tsx src/features/invite-flow/api/join-invite.test.ts`
+  - `cd typescript && npm run typecheck`
+  - `make validate`
 
 ## Notes
-- `typescript/node_modules` が存在しないためローカル typecheck / Vitest は未実行。
-- local 開発では `make dev` が `scylla-bootstrap` を先行実行するように変更した。
-- `scylla-bootstrap` は `.env` を読み込んだうえで `scylla-wait` を通すため、Scylla 起動直後の race で Rust API が不健康な session を掴む確率を下げている。
+- frontend 検証失敗の主因はコードではなく依存未導入。
+  - `vitest: not found`
+  - `prettier: not found`
+- 現時点で invite 関連の repo-tracked code 変更は加えていない。

--- a/Implement.md
+++ b/Implement.md
@@ -1,44 +1,40 @@
 # Implement
 
-## 2026-03-10 LIN-829 frontend message timeline/composer real-data run
+## 2026-03-27 LIN-796 invite parent delta confirmation
 
 ### 必須参照
+- `docs/RUST.md`
 - `docs/TYPESCRIPT.md`
-- `docs/runbooks/realtime-nats-core-subject-subscription-runbook.md`
-- `docs/runbooks/message-v1-api-ws-contract-runbook.md`
-- `.agents/skills/linear-implementation-leaf/references/core-policy.md`
-- `.agents/skills/linear-implementation-leaf/references/delivery-flow.md`
-- `.agents/skills/linear-implementation-leaf/references/review-gates.md`
+- `docs/DATABASE.md`
+- `docs/adr/ADR-004-authz-fail-close-and-cache-strategy.md`
+- `docs/adr/ADR-005-dragonfly-ratelimit-failure-policy.md`
+- `.agents/skills/linear-implementation-simple-review-parent/SKILL.md`
 
 ### Start mode
-- `standalone smallest-unit`
-- current branch: `codex/lin-829`
+- `parent issue confirmation`
+- current branch: `codex/lin-796`
 
 ### Scope decisions
-- guild text channel のみを対象にする
-- DM route は non-goal として read/write を有効化しない
-- author 表示は frontend 最小補完
-- paging UI は timeline 上部ボタン方式
+- `LIN-796` は親 issue として扱う。
+- 既存 `main` に invite verify / join / FE 導線が入っている前提で差分だけ確認する。
+- 追加要件や再現不具合が無い限り product code は変更しない。
 
-### Progress log
-- [x] memory files 更新
-- [x] message API / query / cache helper
-- [x] chat UI / composer / paging
-- [x] WS subscribe / realtime cache apply
-- [x] review 指摘の blocking 修正
-- [ ] tests / validation
+### Evidence gathered
+- Linear 上で `LIN-796` の子課題は `LIN-811` / `LIN-816` / `LIN-819` と確認した。
+- 既存コード上で以下を確認した。
+  - public invite verify route
+  - invite join route
+  - `/invite/[code]` page と invite join frontend
+- `git rev-list --left-right --count origin/main...HEAD` は `0 0` だった。
+- `cargo test -p linklynx_backend invite::tests:: -- --nocapture` は `28 passed, 0 failed`。
 
-### Review-driven fixes
-- message REST/WS の `i64` ID は exact decimal として保持するように parser を追加
-- reconnect 後は active channel の timeline query を invalidate して履歴補償する
-- auth-store に `currentPrincipalId` を保持し、own-message 判定を Firebase UID 依存から分離した
+### Validation blockers
+- `typescript/node_modules` が存在しないため `vitest` / `prettier` が未導入。
+- そのため以下は現環境では未完了。
+  - `cd typescript && npm run test -- --run ...`
+  - `cd typescript && npm run typecheck`
+  - `make validate`
 
-## 2026-03-10 local dev startup fix
-
-### Goal
-- `make dev` で Scylla 起動直後でも message runtime が安定して立ち上がるようにする
-
-### Changes
-- `Makefile` に `scylla-wait` を追加し、CQL 応答待ちを共通化
-- `scylla-bootstrap` で `.env` を読み込み、`SCYLLA_KEYSPACE` を local runtime と一致させる
-- `dev` 起動時に `scylla-bootstrap` を必ず実行してから Rust API を起動する
+### Actions taken
+- root memory files を `LIN-796` 向けに更新した。
+- 既存実装の再編集は行っていない。

--- a/Plan.md
+++ b/Plan.md
@@ -1,28 +1,22 @@
 # Plan
 
 ## Rules
-- Stop-and-fix: 検証またはレビューで失敗したら次工程へ進まず修正する。
-- Scope lock: guild text channel の frontend 接続に限定し、DM や backend 契約拡張は行わない。
+- Stop-and-fix: 追加差分を実装する場合は、検証失敗を解消してから次へ進む。
+- Scope lock: 今回は `LIN-796` の差分確認に限定し、追加要件が無い限り product code を編集しない。
 
 ## Milestones
-### M1: 実装前提の更新
+### M1: 親 issue と既存実装の対応確認
 - Acceptance criteria:
-  - [ ] `Prompt.md` / `Plan.md` / `Implement.md` / `Documentation.md` を `LIN-829` 用に更新
-  - [ ] 既存 message/chat/WS 導線の変更点を確定
+  - [x] `LIN-796` の子課題 `LIN-811` / `LIN-816` / `LIN-819` を特定する。
+  - [x] invite verify / join / `/invite/[code]` の実装が現行コードに存在することを確認する。
+  - [x] `origin/main...HEAD` が `0 0` であることを確認する。
 
-### M2: message API/query 基盤
+### M2: 検証結果の取得
 - Acceptance criteria:
-  - [ ] message list/create 用型と query key を整理
-  - [ ] `GuildChannelAPIClient` で guild message list/create が動く
-  - [ ] cache merge helper を追加
+  - [x] Rust invite 関連テストを実行し、既存 backend 実装の健全性を確認する。
+  - [x] frontend 検証が環境要因で未実行の場合、その理由を明記する。
 
-### M3: chat UI / realtime 接続
+### M3: 作業記録の是正
 - Acceptance criteria:
-  - [ ] `ChatArea` / `MessageList` / `MessageInput` に guildId と paging/error 表示を配線
-  - [ ] `WsAuthBridge` で active channel 購読と `message.created` cache 反映が動く
-
-### M4: テストと収束
-- Acceptance criteria:
-  - [ ] API client / hook / WS/chat の回帰テストを更新
-  - [ ] `make validate` と `cd typescript && npm run typecheck` を実行
-  - [ ] 実装内容と意図を日本語で説明できる状態にする
+  - [x] `Prompt.md` / `Plan.md` / `Implement.md` / `Documentation.md` を `LIN-796` 用に更新する。
+  - [x] 「追加差分なし」の判断根拠と未解決事項を残す。

--- a/Prompt.md
+++ b/Prompt.md
@@ -1,27 +1,25 @@
 # Prompt
 
 ## Goals
-- `LIN-829` として guild text channel の timeline/composer を実データ送受信へ接続する。
-- send/list 実 API、WS `message.subscribe` / `message.created`、履歴ページング導線を frontend で成立させる。
-- 既存 UI を維持しつつ、権限/レート制限エラーでも composer 表示を崩さない。
+- `LIN-796` の親要件に対して、現行 `main` に未実装差分が残っているかを確認する。
+- 追加差分がなければ、既存実装を前提に完了判断できる状態へ作業記録を揃える。
 
 ## Non-goals
-- DM 送受信の実装。
-- backend 契約の拡張や UI 全面再設計。
+- 既に `main` に存在する invite verify / join / FE 導線の再実装。
+- 新規仕様追加や invite 契約変更。
 
 ## Deliverables
-- `typescript/src/shared/api/*` の message 実接続。
-- `typescript/src/app/providers/ws-auth-bridge.tsx` の channel subscribe / cache 更新。
-- `typescript/src/widgets/chat/ui/*` の timeline/composer/paging/error 表示。
-- 関連 unit/component test 更新。
+- `LIN-796` 向けの `Prompt.md` / `Plan.md` / `Implement.md` / `Documentation.md` 更新。
+- 現状確認の根拠整理。
+- 実行できた検証結果と、環境依存で未実行の検証の明確化。
 
 ## Done when
-- [ ] guild channel で send -> receive が UI 反映まで成立する。
-- [ ] WS 再接続後も active channel の購読が復元される。
-- [ ] 過去メッセージ読み込み導線が動作する。
-- [ ] `make validate` と `cd typescript && npm run typecheck` が通る。
+- [x] `LIN-796` の子課題相当実装が既存コードに存在することを確認する。
+- [x] `codex/lin-796` が `origin/main` と差分 `0/0` であることを確認する。
+- [x] root memory files が `LIN-796` の内容に更新されている。
+- [ ] frontend 依存導入済み環境で `make validate` と `cd typescript && npm run typecheck` を再確認する。
 
 ## Constraints
-- `LIN-829` の `Don't` に従い DM 実装を混在させない。
-- TypeScript / FSD ルールに従い、UI・query・api helper を分離する。
-- backend message contract は現状の `author_id` までを前提にし、frontend で最小補完する。
+- invite verify / join の AuthN/AuthZ 契約は ADR-004 に従い維持する。
+- invite access の rate-limit outage policy は ADR-005 に従い維持する。
+- 追加要件や不具合再現が無い限り、repo-tracked の product code は変更しない。


### PR DESCRIPTION
## 概要

LIN-796 の親 issue について、現行 main の実装状況を確認し、run memory を最新化しました。
既存コードを確認した結果、招待リンク参加フローの子 issue 相当実装はすでに main に存在していたため、product code の変更は行っていません。

## 変更内容

- root の `Prompt.md` を LIN-796 向けに更新
- root の `Plan.md` を LIN-796 向けに更新
- root の `Implement.md` を LIN-796 向けに更新
- root の `Documentation.md` を LIN-796 向けに更新
- LIN-796 の子 issue 相当実装が既存コードに存在することを確認
  - LIN-811: 招待コード検証 API
  - LIN-816: 招待参加 API
  - LIN-819: FE 招待導線接続
- `codex/lin-796` が `origin/main` と差分 `0/0` であることを確認

## 変更しないもの

- invite verify / join / FE 導線の product code
- API 契約や UI 挙動
- 新規仕様追加

## 検証

### 実行済み

- `cargo test -p linklynx_backend invite::tests:: -- --nocapture`
  - 結果: 28 passed / 0 failed

### 環境依存で未実行

- `make validate`
- `cd typescript && npm run typecheck`
- `cd typescript && npm run test -- --run src/app/invite/[code]/page.test.tsx src/app/invite/[code]/invite-page-client.test.tsx src/features/invite-flow/api/join-invite.test.ts`

未実行理由:
- `typescript/node_modules` が存在せず、`prettier` / `vitest` が未導入のため

## ADR-001 チェック

- event schema 変更: なし
- additive compatibility 判断: N/A
- consumer 影響: なし

## 補足

- invite join の `AuthN required / AuthZ excluded` 契約は ADR-004 を維持
- invite access の rate-limit outage policy は ADR-005 を維持
- 現時点では LIN-796 に対する追加の product code 差分は確認できていません
