### PR TITLE
LIN-950 契約整理（Discord ライク role/API/AuthZ）

### DIFF
--- a/database/contracts/lin950_v2_server_role_authz_contract.md
+++ b/database/contracts/lin950_v2_server_role_authz_contract.md
@@ -1,0 +1,268 @@
+# LIN-950 v2 Server Role / Channel Permission / AuthZ Contract
+
+## Purpose
+
+- target issue: LIN-950
+- `LIN-949` の後続実装が迷わないよう、v2 最小スコープの server role / member role assignment / channel permission override / SpiceDB AuthZ 接続点を固定する。
+- 既存の `guild_roles_v2` / `guild_member_roles_v2` / `channel_role_permission_overrides_v2` / `channel_user_permission_overrides_v2` を SoR のまま使い、破壊的な schema 追加なしで進める。
+
+## Scope
+
+In scope:
+- server role CRUD / reorder の最小契約
+- member role assignment の最小契約
+- channel role/user override の read/write 契約
+- system role 保護、owner lock-out 防止、cross-guild 拒否
+- `View/Post/Manage` と endpoint/UI の写像
+- invalidation / tuple sync / permission snapshot の反映経路
+
+Out of scope:
+- Discord full permission bitset
+- `color` / `hoist` / `mentionable` の backend 永続化
+- 新しい system role や新規 permission column の追加
+- voice/forum/thread/stage など別ドメイン固有の permission surface
+
+## 1. Minimal role model baseline
+
+### 1.1 Role fields
+
+v2 minimal scope で backend が扱う role field は以下に固定する。
+
+- `role_key`
+- `name`
+- `priority`
+- `allow_view`
+- `allow_post`
+- `allow_manage`
+- `is_system`
+- `member_count`（read only）
+
+Notes:
+- `color` / `hoist` / `mentionable` / Discord bitset `permissions` は今回の backend 契約に含めない。
+- frontend は未対応 metadata を hidden または read-only fallback とし、保存対象に含めない。
+
+### 1.2 System role baseline
+
+system role は既存 seed に合わせて以下で固定する。
+
+- `owner`
+- `admin`
+- `member`
+
+Rule:
+- `member` は UI では必要に応じて `@everyone` と表示してよい。
+- backend の canonical key は `member` のままとする。
+- v2 minimal scope では system role は read-only とする。
+  - rename 不可
+  - delete 不可
+  - reorder 不可
+  - `allow_view` / `allow_post` / `allow_manage` 変更不可
+
+### 1.3 Role mutability
+
+- custom role のみ create / update / delete / reorder を許可する。
+- create 時の `role_key` は client 入力ではなく backend 生成とする。
+  - source: `name` を slug 化
+  - collision 時は連番 suffix を付与
+- update で変更可能なのは `name` / `allow_view` / `allow_post` / `allow_manage` のみとする。
+- `priority` は reorder API でのみ更新する。
+
+## 2. Member assignment baseline
+
+- guild member の role assignment は `guild_member_roles_v2` を SoR とする。
+- write API は full replacement 方式で固定する。
+  - caller は対象 member の最終 `role_keys[]` を送る
+  - server が差分計算して assign/revoke を行う
+- validation:
+  - `member` は guild member から外せない
+  - guild owner から `owner` を外せない
+  - guild owner 以外へ `owner` を付与できない
+  - role は同一 guild 所属のみ指定可能
+  - unknown role / non-member / cross-guild は validation or forbidden で fail-close
+
+## 3. Channel permission override baseline
+
+- channel override は channel 全体の replacement write 方式で固定する。
+- request/response は role override と user override を同一 payload で扱う。
+
+### 3.1 Override state
+
+transport value は以下に固定する。
+
+- `allow`
+- `deny`
+- `inherit`
+
+DB mapping:
+- `allow` -> `TRUE`
+- `deny` -> `FALSE`
+- `inherit` -> `NULL`
+
+### 3.2 Evaluation precedence
+
+`View` / `Post` の評価順は既存契約を維持する。
+
+1. user explicit deny
+2. user explicit allow
+3. role explicit deny
+4. role explicit allow
+5. role default (`allow_view` / `allow_post`)
+6. default deny
+
+## 4. Planned REST API family
+
+### 4.1 Role APIs
+
+- `GET /v1/guilds/{guild_id}/roles`
+- `POST /v1/guilds/{guild_id}/roles`
+- `PATCH /v1/guilds/{guild_id}/roles/{role_key}`
+- `DELETE /v1/guilds/{guild_id}/roles/{role_key}`
+- `PUT /v1/guilds/{guild_id}/roles/reorder`
+
+Response baseline:
+
+```json
+{
+  "roles": [
+    {
+      "role_key": "member",
+      "name": "Member",
+      "priority": 100,
+      "allow_view": true,
+      "allow_post": true,
+      "allow_manage": false,
+      "is_system": true,
+      "member_count": 42
+    }
+  ]
+}
+```
+
+Reorder baseline:
+- request body は custom role の ordered `role_keys[]` を送る
+- server は pinned system role（`owner > admin > member`）を維持しつつ custom role priority を再計算する
+
+### 4.2 Member role assignment APIs
+
+- `GET /v1/guilds/{guild_id}/members`
+- `PUT /v1/guilds/{guild_id}/members/{member_id}/roles`
+
+Assignment write baseline:
+
+```json
+{
+  "role_keys": ["member", "moderator"]
+}
+```
+
+### 4.3 Channel permission APIs
+
+- `GET /v1/guilds/{guild_id}/channels/{channel_id}/permissions`
+- `PUT /v1/guilds/{guild_id}/channels/{channel_id}/permissions`
+
+Payload baseline:
+
+```json
+{
+  "role_overrides": [
+    {
+      "role_key": "member",
+      "can_view": "allow",
+      "can_post": "deny"
+    }
+  ],
+  "user_overrides": [
+    {
+      "user_id": 2001,
+      "can_view": "inherit",
+      "can_post": "allow"
+    }
+  ]
+}
+```
+
+Notes:
+- `GET` response は UI 用の `subject_name` / `is_system` などの read field を追加してよい。
+- `PUT` は channel 内の managed subjects を replacement 更新し、未送信 subject は row 削除または全 `inherit` 扱いへ正規化する。
+
+## 5. AuthZ mapping baseline
+
+### 5.1 Required action mapping
+
+- role management APIs: `AuthzResource::Guild { guild_id } + Manage`
+- member role assignment APIs: `AuthzResource::Guild { guild_id } + Manage`
+- channel permission APIs: `AuthzResource::GuildChannel { guild_id, channel_id } + Manage`
+- existing channel/message operations:
+  - view -> `View`
+  - post -> `Post`
+  - create/edit/delete/settings -> `Manage`
+
+### 5.2 Permission snapshot alignment
+
+- permission snapshot の boolean contract は `LIN-925` / `LIN-926` を維持する。
+- v2 scope で追加 UI は snapshot の既存 boolean だけを利用する。
+  - settings route / role management / member role assignment -> `guild.can_manage_settings`
+  - channel permission editor -> `channel.can_manage`
+- frontend は role bitset をローカル解釈しない。
+
+### 5.3 Fail-close behavior
+
+ADR-004 に従い、以下を維持する。
+
+- deterministic deny -> `403 / AUTHZ_DENIED`
+- dependency unavailable -> `503 / AUTHZ_UNAVAILABLE`
+- WS deny -> `1008`
+- WS unavailable -> `1011`
+
+## 6. Persistence and propagation baseline
+
+- SoR:
+  - `guild_roles_v2`
+  - `guild_member_roles_v2`
+  - `channel_role_permission_overrides_v2`
+  - `channel_user_permission_overrides_v2`
+- role / assignment / override 変更後は以下の両方へ接続する。
+  - AuthZ cache invalidation
+  - SpiceDB tuple sync 用 outbox event
+
+Required invalidation kind:
+- `guild_role_changed`
+- `guild_member_role_changed`
+- `channel_role_override_changed`
+- `channel_user_override_changed`
+
+Tuple sync family:
+- `authz.tuple.guild_role.v1`
+- `authz.tuple.guild_member_role.v1`
+- `authz.tuple.channel_role_override.v1`
+- `authz.tuple.channel_user_override.v1`
+
+Rule:
+- write transaction が commit された変更だけを invalidation / tuple sync 対象とする。
+- invalidation / tuple sync の一部失敗は silent ignore せず、後続 issue で retry / observability を保証する。
+
+## 7. Frontend compatibility baseline
+
+- `ServerRoles` は current mock `Role` shape から最小 DTO へ移行する。
+- `ServerMembers` は `role_keys[]` を SSOT とし、role label は role list query で解決する。
+- `ChannelEditPermissions` は `allow|deny|inherit` を transport value とし、bitset 由来の permission UI は持ち込まない。
+- UI label:
+  - backend `member` -> UI `@everyone`
+  - `owner` / `admin` / custom role はそのまま表示
+
+## 8. Explicit non-goals for follow-up issues
+
+- system role の mutable 化
+- full Discord permission matrix
+- `member` と別の dedicated `everyone` role 新設
+- `color` / `hoist` / `mentionable` backend persistence
+
+## 9. Validation
+
+Docs/contract issue の最小検証:
+
+```bash
+make validate
+make rust-lint
+cd typescript && npm run typecheck
+```

--- a/docs/AUTHZ.md
+++ b/docs/AUTHZ.md
@@ -294,3 +294,24 @@ v0 での認可関連 SoR:
   - `guild:moderate` -> moderation queue / moderation report detail / resolve / reopen / mute
   - `channel:manage` -> channel context menu の edit/delete / channel item settings shortcut / channel edit overview / channel delete modal
 - invite 作成に加えて、invite 一覧/取消も real API/client 実装済み。invite は引き続き guild-scope 管理とし、channel 固有 list は持たない。
+
+## 16. LIN-950 v2 server role / channel permission management baseline
+
+- `LIN-949` 配下の v2 最小スコープでは、server role / member role assignment / channel permission override の契約SSOTを `database/contracts/lin950_v2_server_role_authz_contract.md` に固定する。
+- role model は既存 `guild_roles_v2` 系の最小 field を維持し、backend scope は `role_key`, `name`, `priority`, `allow_view`, `allow_post`, `allow_manage`, `is_system`, `member_count` に限定する。
+- `color` / `hoist` / `mentionable` / Discord full bitset は今回の backend/AuthZ 契約に含めない。
+- system role は既存 seed (`owner`, `admin`, `member`) を唯一の baseline とし、v2 minimal scope では read-only とする。
+  - `member` は UI で `@everyone` alias として表示してよい
+  - backend canonical key は `member` のままとする
+- planned endpoint family は以下で固定する。
+  - `/v1/guilds/{guild_id}/roles`
+  - `/v1/guilds/{guild_id}/members/{member_id}/roles`
+  - `/v1/guilds/{guild_id}/channels/{channel_id}/permissions`
+- action mapping は以下で固定する。
+  - role management: `Guild + Manage`
+  - member role assignment: `Guild + Manage`
+  - channel permission editor: `GuildChannel + Manage`
+- permission snapshot と FE ActionGuard は `LIN-925` / `LIN-926` の boolean contract を維持し、新しい role bitset 解釈は frontend に導入しない。
+- role / assignment / override 変更時は `LIN-864` tuple sync family と AuthZ cache invalidation の両方へ接続する。
+  - invalidation kind: `guild_role_changed`, `guild_member_role_changed`, `channel_role_override_changed`, `channel_user_override_changed`
+  - tuple sync family: `authz.tuple.guild_role.v1`, `authz.tuple.guild_member_role.v1`, `authz.tuple.channel_role_override.v1`, `authz.tuple.channel_user_override.v1`

--- a/docs/AUTHZ_API_MATRIX.md
+++ b/docs/AUTHZ_API_MATRIX.md
@@ -170,3 +170,39 @@
   - backend に等価な `v1` alias を追加しても AuthN/AuthZ/監査ログ契約が変わらないこと
   - FE / client query が `v1` alias へ移行済みであること
   - 監査ダッシュボード / runbook が新旧 path の混在を不要と判断できること
+
+## 7. LIN-950 planned v2 role-management additions (not yet implemented)
+
+この節は current implementation ではなく、`LIN-950` で固定した downstream 実装前提を記録する。
+
+### 7.1 Planned protected endpoints
+
+- `GET /v1/guilds/:guild_id/roles`
+- `POST /v1/guilds/:guild_id/roles`
+- `PATCH /v1/guilds/:guild_id/roles/:role_key`
+- `DELETE /v1/guilds/:guild_id/roles/:role_key`
+- `PUT /v1/guilds/:guild_id/roles/reorder`
+- `GET /v1/guilds/:guild_id/members`
+- `PUT /v1/guilds/:guild_id/members/:member_id/roles`
+- `GET /v1/guilds/:guild_id/channels/:channel_id/permissions`
+- `PUT /v1/guilds/:guild_id/channels/:channel_id/permissions`
+
+### 7.2 Planned action mapping
+
+| Surface | Operation | Principal | Resource | Action | Planned decision handling |
+| --- | --- | --- | --- | --- | --- |
+| REST | `GET /v1/guilds/:guild_id/roles` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | settings read を一般 member に開かず、deny=`403`, unavailable=`503` |
+| REST | `POST /v1/guilds/:guild_id/roles` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | custom role create のみ許可 |
+| REST | `PATCH /v1/guilds/:guild_id/roles/:role_key` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | system role update は deterministic deny |
+| REST | `DELETE /v1/guilds/:guild_id/roles/:role_key` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | system role delete と owner lock-out は deterministic deny |
+| REST | `PUT /v1/guilds/:guild_id/roles/reorder` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | pinned system role 順序は維持 |
+| REST | `GET /v1/guilds/:guild_id/members` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | settings read として manage 保護へ引き上げる |
+| REST | `PUT /v1/guilds/:guild_id/members/:member_id/roles` | AuthN済み `principal_id` | `AuthzResource::Guild { guild_id }` | `Manage` | `member` baseline、`owner` 制約、cross-guild 拒否を fail-close 適用する |
+| REST | `GET /v1/guilds/:guild_id/channels/:channel_id/permissions` | AuthN済み `principal_id` | `AuthzResource::GuildChannel { guild_id, channel_id }` | `Manage` | role/user override editor の read |
+| REST | `PUT /v1/guilds/:guild_id/channels/:channel_id/permissions` | AuthN済み `principal_id` | `AuthzResource::GuildChannel { guild_id, channel_id }` | `Manage` | role/user override replacement write。deny=`403`, unavailable=`503` |
+
+### 7.3 Planned FE/API alignment
+
+- settings route の role list / member list / role assignment は `guild.can_manage_settings` 前提で guarded にする。
+- channel permission editor は `channel.can_manage` 前提で guarded にする。
+- `member` role は UI で `@everyone` として表示し、backend transport では `member` を送る。

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -261,6 +261,12 @@ The source of truth for SpiceDB namespace/relation/permission design aligned wit
 The source of truth for Postgres `*_v2` permission data to canonical SpiceDB tuple conversion, initial backfill contract, outbox delta-sync semantics, and full-resync operational hook is:
 
 - `database/contracts/lin864_postgres_spicedb_tuple_sync_contract.md`
+
+### 2.24 v2 Server Role / Channel Permission / AuthZ Contract (LIN-950)
+
+The source of truth for v2 minimal server role fields, member role assignment rules, channel permission override transport, system role protection, and downstream AuthZ integration points is:
+
+- `database/contracts/lin950_v2_server_role_authz_contract.md`
 ## 3. ScyllaDB の現在状態
 
 基準: `database/scylla/001_lin139_messages.cql`
@@ -348,3 +354,5 @@ The source of truth for Scylla operations (SoR boundary, partition review criter
   - `database/contracts/lin948_message_create_idempotency_contract.md`
 - LIN-862 SpiceDB namespace/relation/permission model contract:
   - `database/contracts/lin862_spicedb_namespace_relation_permission_contract.md`
+- LIN-950 v2 server role / channel permission / AuthZ contract:
+  - `database/contracts/lin950_v2_server_role_authz_contract.md`

--- a/docs/agent_runs/LIN-950/Documentation.md
+++ b/docs/agent_runs/LIN-950/Documentation.md
@@ -1,0 +1,30 @@
+# Documentation
+
+## Current status
+- Now: LIN-950 contract docs と SSOT 追記は完了
+- Next: review evidence を固めて child PR 化する
+
+## Decisions
+- `@everyone` は UI alias とし、backend の baseline system role は `member` を維持する。
+- role metadata は `name` / `priority` / `allow_view` / `allow_post` / `allow_manage` / `is_system` に限定する。
+- system role (`owner/admin/member`) は v2 minimal scope では read-only とする。
+
+## How to run / demo
+- docs diff を確認し、後続 issue が参照すべき SSOT を確認する。
+
+## Validation log
+- `git diff --check`: pass
+- `pnpm -C typescript install --frozen-lockfile`: pass
+- `make rust-lint`: pass
+- `cd typescript && npm run typecheck`: pass
+- `make validate`: pass
+
+## Environment notes
+- `make validate` 実行前に Python 環境で `pip` が使えなかったため、local の `python/.venv` を bootstrap して依存関係を投入した。
+- validation 用に生成された `typescript/tsconfig.tsbuildinfo` は issue diff に含めない。
+
+## Known issues / follow-ups
+- actual endpoint / DTO 実装は `LIN-951`
+- request-time AuthZ 適用は `LIN-952`
+- frontend 接続は `LIN-953`
+- regression/runbook は `LIN-954`

--- a/docs/agent_runs/LIN-950/Implement.md
+++ b/docs/agent_runs/LIN-950/Implement.md
@@ -1,0 +1,13 @@
+# Implement
+
+- Follow `Plan.md` as the single execution order. If order changes are needed, record the reason in `Documentation.md`.
+- Keep the diff limited to docs and issue-run memory files.
+- Preserve current implementation facts in `docs/AUTHZ_API_MATRIX.md`; add LIN-950 content as planned/future baseline instead of rewriting current-state sections.
+- Reuse existing terminology:
+  - role defaults: `allow_view` / `allow_post` / `allow_manage`
+  - channel override tri-state: `allow` / `deny` / `inherit`
+  - invalidation kinds: `guild_role_changed`, `guild_member_role_changed`, `channel_role_override_changed`, `channel_user_override_changed`
+- Before closing the issue, ensure the docs make these defaults explicit:
+  - UI label `@everyone` maps to backend `member`
+  - system roles are read-only in v2 minimal scope
+  - unsupported metadata (`color` / `hoist` / `mentionable`) stays out of backend scope

--- a/docs/agent_runs/LIN-950/Plan.md
+++ b/docs/agent_runs/LIN-950/Plan.md
@@ -1,0 +1,31 @@
+# Plan
+
+## Rules
+- Stop-and-fix: validation / review 失敗時は次工程へ進まない。
+- Scope lock: LIN-950 は contract/doc 整理に限定し、backend/frontend 実装は `LIN-951` 以降へ送る。
+- Start mode: child issue start (`LIN-950` under `LIN-949`)。
+
+## Milestones
+### M1: v2 server role / channel permission / AuthZ 最小契約を定義する
+- Acceptance criteria:
+  - [x] role metadata scope と `@everyone` 方針が固定されている
+  - [x] planned REST family と request/response の基準がある
+  - [x] system role 保護と owner lock-out 防止条件が明文化されている
+- Validation:
+  - `make validate`
+
+### M2: 既存 SSOT docs に downstream 向け参照を追加する
+- Acceptance criteria:
+  - [x] `docs/AUTHZ.md` が LIN-950 baseline を参照している
+  - [x] `docs/AUTHZ_API_MATRIX.md` に planned endpoint/action mapping がある
+  - [x] `docs/DATABASE.md` が新 contract を参照している
+- Validation:
+  - `make validate`
+
+### M3: issue run 記録と review evidence を固める
+- Acceptance criteria:
+  - [x] `Documentation.md` に decisions と validation 結果が残っている
+  - [x] review gate の blocking finding がない
+  - [x] child issue evidence を PR に転記できる状態である
+- Validation:
+  - `make validate`

--- a/docs/agent_runs/LIN-950/Prompt.md
+++ b/docs/agent_runs/LIN-950/Prompt.md
@@ -1,0 +1,27 @@
+# Prompt
+
+## Goals
+- `LIN-949` 配下の `LIN-950` として、v2 server role / channel permission / SpiceDB AuthZ の最小契約を固定する。
+- 後続の `LIN-951`〜`LIN-954` が API、UI、AuthZ 適用点、反映経路で迷わない状態にする。
+
+## Non-goals
+- backend / frontend の実装着手
+- Discord full permission bitset の導入
+- `color` / `hoist` / `mentionable` の永続化
+
+## Deliverables
+- `database/contracts/lin950_v2_server_role_authz_contract.md`
+- `docs/AUTHZ.md` への LIN-950 baseline 追記
+- `docs/AUTHZ_API_MATRIX.md` への planned endpoint/action mapping 追記
+- `docs/DATABASE.md` への contract 参照追記
+
+## Done when
+- [x] v2 最小スコープの role/API/AuthZ 契約が 1 文書で追える
+- [x] planned endpoint と `View/Post/Manage` 写像が明記されている
+- [x] `@everyone` / system role / owner lock-out / invalidation 経路の扱いが固定されている
+- [x] 後続 issue 向けの docs 参照先が更新されている
+
+## Constraints
+- Perf: outbox / tuple sync / cache invalidation の既存経路を再利用する
+- Security: ADR-004 fail-close を厳守する
+- Compatibility: existing `*_v2` schema と permission snapshot 契約を壊さない


### PR DESCRIPTION
## 概要
- v2 の server role / member role assignment / channel permission override の最小契約を追加
- AuthZ / permission snapshot / invalidation / tuple sync の接続点を SSOT docs に反映
- 後続の LIN-951 から LIN-954 が参照すべき planned endpoint と action mapping を固定

## 変更内容
- `database/contracts/lin950_v2_server_role_authz_contract.md` を追加
- `docs/AUTHZ.md` に LIN-950 baseline を追記
- `docs/AUTHZ_API_MATRIX.md` に planned v2 role-management additions を追記
- `docs/DATABASE.md` に LIN-950 contract 参照を追記
- `docs/agent_runs/LIN-950/` に Prompt/Plan/Implement/Documentation を追加

## 検証
- `git diff --check`
- `make validate`
- `make rust-lint`
- `cd typescript && npm run typecheck`

## 補足
- backend / frontend の実装着手は含めず、LIN-951 以降の入力を固定する docs-only PR です
- event contract 変更はなく、ADR-001 の追加互換性判断は不要です

Closes LIN-950
