### PR TITLE
LIN-951 role/member/permission backend API 実装

### DIFF
--- a/docs/agent_runs/LIN-951/Documentation.md
+++ b/docs/agent_runs/LIN-951/Documentation.md
@@ -1,0 +1,27 @@
+# Documentation
+
+## Current status
+- Now: backend API 実装と handler テスト、validation が完了しており、child PR 化の evidence を整理している
+- Next: `git diff --check` と review/smoke evidence を確定して commit / PR / Linear 更新へ進む
+
+## Decisions
+- role/member/permission 管理 API は既存 `user_directory` 境界を拡張して実装する。
+- invalidation / tuple sync は既存 event kind / event type を再利用する。
+- write は Postgres transaction で完結させ、tuple sync 用 outbox event は transaction 内で追加する。
+- AuthZ cache invalidation は handler 成功後に `state.authorizer.invalidate_cache(...)` で行い、DB service は DB write と event 生成に責務を限定する。
+- backend の canonical system role key は `member` を維持し、UI alias の `@everyone` は `LIN-953` 側で扱う。
+
+## How to run / demo
+- Validation:
+  - `cargo test -p linklynx_backend -- --nocapture` : pass
+  - `make rust-lint` : pass
+  - `cd typescript && npm run typecheck` : pass
+  - `make validate` : pass
+- Runtime smoke:
+  - backend API 変更であり UI 変更を含まないため、`make dev` / Playwright の end-to-end smoke は child issue `LIN-954` の統合回帰で実施する。
+
+## Known issues / follow-ups
+- request-time AuthZ 実接続は `LIN-952`
+- frontend 接続は `LIN-953`
+- end-to-end 回帰整理は `LIN-954`
+- Postgres write path は compile/validation と handler テストで担保しており、専用 DB integration test の厚みは今後の回帰で強化余地がある。

--- a/docs/agent_runs/LIN-951/Implement.md
+++ b/docs/agent_runs/LIN-951/Implement.md
@@ -1,0 +1,19 @@
+# Implement
+
+- Follow `Plan.md` as the single execution order. If order changes are needed, record the reason in `Documentation.md`.
+- Reuse `user_directory` as the API/service boundary unless a hard blocker appears.
+- Keep write logic transactional and co-locate validation with persistence where possible.
+- Reuse existing invalidation kinds and tuple event types:
+  - `guild_role_changed`
+  - `guild_member_role_changed`
+  - `channel_role_override_changed`
+  - `channel_user_override_changed`
+  - `authz.tuple.guild_role.v1`
+  - `authz.tuple.guild_member_role.v1`
+  - `authz.tuple.channel_role_override.v1`
+  - `authz.tuple.channel_user_override.v1`
+- Before closing the issue, ensure these contract points are enforced in code:
+  - system role (`owner/admin/member`) is read-only
+  - backend canonical role key stays `member`
+  - custom role reorder keeps pinned system role order
+  - replacement writes normalize missing overrides to deletion / inherit

--- a/docs/agent_runs/LIN-951/Plan.md
+++ b/docs/agent_runs/LIN-951/Plan.md
@@ -1,0 +1,29 @@
+# Plan
+
+## Rules
+- Stop-and-fix: validation / review 失敗時は次工程へ進まない。
+- Scope lock: LIN-951 は backend API と server-side validation に限定し、request-time AuthZ 適用や frontend 接続は混ぜない。
+
+## Milestones
+### M1: service / route 契約を write-aware に拡張する
+- Acceptance criteria:
+  - [x] role CRUD / reorder / assignment / override 用 DTO と endpoint が追加されている
+  - [x] error model が既存 user directory contract と整合している
+- Validation:
+  - `make rust-lint`
+
+### M2: Postgres write path と event 経路を実装する
+- Acceptance criteria:
+  - [x] transaction 境界で validation と DB write が実装されている
+  - [x] invalidation / tuple sync outbox event が生成される
+  - [x] system role 保護 / cross-guild 拒否 / owner lock-out 防止が server 側で強制される
+- Validation:
+  - `make rust-lint`
+
+### M3: 主要正常系 / 異常系テストと issue evidence を固める
+- Acceptance criteria:
+  - [x] handler / Postgres テストで主要ケースが固定されている
+  - [x] `Documentation.md` に decisions と validation 結果が残っている
+  - [x] child PR に転記できる evidence が揃っている
+- Validation:
+  - `make validate`

--- a/docs/agent_runs/LIN-951/Prompt.md
+++ b/docs/agent_runs/LIN-951/Prompt.md
@@ -1,0 +1,27 @@
+# Prompt
+
+## Goals
+- `LIN-951` として、v2 server role CRUD / reorder、member role assignment、channel role/user permission override の backend API を実装する。
+- `guild_roles_v2`, `guild_member_roles_v2`, `channel_role_permission_overrides_v2`, `channel_user_permission_overrides_v2` を SoR として、validation と event 経路まで end-to-end で繋ぐ。
+
+## Non-goals
+- frontend UI 接続
+- request-time `AUTHZ_PROVIDER=spicedb` 適用切替
+- Discord full permission bitset 導入
+
+## Deliverables
+- backend endpoint 実装
+- Postgres transaction / validation / outbox event 実装
+- handler/service/postgres テスト
+- `docs/agent_runs/LIN-951/*`
+
+## Done when
+- [x] role CRUD / reorder が contract どおりに動く
+- [x] member role assignment と channel permission read/write が contract どおりに動く
+- [x] system role 保護 / cross-guild 拒否 / owner lock-out 防止が固定される
+- [x] invalidation / tuple sync 用 event が write transaction と同時に生成される
+
+## Constraints
+- Perf: 既存 `user_directory` / outbox / tuple sync 基盤を再利用する
+- Security: fail-close と server-side validation を優先する
+- Compatibility: `LIN-950` contract と既存 `*_v2` schema を壊さない

--- a/rust/apps/api/src/main.rs
+++ b/rust/apps/api/src/main.rs
@@ -40,7 +40,7 @@ use axum::{
     http::{header::RETRY_AFTER, HeaderMap, HeaderValue, Request, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Response},
-    routing::{get, patch, post},
+    routing::{get, patch, post, put},
     Json, Router,
 };
 use dm::{build_runtime_dm_service, dm_error_response, DmService};

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -72,7 +72,22 @@ fn app_with_state(state: AppState) -> Router {
         .route("/v1/guilds/{guild_id}", get(get_guild))
         .route("/v1/guilds/{guild_id}", axum::routing::patch(update_guild))
         .route("/v1/guilds/{guild_id}/members", get(get_guild_members))
-        .route("/v1/guilds/{guild_id}/roles", get(get_guild_roles))
+        .route(
+            "/v1/guilds/{guild_id}/members/{member_id}/roles",
+            put(replace_member_roles),
+        )
+        .route(
+            "/v1/guilds/{guild_id}/roles",
+            get(get_guild_roles).post(create_guild_role),
+        )
+        .route(
+            "/v1/guilds/{guild_id}/roles/reorder",
+            put(reorder_guild_roles),
+        )
+        .route(
+            "/v1/guilds/{guild_id}/roles/{role_key}",
+            axum::routing::patch(update_guild_role).delete(delete_guild_role),
+        )
         .route(
             "/v1/guilds/{guild_id}/invites",
             get(list_guild_invites).post(create_guild_invite),
@@ -84,6 +99,10 @@ fn app_with_state(state: AppState) -> Router {
         .route(
             "/v1/guilds/{guild_id}/channels/{channel_id}",
             get(get_guild_channel),
+        )
+        .route(
+            "/v1/guilds/{guild_id}/channels/{channel_id}/permissions",
+            get(get_channel_permissions).put(replace_channel_permissions),
         )
         .route(
             "/v1/guilds/{guild_id}/channels/{channel_id}/messages",
@@ -1564,6 +1583,17 @@ fn build_authz_cache_invalidation_event(
     Ok(AuthzCacheInvalidationEvent { kind, occurred_at })
 }
 
+/// 認可キャッシュ invalidation イベント群を適用する。
+/// @param state アプリケーション状態
+/// @param events 適用対象イベント
+/// @returns なし
+/// @throws なし
+async fn invalidate_authz_cache_events(state: &AppState, events: &[AuthzCacheInvalidationEvent]) {
+    for event in events {
+        state.authorizer.invalidate_cache(event).await;
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct WsTicketResponse {
     ticket: String,
@@ -1867,6 +1897,58 @@ struct GuildRolesResponse {
     roles: Vec<user_directory::GuildRoleDirectoryEntry>,
 }
 
+#[derive(Debug, Serialize)]
+struct GuildMemberResponse {
+    member: user_directory::GuildMemberDirectoryEntry,
+}
+
+#[derive(Debug, Serialize)]
+struct GuildRoleResponse {
+    role: user_directory::GuildRoleDirectoryEntry,
+}
+
+#[derive(Debug, Serialize)]
+struct ChannelPermissionsResponse {
+    permissions: user_directory::ChannelPermissionDirectoryEntry,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateGuildRoleRequest {
+    name: String,
+    allow_view: bool,
+    allow_post: bool,
+    allow_manage: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PatchGuildRoleRequest {
+    name: Option<String>,
+    allow_view: Option<bool>,
+    allow_post: Option<bool>,
+    allow_manage: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReorderGuildRolesRequest {
+    role_keys: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReplaceMemberRolesRequest {
+    role_keys: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReplaceChannelPermissionsRequest {
+    role_overrides: Vec<user_directory::ChannelRolePermissionOverrideInput>,
+    user_overrides: Vec<user_directory::ChannelUserPermissionOverrideInput>,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ProfileMediaUploadUrlRequest {
@@ -1899,6 +1981,18 @@ struct ModerationGuildPathParams {
 #[derive(Debug, Deserialize)]
 struct UserPathParams {
     user_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GuildMemberPathParams {
+    guild_id: String,
+    member_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GuildRolePathParams {
+    guild_id: String,
+    role_key: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3391,6 +3485,323 @@ async fn get_guild_roles(
     }
 }
 
+/// guild role を作成する。
+/// @param state アプリケーション状態
+/// @param auth_context 認証文脈
+/// @param params guild_id を含むパスパラメータ
+/// @param request 作成入力
+/// @returns guild role レスポンス
+/// @throws なし
+async fn create_guild_role(
+    State(state): State<AppState>,
+    Extension(auth_context): Extension<AuthContext>,
+    Path(params): Path<GuildPathParams>,
+    Json(request): Json<CreateGuildRoleRequest>,
+) -> Response {
+    let request_id = auth_context.request_id.clone();
+    let guild_id = match parse_user_directory_guild_id(&params.guild_id) {
+        Ok(value) => value,
+        Err(error) => return user_directory_error_response(&error, request_id),
+    };
+
+    match state
+        .user_directory_service
+        .create_guild_role(
+            auth_context.principal_id,
+            guild_id,
+            user_directory::CreateGuildRoleInput {
+                name: request.name,
+                allow_view: request.allow_view,
+                allow_post: request.allow_post,
+                allow_manage: request.allow_manage,
+            },
+        )
+        .await
+    {
+        Ok(role) => {
+            invalidate_authz_cache_events(
+                &state,
+                &[AuthzCacheInvalidationEvent {
+                    kind: AuthzCacheInvalidationEventKind::GuildRoleChanged { guild_id },
+                    occurred_at: std::time::SystemTime::now(),
+                }],
+            )
+            .await;
+            (StatusCode::CREATED, Json(GuildRoleResponse { role })).into_response()
+        }
+        Err(error) => user_directory_error_response(&error, request_id),
+    }
+}
+
+/// guild role を更新する。
+/// @param state アプリケーション状態
+/// @param auth_context 認証文脈
+/// @param params guild_id/role_key を含むパスパラメータ
+/// @param request 更新入力
+/// @returns guild role レスポンス
+/// @throws なし
+async fn update_guild_role(
+    State(state): State<AppState>,
+    Extension(auth_context): Extension<AuthContext>,
+    Path(params): Path<GuildRolePathParams>,
+    Json(request): Json<PatchGuildRoleRequest>,
+) -> Response {
+    let request_id = auth_context.request_id.clone();
+    let guild_id = match parse_user_directory_guild_id(&params.guild_id) {
+        Ok(value) => value,
+        Err(error) => return user_directory_error_response(&error, request_id),
+    };
+
+    match state
+        .user_directory_service
+        .update_guild_role(
+            auth_context.principal_id,
+            guild_id,
+            &params.role_key,
+            user_directory::GuildRolePatchInput {
+                name: request.name,
+                allow_view: request.allow_view,
+                allow_post: request.allow_post,
+                allow_manage: request.allow_manage,
+            },
+        )
+        .await
+    {
+        Ok(role) => {
+            invalidate_authz_cache_events(
+                &state,
+                &[AuthzCacheInvalidationEvent {
+                    kind: AuthzCacheInvalidationEventKind::GuildRoleChanged { guild_id },
+                    occurred_at: std::time::SystemTime::now(),
+                }],
+            )
+            .await;
+            Json(GuildRoleResponse { role }).into_response()
+        }
+        Err(error) => user_directory_error_response(&error, request_id),
+    }
+}
+
+/// guild role を削除する。
+/// @param state アプリケーション状態
+/// @param auth_context 認証文脈
+/// @param params guild_id/role_key を含むパスパラメータ
+/// @returns no content
+/// @throws なし
+async fn delete_guild_role(
+    State(state): State<AppState>,
+    Extension(auth_context): Extension<AuthContext>,
+    Path(params): Path<GuildRolePathParams>,
+) -> Response {
+    let request_id = auth_context.request_id.clone();
+    let guild_id = match parse_user_directory_guild_id(&params.guild_id) {
+        Ok(value) => value,
+        Err(error) => return user_directory_error_response(&error, request_id),
+    };
+
+    match state
+        .user_directory_service
+        .delete_guild_role(auth_context.principal_id, guild_id, &params.role_key)
+        .await
+    {
+        Ok(()) => {
+            invalidate_authz_cache_events(
+                &state,
+                &[AuthzCacheInvalidationEvent {
+                    kind: AuthzCacheInvalidationEventKind::GuildRoleChanged { guild_id },
+                    occurred_at: std::time::SystemTime::now(),
+                }],
+            )
+            .await;
+            StatusCode::NO_CONTENT.into_response()
+        }
+        Err(error) => user_directory_error_response(&error, request_id),
+    }
+}
+
+/// guild custom role の順序を置換する。
+/// @param state アプリケーション状態
+/// @param auth_context 認証文脈
+/// @param params guild_id を含むパスパラメータ
+/// @param request 並び替え入力
+/// @returns guild role 一覧レスポンス
+/// @throws なし
+async fn reorder_guild_roles(
+    State(state): State<AppState>,
+    Extension(auth_context): Extension<AuthContext>,
+    Path(params): Path<GuildPathParams>,
+    Json(request): Json<ReorderGuildRolesRequest>,
+) -> Response {
+    let request_id = auth_context.request_id.clone();
+    let guild_id = match parse_user_directory_guild_id(&params.guild_id) {
+        Ok(value) => value,
+        Err(error) => return user_directory_error_response(&error, request_id),
+    };
+
+    match state
+        .user_directory_service
+        .reorder_guild_roles(auth_context.principal_id, guild_id, request.role_keys)
+        .await
+    {
+        Ok(roles) => {
+            invalidate_authz_cache_events(
+                &state,
+                &[AuthzCacheInvalidationEvent {
+                    kind: AuthzCacheInvalidationEventKind::GuildRoleChanged { guild_id },
+                    occurred_at: std::time::SystemTime::now(),
+                }],
+            )
+            .await;
+            Json(GuildRolesResponse { roles }).into_response()
+        }
+        Err(error) => user_directory_error_response(&error, request_id),
+    }
+}
+
+/// guild member の role 割当を置換する。
+/// @param state アプリケーション状態
+/// @param auth_context 認証文脈
+/// @param params guild_id/member_id を含むパスパラメータ
+/// @param request 割当入力
+/// @returns guild member レスポンス
+/// @throws なし
+async fn replace_member_roles(
+    State(state): State<AppState>,
+    Extension(auth_context): Extension<AuthContext>,
+    Path(params): Path<GuildMemberPathParams>,
+    Json(request): Json<ReplaceMemberRolesRequest>,
+) -> Response {
+    let request_id = auth_context.request_id.clone();
+    let guild_id = match parse_user_directory_guild_id(&params.guild_id) {
+        Ok(value) => value,
+        Err(error) => return user_directory_error_response(&error, request_id),
+    };
+    let member_id = match parse_user_id(&params.member_id) {
+        Ok(value) => value,
+        Err(error) => return user_directory_error_response(&error, request_id),
+    };
+
+    match state
+        .user_directory_service
+        .replace_member_roles(auth_context.principal_id, guild_id, member_id, request.role_keys)
+        .await
+    {
+        Ok(member) => {
+            invalidate_authz_cache_events(
+                &state,
+                &[AuthzCacheInvalidationEvent {
+                    kind: AuthzCacheInvalidationEventKind::GuildMemberRoleChanged {
+                        guild_id,
+                        user_id: member_id,
+                    },
+                    occurred_at: std::time::SystemTime::now(),
+                }],
+            )
+            .await;
+            Json(GuildMemberResponse { member }).into_response()
+        }
+        Err(error) => user_directory_error_response(&error, request_id),
+    }
+}
+
+/// channel permission を返す。
+/// @param state アプリケーション状態
+/// @param auth_context 認証文脈
+/// @param params guild_id/channel_id を含むパスパラメータ
+/// @returns channel permission レスポンス
+/// @throws なし
+async fn get_channel_permissions(
+    State(state): State<AppState>,
+    Extension(auth_context): Extension<AuthContext>,
+    Path(params): Path<GuildChannelPathParams>,
+) -> Response {
+    let request_id = auth_context.request_id.clone();
+    let guild_id = match parse_user_directory_guild_id(&params.guild_id) {
+        Ok(value) => value,
+        Err(error) => return user_directory_error_response(&error, request_id),
+    };
+    let channel_id = match parse_channel_id(&params.channel_id) {
+        Ok(value) => value,
+        Err(error) => return guild_channel_error_response(&error, request_id),
+    };
+
+    match state
+        .user_directory_service
+        .get_channel_permissions(auth_context.principal_id, guild_id, channel_id)
+        .await
+    {
+        Ok(permissions) => Json(ChannelPermissionsResponse { permissions }).into_response(),
+        Err(error) => user_directory_error_response(&error, request_id),
+    }
+}
+
+/// channel permission を置換する。
+/// @param state アプリケーション状態
+/// @param auth_context 認証文脈
+/// @param params guild_id/channel_id を含むパスパラメータ
+/// @param request override 入力
+/// @returns channel permission レスポンス
+/// @throws なし
+async fn replace_channel_permissions(
+    State(state): State<AppState>,
+    Extension(auth_context): Extension<AuthContext>,
+    Path(params): Path<GuildChannelPathParams>,
+    Json(request): Json<ReplaceChannelPermissionsRequest>,
+) -> Response {
+    let request_id = auth_context.request_id.clone();
+    let guild_id = match parse_user_directory_guild_id(&params.guild_id) {
+        Ok(value) => value,
+        Err(error) => return user_directory_error_response(&error, request_id),
+    };
+    let channel_id = match parse_channel_id(&params.channel_id) {
+        Ok(value) => value,
+        Err(error) => return guild_channel_error_response(&error, request_id),
+    };
+
+    match state
+        .user_directory_service
+        .replace_channel_permissions(
+            auth_context.principal_id,
+            guild_id,
+            channel_id,
+            user_directory::ReplaceChannelPermissionsInput {
+                role_overrides: request.role_overrides,
+                user_overrides: request.user_overrides,
+            },
+        )
+        .await
+    {
+        Ok(result) => {
+            let mut events = Vec::new();
+            if result.changed_role_overrides {
+                events.push(AuthzCacheInvalidationEvent {
+                    kind: AuthzCacheInvalidationEventKind::ChannelRoleOverrideChanged {
+                        guild_id,
+                        channel_id,
+                    },
+                    occurred_at: std::time::SystemTime::now(),
+                });
+            }
+            for user_id in result.changed_user_ids {
+                events.push(AuthzCacheInvalidationEvent {
+                    kind: AuthzCacheInvalidationEventKind::ChannelUserOverrideChanged {
+                        guild_id,
+                        channel_id,
+                        user_id,
+                    },
+                    occurred_at: std::time::SystemTime::now(),
+                });
+            }
+            invalidate_authz_cache_events(&state, &events).await;
+            Json(ChannelPermissionsResponse {
+                permissions: result.permissions,
+            })
+            .into_response()
+        }
+        Err(error) => user_directory_error_response(&error, request_id),
+    }
+}
+
 /// REST認証ミドルウェアを実行する。
 /// @param state アプリケーション状態
 /// @param request HTTPリクエスト
@@ -3650,6 +4061,10 @@ fn parse_guild_path(path: &str) -> Option<i64> {
         ["guilds", guild_id] => guild_id.parse::<i64>().ok(),
         ["guilds", guild_id, "permission-snapshot"] => guild_id.parse::<i64>().ok(),
         ["v1", "guilds", guild_id] => guild_id.parse::<i64>().ok(),
+        ["v1", "guilds", guild_id, "members"]
+        | ["v1", "guilds", guild_id, "members", _, "roles"]
+        | ["v1", "guilds", guild_id, "roles"]
+        | ["v1", "guilds", guild_id, "roles", _] => guild_id.parse::<i64>().ok(),
         _ => None,
     }
 }

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -63,8 +63,11 @@ mod tests {
     };
     use scylla_health::{ScyllaHealthReport, ScyllaHealthReporter};
     use user_directory::{
-        GuildMemberDirectoryEntry, GuildRoleDirectoryEntry, UserDirectoryError,
-        UserDirectoryService, UserProfileDirectoryEntry,
+        ChannelPermissionDirectoryEntry, ChannelPermissionUpdateResult,
+        ChannelRolePermissionOverrideEntry, ChannelUserPermissionOverrideEntry,
+        CreateGuildRoleInput, GuildMemberDirectoryEntry, GuildRoleDirectoryEntry,
+        GuildRolePatchInput, PermissionOverrideValue, ReplaceChannelPermissionsInput,
+        UserDirectoryError, UserDirectoryService, UserProfileDirectoryEntry,
     };
     use std::{
         collections::{HashMap, HashSet},
@@ -1429,17 +1432,255 @@ mod tests {
                     role_key: "owner".to_owned(),
                     name: "Owner".to_owned(),
                     priority: 300,
+                    allow_view: true,
+                    allow_post: true,
                     allow_manage: true,
+                    is_system: true,
                     member_count: 1,
                 },
                 GuildRoleDirectoryEntry {
                     role_key: "member".to_owned(),
                     name: "Member".to_owned(),
                     priority: 100,
+                    allow_view: true,
+                    allow_post: true,
                     allow_manage: false,
+                    is_system: true,
                     member_count: 1,
                 },
             ])
+        }
+
+        async fn create_guild_role(
+            &self,
+            principal_id: PrincipalId,
+            guild_id: i64,
+            input: CreateGuildRoleInput,
+        ) -> Result<GuildRoleDirectoryEntry, UserDirectoryError> {
+            if guild_id != 2001 {
+                return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+            }
+            if principal_id.0 != 1001 {
+                return Err(UserDirectoryError::forbidden(
+                    "guild_manage_permission_required",
+                ));
+            }
+            if input.name.trim().is_empty() {
+                return Err(UserDirectoryError::validation("role_name_required"));
+            }
+
+            Ok(GuildRoleDirectoryEntry {
+                role_key: "moderator".to_owned(),
+                name: input.name.trim().to_owned(),
+                priority: 99,
+                allow_view: input.allow_view,
+                allow_post: input.allow_post,
+                allow_manage: input.allow_manage,
+                is_system: false,
+                member_count: 0,
+            })
+        }
+
+        async fn update_guild_role(
+            &self,
+            principal_id: PrincipalId,
+            guild_id: i64,
+            role_key: &str,
+            patch: GuildRolePatchInput,
+        ) -> Result<GuildRoleDirectoryEntry, UserDirectoryError> {
+            if guild_id != 2001 {
+                return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+            }
+            if principal_id.0 != 1001 {
+                return Err(UserDirectoryError::forbidden(
+                    "guild_manage_permission_required",
+                ));
+            }
+            if patch.is_empty() {
+                return Err(UserDirectoryError::validation("role_patch_empty"));
+            }
+            if role_key == "owner" || role_key == "member" {
+                return Err(UserDirectoryError::forbidden("system_role_update_forbidden"));
+            }
+            if role_key != "moderator" {
+                return Err(UserDirectoryError::role_not_found("role_not_found"));
+            }
+
+            Ok(GuildRoleDirectoryEntry {
+                role_key: "moderator".to_owned(),
+                name: patch
+                    .name
+                    .unwrap_or_else(|| "Moderator".to_owned())
+                    .trim()
+                    .to_owned(),
+                priority: 99,
+                allow_view: patch.allow_view.unwrap_or(true),
+                allow_post: patch.allow_post.unwrap_or(true),
+                allow_manage: patch.allow_manage.unwrap_or(false),
+                is_system: false,
+                member_count: 1,
+            })
+        }
+
+        async fn delete_guild_role(
+            &self,
+            principal_id: PrincipalId,
+            guild_id: i64,
+            role_key: &str,
+        ) -> Result<(), UserDirectoryError> {
+            if guild_id != 2001 {
+                return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+            }
+            if principal_id.0 != 1001 {
+                return Err(UserDirectoryError::forbidden(
+                    "guild_manage_permission_required",
+                ));
+            }
+            if role_key == "owner" || role_key == "member" {
+                return Err(UserDirectoryError::forbidden("system_role_delete_forbidden"));
+            }
+            if role_key != "moderator" {
+                return Err(UserDirectoryError::role_not_found("role_not_found"));
+            }
+            Ok(())
+        }
+
+        async fn reorder_guild_roles(
+            &self,
+            principal_id: PrincipalId,
+            guild_id: i64,
+            role_keys: Vec<String>,
+        ) -> Result<Vec<GuildRoleDirectoryEntry>, UserDirectoryError> {
+            if guild_id != 2001 {
+                return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+            }
+            if principal_id.0 != 1001 {
+                return Err(UserDirectoryError::forbidden(
+                    "guild_manage_permission_required",
+                ));
+            }
+            if role_keys != vec!["moderator".to_owned()] {
+                return Err(UserDirectoryError::validation(
+                    "role_reorder_custom_role_set_mismatch",
+                ));
+            }
+            self.list_guild_roles(principal_id, guild_id).await
+        }
+
+        async fn replace_member_roles(
+            &self,
+            principal_id: PrincipalId,
+            guild_id: i64,
+            member_id: i64,
+            role_keys: Vec<String>,
+        ) -> Result<GuildMemberDirectoryEntry, UserDirectoryError> {
+            if guild_id != 2001 {
+                return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+            }
+            if principal_id.0 != 1001 {
+                return Err(UserDirectoryError::forbidden(
+                    "guild_manage_permission_required",
+                ));
+            }
+            if member_id != 1003 {
+                return Err(UserDirectoryError::member_not_found("member_not_found"));
+            }
+            if !role_keys.iter().any(|role_key| role_key == "member") {
+                return Err(UserDirectoryError::validation("member_role_required"));
+            }
+
+            Ok(GuildMemberDirectoryEntry {
+                user_id: 1003,
+                display_name: "Carol".to_owned(),
+                avatar_key: None,
+                status_text: Some("Reviewing".to_owned()),
+                nickname: None,
+                joined_at: "2026-03-02T00:00:00Z".to_owned(),
+                role_keys,
+            })
+        }
+
+        async fn get_channel_permissions(
+            &self,
+            principal_id: PrincipalId,
+            guild_id: i64,
+            channel_id: i64,
+        ) -> Result<ChannelPermissionDirectoryEntry, UserDirectoryError> {
+            if guild_id != 2001 {
+                return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+            }
+            if principal_id.0 != 1001 {
+                return Err(UserDirectoryError::forbidden(
+                    "guild_manage_permission_required",
+                ));
+            }
+            if channel_id != 3001 {
+                return Err(UserDirectoryError::channel_not_found("channel_not_found"));
+            }
+
+            Ok(ChannelPermissionDirectoryEntry {
+                role_overrides: vec![ChannelRolePermissionOverrideEntry {
+                    role_key: "member".to_owned(),
+                    subject_name: "Member".to_owned(),
+                    is_system: true,
+                    can_view: PermissionOverrideValue::Allow,
+                    can_post: PermissionOverrideValue::Deny,
+                }],
+                user_overrides: vec![ChannelUserPermissionOverrideEntry {
+                    user_id: 1003,
+                    subject_name: "Carol".to_owned(),
+                    can_view: PermissionOverrideValue::Inherit,
+                    can_post: PermissionOverrideValue::Allow,
+                }],
+            })
+        }
+
+        async fn replace_channel_permissions(
+            &self,
+            principal_id: PrincipalId,
+            guild_id: i64,
+            channel_id: i64,
+            input: ReplaceChannelPermissionsInput,
+        ) -> Result<ChannelPermissionUpdateResult, UserDirectoryError> {
+            if guild_id != 2001 {
+                return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+            }
+            if principal_id.0 != 1001 {
+                return Err(UserDirectoryError::forbidden(
+                    "guild_manage_permission_required",
+                ));
+            }
+            if channel_id != 3001 {
+                return Err(UserDirectoryError::channel_not_found("channel_not_found"));
+            }
+
+            Ok(ChannelPermissionUpdateResult {
+                permissions: ChannelPermissionDirectoryEntry {
+                    role_overrides: input
+                        .role_overrides
+                        .into_iter()
+                        .map(|entry| ChannelRolePermissionOverrideEntry {
+                            role_key: entry.role_key,
+                            subject_name: "Role".to_owned(),
+                            is_system: false,
+                            can_view: entry.can_view,
+                            can_post: entry.can_post,
+                        })
+                        .collect(),
+                    user_overrides: input
+                        .user_overrides
+                        .into_iter()
+                        .map(|entry| ChannelUserPermissionOverrideEntry {
+                            user_id: entry.user_id,
+                            subject_name: "User".to_owned(),
+                            can_view: entry.can_view,
+                            can_post: entry.can_post,
+                        })
+                        .collect(),
+                },
+                changed_role_overrides: true,
+                changed_user_ids: vec![1003],
+            })
         }
 
         async fn get_user_profile(
@@ -7001,7 +7242,7 @@ mod tests {
     #[tokio::test]
     async fn get_guild_roles_returns_directory_entries() {
         let app = app_for_test().await;
-        let token = format!("u-3:{}", unix_timestamp_seconds() + 300);
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
         let response = app
             .oneshot(
                 Request::builder()
@@ -7020,7 +7261,96 @@ mod tests {
         let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
         assert_eq!(json["roles"][0]["role_key"], "owner");
         assert_eq!(json["roles"][0]["member_count"], 1);
+        assert_eq!(json["roles"][0]["allow_view"], true);
+        assert_eq!(json["roles"][0]["allow_post"], true);
+        assert_eq!(json["roles"][0]["is_system"], true);
         assert_eq!(json["roles"][1]["role_key"], "member");
+    }
+
+    #[tokio::test]
+    async fn create_guild_role_returns_created_role() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/guilds/2001/roles")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"Moderator","allow_view":true,"allow_post":true,"allow_manage":false}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["role"]["role_key"], "moderator");
+        assert_eq!(json["role"]["name"], "Moderator");
+        assert_eq!(json["role"]["is_system"], false);
+    }
+
+    #[tokio::test]
+    async fn replace_member_roles_returns_updated_member() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/v1/guilds/2001/members/1003/roles")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"role_keys":["member","moderator"]}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["member"]["user_id"], 1003);
+        assert_eq!(json["member"]["role_keys"][0], "member");
+        assert_eq!(json["member"]["role_keys"][1], "moderator");
+    }
+
+    #[tokio::test]
+    async fn replace_channel_permissions_returns_updated_permissions() {
+        let app = app_for_test().await;
+        let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/v1/guilds/2001/channels/3001/permissions")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"role_overrides":[{"role_key":"member","can_view":"allow","can_post":"deny"}],"user_overrides":[{"user_id":1003,"can_view":"inherit","can_post":"allow"}]}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["permissions"]["role_overrides"][0]["role_key"], "member");
+        assert_eq!(json["permissions"]["role_overrides"][0]["can_post"], "deny");
+        assert_eq!(json["permissions"]["user_overrides"][0]["user_id"], 1003);
+        assert_eq!(json["permissions"]["user_overrides"][0]["can_post"], "allow");
     }
 
     #[tokio::test]

--- a/rust/apps/api/src/user_directory.rs
+++ b/rust/apps/api/src/user_directory.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     env,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -13,9 +14,9 @@ use axum::{
     Json,
 };
 use linklynx_shared::PrincipalId;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use tokio_postgres::NoTls;
+use tokio_postgres::{GenericClient, NoTls};
 use tracing::warn;
 
 include!("user_directory/errors.rs");

--- a/rust/apps/api/src/user_directory/errors.rs
+++ b/rust/apps/api/src/user_directory/errors.rs
@@ -3,6 +3,9 @@
 pub enum UserDirectoryErrorKind {
     Validation,
     UserNotFound,
+    MemberNotFound,
+    RoleNotFound,
+    ChannelNotFound,
     GuildNotFound,
     Forbidden,
     DependencyUnavailable,
@@ -34,6 +37,39 @@ impl UserDirectoryError {
     pub fn user_not_found(reason: impl Into<String>) -> Self {
         Self {
             kind: UserDirectoryErrorKind::UserNotFound,
+            reason: reason.into(),
+        }
+    }
+
+    /// member未存在エラーを生成する。
+    /// @param reason 失敗理由
+    /// @returns member未存在エラー
+    /// @throws なし
+    pub fn member_not_found(reason: impl Into<String>) -> Self {
+        Self {
+            kind: UserDirectoryErrorKind::MemberNotFound,
+            reason: reason.into(),
+        }
+    }
+
+    /// role未存在エラーを生成する。
+    /// @param reason 失敗理由
+    /// @returns role未存在エラー
+    /// @throws なし
+    pub fn role_not_found(reason: impl Into<String>) -> Self {
+        Self {
+            kind: UserDirectoryErrorKind::RoleNotFound,
+            reason: reason.into(),
+        }
+    }
+
+    /// channel未存在エラーを生成する。
+    /// @param reason 失敗理由
+    /// @returns channel未存在エラー
+    /// @throws なし
+    pub fn channel_not_found(reason: impl Into<String>) -> Self {
+        Self {
+            kind: UserDirectoryErrorKind::ChannelNotFound,
             reason: reason.into(),
         }
     }
@@ -79,6 +115,9 @@ impl UserDirectoryError {
         match self.kind {
             UserDirectoryErrorKind::Validation => StatusCode::BAD_REQUEST,
             UserDirectoryErrorKind::UserNotFound => StatusCode::NOT_FOUND,
+            UserDirectoryErrorKind::MemberNotFound => StatusCode::NOT_FOUND,
+            UserDirectoryErrorKind::RoleNotFound => StatusCode::NOT_FOUND,
+            UserDirectoryErrorKind::ChannelNotFound => StatusCode::NOT_FOUND,
             UserDirectoryErrorKind::GuildNotFound => StatusCode::NOT_FOUND,
             UserDirectoryErrorKind::Forbidden => StatusCode::FORBIDDEN,
             UserDirectoryErrorKind::DependencyUnavailable => StatusCode::SERVICE_UNAVAILABLE,
@@ -93,6 +132,9 @@ impl UserDirectoryError {
         match self.kind {
             UserDirectoryErrorKind::Validation => "VALIDATION_ERROR",
             UserDirectoryErrorKind::UserNotFound => "USER_NOT_FOUND",
+            UserDirectoryErrorKind::MemberNotFound => "MEMBER_NOT_FOUND",
+            UserDirectoryErrorKind::RoleNotFound => "ROLE_NOT_FOUND",
+            UserDirectoryErrorKind::ChannelNotFound => "CHANNEL_NOT_FOUND",
             UserDirectoryErrorKind::GuildNotFound => "GUILD_NOT_FOUND",
             UserDirectoryErrorKind::Forbidden => "AUTHZ_DENIED",
             UserDirectoryErrorKind::DependencyUnavailable => "AUTHZ_UNAVAILABLE",
@@ -107,6 +149,9 @@ impl UserDirectoryError {
         match self.kind {
             UserDirectoryErrorKind::Validation => "request payload is invalid",
             UserDirectoryErrorKind::UserNotFound => "user resource was not found",
+            UserDirectoryErrorKind::MemberNotFound => "member resource was not found",
+            UserDirectoryErrorKind::RoleNotFound => "role resource was not found",
+            UserDirectoryErrorKind::ChannelNotFound => "channel resource was not found",
             UserDirectoryErrorKind::GuildNotFound => "guild resource was not found",
             UserDirectoryErrorKind::Forbidden => "access is denied by authorization policy",
             UserDirectoryErrorKind::DependencyUnavailable => {

--- a/rust/apps/api/src/user_directory/postgres.rs
+++ b/rust/apps/api/src/user_directory/postgres.rs
@@ -1,3 +1,13 @@
+const MEMBER_ROLE_KEY: &str = "member";
+const OWNER_ROLE_KEY: &str = "owner";
+const FIRST_CUSTOM_ROLE_PRIORITY: i32 = 99;
+const ROLE_KEY_MAX_LEN: usize = 64;
+const ROLE_NAME_MAX_LEN: usize = 100;
+const AUTHZ_TUPLE_EVENT_GUILD_ROLE: &str = "authz.tuple.guild_role.v1";
+const AUTHZ_TUPLE_EVENT_GUILD_MEMBER_ROLE: &str = "authz.tuple.guild_member_role.v1";
+const AUTHZ_TUPLE_EVENT_CHANNEL_ROLE_OVERRIDE: &str = "authz.tuple.channel_role_override.v1";
+const AUTHZ_TUPLE_EVENT_CHANNEL_USER_OVERRIDE: &str = "authz.tuple.channel_user_override.v1";
+
 /// Postgres-backed user directory サービスを表現する。
 #[derive(Clone)]
 pub struct PostgresUserDirectoryService {
@@ -6,6 +16,32 @@ pub struct PostgresUserDirectoryService {
     clients: Arc<RwLock<Vec<Arc<tokio_postgres::Client>>>>,
     next_index: Arc<AtomicU64>,
     pool_size: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GuildRoleState {
+    role_key: String,
+    name: String,
+    priority: i32,
+    allow_view: bool,
+    allow_post: bool,
+    allow_manage: bool,
+    is_system: bool,
+}
+
+impl GuildRoleState {
+    fn to_directory_entry(&self, member_count: i64) -> GuildRoleDirectoryEntry {
+        GuildRoleDirectoryEntry {
+            role_key: self.role_key.clone(),
+            name: self.name.clone(),
+            priority: self.priority,
+            allow_view: self.allow_view,
+            allow_post: self.allow_post,
+            allow_manage: self.allow_manage,
+            is_system: self.is_system,
+            member_count,
+        }
+    }
 }
 
 impl PostgresUserDirectoryService {
@@ -72,9 +108,18 @@ impl PostgresUserDirectoryService {
 
     /// Postgresクライアントを接続する。
     /// @param なし
-    /// @returns Postgresクライアント
+    /// @returns 共有Postgresクライアント
     /// @throws UserDirectoryError 接続失敗時
     async fn connect_client(&self) -> Result<Arc<tokio_postgres::Client>, UserDirectoryError> {
+        let client = self.connect_owned_client().await?;
+        Ok(Arc::new(client))
+    }
+
+    /// transaction 用の専用Postgresクライアントを接続する。
+    /// @param なし
+    /// @returns 専用Postgresクライアント
+    /// @throws UserDirectoryError 接続失敗時
+    async fn connect_owned_client(&self) -> Result<tokio_postgres::Client, UserDirectoryError> {
         if !self.allow_postgres_notls {
             return Err(UserDirectoryError::dependency_unavailable(
                 "postgres_tls_required",
@@ -95,7 +140,7 @@ impl PostgresUserDirectoryService {
             }
         });
 
-        Ok(Arc::new(client))
+        Ok(client)
     }
 
     /// 接続プールを初期化する。
@@ -140,18 +185,73 @@ impl PostgresUserDirectoryService {
         Ok(Arc::clone(&guard[index]))
     }
 
-    /// guild membership を検証する。
+    /// guild が存在するかを確認する。
     /// @param client Postgres client
     /// @param guild_id 対象guild_id
-    /// @param principal_id 認証済みprincipal_id
-    /// @returns 検証結果
+    /// @returns 存在する場合は `true`
     /// @throws UserDirectoryError 依存障害時
-    async fn ensure_guild_member(
+    async fn has_guild<C>(&self, client: &C, guild_id: i64) -> Result<bool, UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        client
+            .query_opt("SELECT 1 FROM guilds WHERE id = $1", &[&guild_id])
+            .await
+            .map(|row| row.is_some())
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_guild_lookup_failed:{error}"
+                ))
+            })
+    }
+
+    /// guild member が存在するかを確認する。
+    /// @param client Postgres client
+    /// @param guild_id 対象guild_id
+    /// @param user_id 対象user_id
+    /// @returns 存在する場合は `true`
+    /// @throws UserDirectoryError 依存障害時
+    async fn is_guild_member<C>(
         &self,
-        client: &tokio_postgres::Client,
+        client: &C,
+        guild_id: i64,
+        user_id: i64,
+    ) -> Result<bool, UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        client
+            .query_opt(
+                "SELECT 1
+                 FROM guild_members
+                 WHERE guild_id = $1
+                   AND user_id = $2",
+                &[&guild_id, &user_id],
+            )
+            .await
+            .map(|row| row.is_some())
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_guild_member_lookup_failed:{error}"
+                ))
+            })
+    }
+
+    /// guild manage 権限を検証する。
+    /// @param client Postgres client
+    /// @param guild_id 対象guild_id
+    /// @param principal_id 実行主体
+    /// @returns なし
+    /// @throws UserDirectoryError 未存在/権限拒否/依存障害時
+    async fn ensure_guild_manage_access<C>(
+        &self,
+        client: &C,
         guild_id: i64,
         principal_id: PrincipalId,
-    ) -> Result<(), UserDirectoryError> {
+    ) -> Result<(), UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
         let row = client
             .query_one(
                 "SELECT
@@ -161,18 +261,36 @@ impl PostgresUserDirectoryService {
                       FROM guild_members
                       WHERE guild_id = $1
                         AND user_id = $2
-                    ) AS is_member",
+                    ) AS is_member,
+                    EXISTS(
+                      SELECT 1
+                      FROM guilds
+                      WHERE id = $1
+                        AND owner_id = $2
+                    ) AS is_owner,
+                    EXISTS(
+                      SELECT 1
+                      FROM guild_member_roles_v2 gmr
+                      JOIN guild_roles_v2 gr
+                        ON gr.guild_id = gmr.guild_id
+                       AND gr.role_key = gmr.role_key
+                      WHERE gmr.guild_id = $1
+                        AND gmr.user_id = $2
+                        AND gr.allow_manage = TRUE
+                    ) AS can_manage",
                 &[&guild_id, &principal_id.0],
             )
             .await
             .map_err(|error| {
                 UserDirectoryError::dependency_unavailable(format!(
-                    "user_directory_guild_scope_query_failed:{error}"
+                    "user_directory_guild_manage_scope_query_failed:{error}"
                 ))
             })?;
 
         let guild_exists = row.get::<&str, bool>("guild_exists");
         let is_member = row.get::<&str, bool>("is_member");
+        let is_owner = row.get::<&str, bool>("is_owner");
+        let can_manage = row.get::<&str, bool>("can_manage");
 
         if !guild_exists {
             return Err(UserDirectoryError::guild_not_found("guild_not_found"));
@@ -180,27 +298,210 @@ impl PostgresUserDirectoryService {
         if !is_member {
             return Err(UserDirectoryError::forbidden("guild_membership_required"));
         }
+        if !is_owner && !can_manage {
+            return Err(UserDirectoryError::forbidden(
+                "guild_manage_permission_required",
+            ));
+        }
 
         Ok(())
     }
-}
 
-#[async_trait]
-impl UserDirectoryService for PostgresUserDirectoryService {
-    /// guild member 一覧を返す。
-    /// @param principal_id 認証済みprincipal_id
+    /// member 存在を検証する。
+    /// @param client Postgres client
+    /// @param guild_id 対象guild_id
+    /// @param member_id 対象member_id
+    /// @returns なし
+    /// @throws UserDirectoryError 未存在/依存障害時
+    async fn ensure_target_member_exists<C>(
+        &self,
+        client: &C,
+        guild_id: i64,
+        member_id: i64,
+    ) -> Result<(), UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        if self.is_guild_member(client, guild_id, member_id).await? {
+            return Ok(());
+        }
+        if !self.has_guild(client, guild_id).await? {
+            return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+        }
+        Err(UserDirectoryError::member_not_found("member_not_found"))
+    }
+
+    /// channel 存在を検証する。
+    /// @param client Postgres client
+    /// @param guild_id 対象guild_id
+    /// @param channel_id 対象channel_id
+    /// @returns なし
+    /// @throws UserDirectoryError 未存在/依存障害時
+    async fn ensure_target_channel_exists<C>(
+        &self,
+        client: &C,
+        guild_id: i64,
+        channel_id: i64,
+    ) -> Result<(), UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        let row = client
+            .query_opt(
+                "SELECT 1
+                 FROM channels
+                 WHERE id = $1
+                   AND guild_id = $2
+                   AND type IN ('guild_text', 'guild_category')",
+                &[&channel_id, &guild_id],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_channel_scope_query_failed:{error}"
+                ))
+            })?;
+
+        if row.is_some() {
+            return Ok(());
+        }
+
+        if !self.has_guild(client, guild_id).await? {
+            return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+        }
+
+        Err(UserDirectoryError::channel_not_found("channel_not_found"))
+    }
+
+    /// role state を読み出す。
+    /// @param client Postgres client
+    /// @param guild_id 対象guild_id
+    /// @param role_key 対象role_key
+    /// @returns role state
+    /// @throws UserDirectoryError 未存在/依存障害時
+    async fn get_role_state<C>(
+        &self,
+        client: &C,
+        guild_id: i64,
+        role_key: &str,
+    ) -> Result<GuildRoleState, UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        let row = client
+            .query_opt(
+                "SELECT
+                    role_key,
+                    name,
+                    priority,
+                    allow_view,
+                    allow_post,
+                    allow_manage,
+                    is_system
+                 FROM guild_roles_v2
+                 WHERE guild_id = $1
+                   AND role_key = $2",
+                &[&guild_id, &role_key],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_role_lookup_failed:{error}"
+                ))
+            })?;
+
+        let Some(row) = row else {
+            return Err(UserDirectoryError::role_not_found("role_not_found"));
+        };
+
+        Ok(GuildRoleState {
+            role_key: row.get::<&str, String>("role_key"),
+            name: row.get::<&str, String>("name"),
+            priority: row.get::<&str, i32>("priority"),
+            allow_view: row.get::<&str, bool>("allow_view"),
+            allow_post: row.get::<&str, bool>("allow_post"),
+            allow_manage: row.get::<&str, bool>("allow_manage"),
+            is_system: row.get::<&str, bool>("is_system"),
+        })
+    }
+
+    /// role 一覧を読み出す。
+    /// @param client Postgres client
+    /// @param guild_id 対象guild_id
+    /// @returns role 一覧
+    /// @throws UserDirectoryError 依存障害時
+    async fn load_guild_roles<C>(
+        &self,
+        client: &C,
+        guild_id: i64,
+    ) -> Result<Vec<GuildRoleDirectoryEntry>, UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        let rows = client
+            .query(
+                "SELECT
+                    gr.role_key,
+                    gr.name,
+                    gr.priority,
+                    gr.allow_view,
+                    gr.allow_post,
+                    gr.allow_manage,
+                    gr.is_system,
+                    COUNT(gmr.user_id)::BIGINT AS member_count
+                 FROM guild_roles_v2 gr
+                 LEFT JOIN guild_member_roles_v2 gmr
+                   ON gmr.guild_id = gr.guild_id
+                  AND gmr.role_key = gr.role_key
+                 WHERE gr.guild_id = $1
+                 GROUP BY
+                    gr.role_key,
+                    gr.name,
+                    gr.priority,
+                    gr.allow_view,
+                    gr.allow_post,
+                    gr.allow_manage,
+                    gr.is_system
+                 ORDER BY gr.priority DESC, gr.role_key ASC",
+                &[&guild_id],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_list_roles_query_failed:{error}"
+                ))
+            })?;
+
+        let mut roles = Vec::with_capacity(rows.len());
+        for row in rows {
+            roles.push(GuildRoleDirectoryEntry {
+                role_key: row.get::<&str, String>("role_key"),
+                name: row.get::<&str, String>("name"),
+                priority: row.get::<&str, i32>("priority"),
+                allow_view: row.get::<&str, bool>("allow_view"),
+                allow_post: row.get::<&str, bool>("allow_post"),
+                allow_manage: row.get::<&str, bool>("allow_manage"),
+                is_system: row.get::<&str, bool>("is_system"),
+                member_count: row.get::<&str, i64>("member_count"),
+            });
+        }
+
+        Ok(roles)
+    }
+
+    /// member 一覧を読み出す。
+    /// @param client Postgres client
     /// @param guild_id 対象guild_id
     /// @returns member 一覧
-    /// @throws UserDirectoryError 権限拒否/依存障害時
-    async fn list_guild_members(
+    /// @throws UserDirectoryError 依存障害時
+    async fn load_guild_members<C>(
         &self,
-        principal_id: PrincipalId,
+        client: &C,
         guild_id: i64,
-    ) -> Result<Vec<GuildMemberDirectoryEntry>, UserDirectoryError> {
-        let client = self.select_client().await?;
-        self.ensure_guild_member(&client, guild_id, principal_id)
-            .await?;
-
+    ) -> Result<Vec<GuildMemberDirectoryEntry>, UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
         let rows = client
             .query(
                 "SELECT
@@ -252,6 +553,520 @@ impl UserDirectoryService for PostgresUserDirectoryService {
         Ok(members)
     }
 
+    /// 単一member を読み出す。
+    /// @param client Postgres client
+    /// @param guild_id 対象guild_id
+    /// @param member_id 対象member_id
+    /// @returns member
+    /// @throws UserDirectoryError 未存在/依存障害時
+    async fn load_guild_member_entry<C>(
+        &self,
+        client: &C,
+        guild_id: i64,
+        member_id: i64,
+    ) -> Result<GuildMemberDirectoryEntry, UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        let row = client
+            .query_opt(
+                "SELECT
+                    u.id AS user_id,
+                    u.display_name,
+                    u.avatar_key,
+                    u.status_text,
+                    gm.nickname,
+                    to_char(gm.joined_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') AS joined_at,
+                    COALESCE(
+                      ARRAY_AGG(gmr.role_key ORDER BY gr.priority DESC, gmr.role_key)
+                        FILTER (WHERE gmr.role_key IS NOT NULL),
+                      ARRAY[]::text[]
+                    ) AS role_keys
+                 FROM guild_members gm
+                 JOIN users u
+                   ON u.id = gm.user_id
+                 LEFT JOIN guild_member_roles_v2 gmr
+                   ON gmr.guild_id = gm.guild_id
+                  AND gmr.user_id = gm.user_id
+                 LEFT JOIN guild_roles_v2 gr
+                   ON gr.guild_id = gmr.guild_id
+                  AND gr.role_key = gmr.role_key
+                 WHERE gm.guild_id = $1
+                   AND gm.user_id = $2
+                 GROUP BY u.id, u.display_name, u.avatar_key, u.status_text, gm.nickname, gm.joined_at",
+                &[&guild_id, &member_id],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_member_query_failed:{error}"
+                ))
+            })?;
+
+        let Some(row) = row else {
+            return Err(UserDirectoryError::member_not_found("member_not_found"));
+        };
+
+        Ok(GuildMemberDirectoryEntry {
+            user_id: row.get::<&str, i64>("user_id"),
+            display_name: row.get::<&str, String>("display_name"),
+            avatar_key: row.get::<&str, Option<String>>("avatar_key"),
+            status_text: row.get::<&str, Option<String>>("status_text"),
+            nickname: row.get::<&str, Option<String>>("nickname"),
+            joined_at: row.get::<&str, String>("joined_at"),
+            role_keys: row.get::<&str, Vec<String>>("role_keys"),
+        })
+    }
+
+    /// channel permission を読み出す。
+    /// @param client Postgres client
+    /// @param guild_id 対象guild_id
+    /// @param channel_id 対象channel_id
+    /// @returns permission 一覧
+    /// @throws UserDirectoryError 依存障害時
+    async fn load_channel_permissions<C>(
+        &self,
+        client: &C,
+        guild_id: i64,
+        channel_id: i64,
+    ) -> Result<ChannelPermissionDirectoryEntry, UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        let role_rows = client
+            .query(
+                "SELECT
+                    cro.role_key,
+                    gr.name,
+                    gr.is_system,
+                    cro.can_view,
+                    cro.can_post
+                 FROM channel_role_permission_overrides_v2 cro
+                 JOIN guild_roles_v2 gr
+                   ON gr.guild_id = cro.guild_id
+                  AND gr.role_key = cro.role_key
+                 WHERE cro.guild_id = $1
+                   AND cro.channel_id = $2
+                 ORDER BY gr.priority DESC, cro.role_key ASC",
+                &[&guild_id, &channel_id],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_channel_role_permissions_query_failed:{error}"
+                ))
+            })?;
+
+        let user_rows = client
+            .query(
+                "SELECT
+                    cuo.user_id,
+                    u.display_name,
+                    cuo.can_view,
+                    cuo.can_post
+                 FROM channel_user_permission_overrides_v2 cuo
+                 JOIN users u
+                   ON u.id = cuo.user_id
+                 WHERE cuo.guild_id = $1
+                   AND cuo.channel_id = $2
+                 ORDER BY cuo.user_id ASC",
+                &[&guild_id, &channel_id],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_channel_user_permissions_query_failed:{error}"
+                ))
+            })?;
+
+        let mut role_overrides = Vec::with_capacity(role_rows.len());
+        for row in role_rows {
+            role_overrides.push(ChannelRolePermissionOverrideEntry {
+                role_key: row.get::<&str, String>("role_key"),
+                subject_name: row.get::<&str, String>("name"),
+                is_system: row.get::<&str, bool>("is_system"),
+                can_view: PermissionOverrideValue::from_option_bool(
+                    row.get::<&str, Option<bool>>("can_view"),
+                ),
+                can_post: PermissionOverrideValue::from_option_bool(
+                    row.get::<&str, Option<bool>>("can_post"),
+                ),
+            });
+        }
+
+        let mut user_overrides = Vec::with_capacity(user_rows.len());
+        for row in user_rows {
+            user_overrides.push(ChannelUserPermissionOverrideEntry {
+                user_id: row.get::<&str, i64>("user_id"),
+                subject_name: row.get::<&str, String>("display_name"),
+                can_view: PermissionOverrideValue::from_option_bool(
+                    row.get::<&str, Option<bool>>("can_view"),
+                ),
+                can_post: PermissionOverrideValue::from_option_bool(
+                    row.get::<&str, Option<bool>>("can_post"),
+                ),
+            });
+        }
+
+        Ok(ChannelPermissionDirectoryEntry {
+            role_overrides,
+            user_overrides,
+        })
+    }
+
+    /// role 名を正規化する。
+    /// @param name 入力名
+    /// @returns trim 済み role 名
+    /// @throws UserDirectoryError 検証失敗時
+    fn normalize_role_name(&self, name: &str) -> Result<String, UserDirectoryError> {
+        let normalized = name.trim();
+        if normalized.is_empty() {
+            return Err(UserDirectoryError::validation("role_name_required"));
+        }
+        if normalized.chars().count() > ROLE_NAME_MAX_LEN {
+            return Err(UserDirectoryError::validation("role_name_too_long"));
+        }
+        Ok(normalized.to_owned())
+    }
+
+    /// role key を正規化する。
+    /// @param role_key 入力role_key
+    /// @returns 正規化済み role_key
+    /// @throws UserDirectoryError 検証失敗時
+    fn normalize_role_key(&self, role_key: &str) -> Result<String, UserDirectoryError> {
+        let normalized = role_key.trim().to_ascii_lowercase();
+        if normalized.is_empty() || normalized.len() > ROLE_KEY_MAX_LEN {
+            return Err(UserDirectoryError::validation("role_key_invalid"));
+        }
+        if !normalized
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+        {
+            return Err(UserDirectoryError::validation("role_key_invalid"));
+        }
+        Ok(normalized)
+    }
+
+    /// role 名から slug ベースの role key を作る。
+    /// @param name 正規化済み role 名
+    /// @returns role key base
+    /// @throws なし
+    fn slugify_role_key(&self, name: &str) -> String {
+        let mut output = String::new();
+        let mut last_was_underscore = false;
+
+        for ch in name.chars() {
+            let normalized = ch.to_ascii_lowercase();
+            if normalized.is_ascii_lowercase() || normalized.is_ascii_digit() {
+                output.push(normalized);
+                last_was_underscore = false;
+                continue;
+            }
+            if !last_was_underscore {
+                output.push('_');
+                last_was_underscore = true;
+            }
+        }
+
+        let trimmed = output.trim_matches('_').to_owned();
+        let mut base = if trimmed.is_empty() {
+            "role".to_owned()
+        } else {
+            trimmed
+        };
+        if base.len() > ROLE_KEY_MAX_LEN {
+            base.truncate(ROLE_KEY_MAX_LEN);
+        }
+        base.trim_matches('_').to_owned()
+    }
+
+    /// suffix 付き role key 候補を作る。
+    /// @param base role key base
+    /// @param suffix 連番
+    /// @returns 候補role_key
+    /// @throws なし
+    fn role_key_with_suffix(&self, base: &str, suffix: usize) -> String {
+        let suffix_value = format!("_{suffix}");
+        let max_base_len = ROLE_KEY_MAX_LEN.saturating_sub(suffix_value.len());
+        let mut prefix = base.to_owned();
+        if prefix.len() > max_base_len {
+            prefix.truncate(max_base_len);
+            prefix = prefix.trim_matches('_').to_owned();
+        }
+        format!("{prefix}{suffix_value}")
+    }
+
+    /// 未使用の role key を確保する。
+    /// @param client Postgres client
+    /// @param guild_id 対象guild_id
+    /// @param name 正規化済み role 名
+    /// @returns 一意 role key
+    /// @throws UserDirectoryError 依存障害時
+    async fn allocate_role_key<C>(
+        &self,
+        client: &C,
+        guild_id: i64,
+        name: &str,
+    ) -> Result<String, UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        let base = self.slugify_role_key(name);
+        for suffix in 0..10_000usize {
+            let candidate = if suffix == 0 {
+                base.clone()
+            } else {
+                self.role_key_with_suffix(&base, suffix)
+            };
+            let exists = client
+                .query_opt(
+                    "SELECT 1
+                     FROM guild_roles_v2
+                     WHERE guild_id = $1
+                       AND role_key = $2",
+                    &[&guild_id, &candidate],
+                )
+                .await
+                .map_err(|error| {
+                    UserDirectoryError::dependency_unavailable(format!(
+                        "user_directory_role_key_lookup_failed:{error}"
+                    ))
+                })?;
+            if exists.is_none() {
+                return Ok(candidate);
+            }
+        }
+        Err(UserDirectoryError::dependency_unavailable(
+            "role_key_allocation_exhausted",
+        ))
+    }
+
+    /// custom role priority の初期値を求める。
+    /// @param client Postgres client
+    /// @param guild_id 対象guild_id
+    /// @returns 新priority
+    /// @throws UserDirectoryError 依存障害時
+    async fn next_custom_role_priority<C>(
+        &self,
+        client: &C,
+        guild_id: i64,
+    ) -> Result<i32, UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        let row = client
+            .query_one(
+                "SELECT COALESCE(MIN(priority), $2)::INT AS min_priority
+                 FROM guild_roles_v2
+                 WHERE guild_id = $1
+                   AND is_system = FALSE",
+                &[&guild_id, &FIRST_CUSTOM_ROLE_PRIORITY],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_custom_role_priority_query_failed:{error}"
+                ))
+            })?;
+        let min_priority = row.get::<&str, i32>("min_priority");
+        if min_priority >= FIRST_CUSTOM_ROLE_PRIORITY {
+            Ok(FIRST_CUSTOM_ROLE_PRIORITY)
+        } else {
+            Ok(min_priority - 1)
+        }
+    }
+
+    /// outbox event を追加する。
+    /// @param client Postgres client
+    /// @param event_type event type
+    /// @param aggregate_id aggregate id
+    /// @param payload event payload
+    /// @returns なし
+    /// @throws UserDirectoryError 依存障害時
+    async fn insert_outbox_event<C>(
+        &self,
+        client: &C,
+        event_type: &str,
+        aggregate_id: &str,
+        payload: &serde_json::Value,
+    ) -> Result<(), UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        let payload_text = payload.to_string();
+        client
+            .execute(
+                "INSERT INTO outbox_events (event_type, aggregate_id, payload)
+                 VALUES ($1, $2, $3::jsonb)",
+                &[&event_type, &aggregate_id, &payload_text],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_outbox_insert_failed:{error}"
+                ))
+            })?;
+        Ok(())
+    }
+
+    /// guild role 用 outbox event を追加する。
+    /// @param client Postgres client
+    /// @param op 操作
+    /// @param role role state
+    /// @returns なし
+    /// @throws UserDirectoryError 依存障害時
+    async fn enqueue_guild_role_event<C>(
+        &self,
+        client: &C,
+        op: &str,
+        role: &GuildRoleState,
+        guild_id: i64,
+    ) -> Result<(), UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        self.insert_outbox_event(
+            client,
+            AUTHZ_TUPLE_EVENT_GUILD_ROLE,
+            &format!("guild:{guild_id}/role:{}", role.role_key),
+            &serde_json::json!({
+                "op": op,
+                "guild_id": guild_id,
+                "role_key": role.role_key,
+                "allow_view": role.allow_view,
+                "allow_post": role.allow_post,
+                "allow_manage": role.allow_manage,
+            }),
+        )
+        .await
+    }
+
+    /// guild member role 用 outbox event を追加する。
+    /// @param client Postgres client
+    /// @param op 操作
+    /// @param guild_id 対象guild_id
+    /// @param user_id 対象user_id
+    /// @param role_key 対象role_key
+    /// @returns なし
+    /// @throws UserDirectoryError 依存障害時
+    async fn enqueue_guild_member_role_event<C>(
+        &self,
+        client: &C,
+        op: &str,
+        guild_id: i64,
+        user_id: i64,
+        role_key: &str,
+    ) -> Result<(), UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        self.insert_outbox_event(
+            client,
+            AUTHZ_TUPLE_EVENT_GUILD_MEMBER_ROLE,
+            &format!("guild:{guild_id}/user:{user_id}/role:{role_key}"),
+            &serde_json::json!({
+                "op": op,
+                "guild_id": guild_id,
+                "user_id": user_id,
+                "role_key": role_key,
+            }),
+        )
+        .await
+    }
+
+    /// channel role override 用 outbox event を追加する。
+    /// @param client Postgres client
+    /// @param op 操作
+    /// @param guild_id 対象guild_id
+    /// @param channel_id 対象channel_id
+    /// @param role_key 対象role_key
+    /// @param values tri-state view/post
+    /// @returns なし
+    /// @throws UserDirectoryError 依存障害時
+    async fn enqueue_channel_role_override_event<C>(
+        &self,
+        client: &C,
+        op: &str,
+        guild_id: i64,
+        channel_id: i64,
+        role_key: &str,
+        values: (Option<bool>, Option<bool>),
+    ) -> Result<(), UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        self.insert_outbox_event(
+            client,
+            AUTHZ_TUPLE_EVENT_CHANNEL_ROLE_OVERRIDE,
+            &format!("channel:{channel_id}/role:{role_key}"),
+            &serde_json::json!({
+                "op": op,
+                "guild_id": guild_id,
+                "channel_id": channel_id,
+                "role_key": role_key,
+                "can_view": values.0,
+                "can_post": values.1,
+            }),
+        )
+        .await
+    }
+
+    /// channel user override 用 outbox event を追加する。
+    /// @param client Postgres client
+    /// @param op 操作
+    /// @param guild_id 対象guild_id
+    /// @param channel_id 対象channel_id
+    /// @param user_id 対象user_id
+    /// @param values tri-state view/post
+    /// @returns なし
+    /// @throws UserDirectoryError 依存障害時
+    async fn enqueue_channel_user_override_event<C>(
+        &self,
+        client: &C,
+        op: &str,
+        guild_id: i64,
+        channel_id: i64,
+        user_id: i64,
+        values: (Option<bool>, Option<bool>),
+    ) -> Result<(), UserDirectoryError>
+    where
+        C: GenericClient + Sync,
+    {
+        self.insert_outbox_event(
+            client,
+            AUTHZ_TUPLE_EVENT_CHANNEL_USER_OVERRIDE,
+            &format!("channel:{channel_id}/user:{user_id}"),
+            &serde_json::json!({
+                "op": op,
+                "guild_id": guild_id,
+                "channel_id": channel_id,
+                "user_id": user_id,
+                "can_view": values.0,
+                "can_post": values.1,
+            }),
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl UserDirectoryService for PostgresUserDirectoryService {
+    /// guild member 一覧を返す。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @returns member 一覧
+    /// @throws UserDirectoryError 権限拒否/依存障害時
+    async fn list_guild_members(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+    ) -> Result<Vec<GuildMemberDirectoryEntry>, UserDirectoryError> {
+        let client = self.select_client().await?;
+        self.ensure_guild_manage_access(&*client, guild_id, principal_id)
+            .await?;
+        self.load_guild_members(&*client, guild_id).await
+    }
+
     /// guild role 一覧を返す。
     /// @param principal_id 認証済みprincipal_id
     /// @param guild_id 対象guild_id
@@ -263,45 +1078,857 @@ impl UserDirectoryService for PostgresUserDirectoryService {
         guild_id: i64,
     ) -> Result<Vec<GuildRoleDirectoryEntry>, UserDirectoryError> {
         let client = self.select_client().await?;
-        self.ensure_guild_member(&client, guild_id, principal_id)
+        self.ensure_guild_manage_access(&*client, guild_id, principal_id)
+            .await?;
+        self.load_guild_roles(&*client, guild_id).await
+    }
+
+    /// guild role を作成する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param input 作成入力
+    /// @returns 作成済み role
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn create_guild_role(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        input: CreateGuildRoleInput,
+    ) -> Result<GuildRoleDirectoryEntry, UserDirectoryError> {
+        let normalized_name = self.normalize_role_name(&input.name)?;
+        let mut client = self.connect_owned_client().await?;
+        let transaction = client.transaction().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_start_failed:{error}"
+            ))
+        })?;
+
+        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
+            .await?;
+        let role_key = self
+            .allocate_role_key(&transaction, guild_id, &normalized_name)
+            .await?;
+        let priority = self.next_custom_role_priority(&transaction, guild_id).await?;
+
+        transaction
+            .execute(
+                "INSERT INTO guild_roles_v2 (
+                    guild_id,
+                    role_key,
+                    name,
+                    priority,
+                    allow_view,
+                    allow_post,
+                    allow_manage,
+                    is_system
+                 ) VALUES ($1, $2, $3, $4, $5, $6, $7, FALSE)",
+                &[
+                    &guild_id,
+                    &role_key,
+                    &normalized_name,
+                    &priority,
+                    &input.allow_view,
+                    &input.allow_post,
+                    &input.allow_manage,
+                ],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_role_insert_failed:{error}"
+                ))
+            })?;
+
+        let role = GuildRoleState {
+            role_key,
+            name: normalized_name,
+            priority,
+            allow_view: input.allow_view,
+            allow_post: input.allow_post,
+            allow_manage: input.allow_manage,
+            is_system: false,
+        };
+        self.enqueue_guild_role_event(&transaction, "upsert", &role, guild_id)
             .await?;
 
-        let rows = client
-            .query(
-                "SELECT
-                    gr.role_key,
-                    gr.name,
-                    gr.priority,
-                    gr.allow_manage,
-                    COUNT(gmr.user_id)::BIGINT AS member_count
-                 FROM guild_roles_v2 gr
-                 LEFT JOIN guild_member_roles_v2 gmr
-                   ON gmr.guild_id = gr.guild_id
-                  AND gmr.role_key = gr.role_key
-                 WHERE gr.guild_id = $1
-                 GROUP BY gr.role_key, gr.name, gr.priority, gr.allow_manage
-                 ORDER BY gr.priority DESC, gr.role_key ASC",
+        transaction.commit().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_commit_failed:{error}"
+            ))
+        })?;
+
+        Ok(role.to_directory_entry(0))
+    }
+
+    /// guild role を更新する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param role_key 対象role_key
+    /// @param patch 更新内容
+    /// @returns 更新済み role
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn update_guild_role(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        role_key: &str,
+        patch: GuildRolePatchInput,
+    ) -> Result<GuildRoleDirectoryEntry, UserDirectoryError> {
+        if patch.is_empty() {
+            return Err(UserDirectoryError::validation("role_patch_empty"));
+        }
+        let normalized_role_key = self.normalize_role_key(role_key)?;
+        let normalized_name = match patch.name.as_deref() {
+            Some(value) => Some(self.normalize_role_name(value)?),
+            None => None,
+        };
+
+        let mut client = self.connect_owned_client().await?;
+        let transaction = client.transaction().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_start_failed:{error}"
+            ))
+        })?;
+
+        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
+            .await?;
+        let current = self
+            .get_role_state(&transaction, guild_id, &normalized_role_key)
+            .await?;
+        if current.is_system {
+            return Err(UserDirectoryError::forbidden("system_role_update_forbidden"));
+        }
+
+        transaction
+            .execute(
+                "UPDATE guild_roles_v2
+                 SET name = COALESCE($3, name),
+                     allow_view = COALESCE($4, allow_view),
+                     allow_post = COALESCE($5, allow_post),
+                     allow_manage = COALESCE($6, allow_manage),
+                     updated_at = now()
+                 WHERE guild_id = $1
+                   AND role_key = $2",
+                &[
+                    &guild_id,
+                    &normalized_role_key,
+                    &normalized_name,
+                    &patch.allow_view,
+                    &patch.allow_post,
+                    &patch.allow_manage,
+                ],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_role_update_failed:{error}"
+                ))
+            })?;
+
+        let updated = self
+            .get_role_state(&transaction, guild_id, &normalized_role_key)
+            .await?;
+        self.enqueue_guild_role_event(&transaction, "upsert", &updated, guild_id)
+            .await?;
+        let member_count = transaction
+            .query_one(
+                "SELECT COUNT(*)::BIGINT AS member_count
+                 FROM guild_member_roles_v2
+                 WHERE guild_id = $1
+                   AND role_key = $2",
+                &[&guild_id, &normalized_role_key],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_role_member_count_query_failed:{error}"
+                ))
+            })?
+            .get::<&str, i64>("member_count");
+
+        transaction.commit().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_commit_failed:{error}"
+            ))
+        })?;
+
+        Ok(updated.to_directory_entry(member_count))
+    }
+
+    /// guild role を削除する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param role_key 対象role_key
+    /// @returns なし
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn delete_guild_role(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        role_key: &str,
+    ) -> Result<(), UserDirectoryError> {
+        let normalized_role_key = self.normalize_role_key(role_key)?;
+        let mut client = self.connect_owned_client().await?;
+        let transaction = client.transaction().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_start_failed:{error}"
+            ))
+        })?;
+
+        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
+            .await?;
+        let current = self
+            .get_role_state(&transaction, guild_id, &normalized_role_key)
+            .await?;
+        if current.is_system {
+            return Err(UserDirectoryError::forbidden("system_role_delete_forbidden"));
+        }
+
+        let in_use = transaction
+            .query_opt(
+                "SELECT 1
+                 FROM guild_member_roles_v2
+                 WHERE guild_id = $1
+                   AND role_key = $2
+                 LIMIT 1",
+                &[&guild_id, &normalized_role_key],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_role_usage_lookup_failed:{error}"
+                ))
+            })?;
+        if in_use.is_some() {
+            return Err(UserDirectoryError::validation("role_in_use"));
+        }
+
+        transaction
+            .execute(
+                "DELETE FROM guild_roles_v2
+                 WHERE guild_id = $1
+                   AND role_key = $2",
+                &[&guild_id, &normalized_role_key],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_role_delete_failed:{error}"
+                ))
+            })?;
+        self.enqueue_guild_role_event(&transaction, "delete", &current, guild_id)
+            .await?;
+
+        transaction.commit().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_commit_failed:{error}"
+            ))
+        })?;
+
+        Ok(())
+    }
+
+    /// guild custom role の順序を置換する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param role_keys custom role の新順序
+    /// @returns 更新後 role 一覧
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn reorder_guild_roles(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        role_keys: Vec<String>,
+    ) -> Result<Vec<GuildRoleDirectoryEntry>, UserDirectoryError> {
+        let mut normalized_role_keys = Vec::with_capacity(role_keys.len());
+        let mut seen = BTreeSet::new();
+        for role_key in role_keys {
+            let normalized = self.normalize_role_key(&role_key)?;
+            if !seen.insert(normalized.clone()) {
+                return Err(UserDirectoryError::validation("duplicate_role_key"));
+            }
+            normalized_role_keys.push(normalized);
+        }
+
+        let mut client = self.connect_owned_client().await?;
+        let transaction = client.transaction().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_start_failed:{error}"
+            ))
+        })?;
+
+        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
+            .await?;
+        let current_roles = self.load_guild_roles(&transaction, guild_id).await?;
+        let custom_roles = current_roles
+            .iter()
+            .filter(|role| !role.is_system)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if custom_roles.len() != normalized_role_keys.len() {
+            return Err(UserDirectoryError::validation(
+                "role_reorder_custom_role_set_mismatch",
+            ));
+        }
+
+        let current_custom_keys = custom_roles
+            .iter()
+            .map(|role| role.role_key.clone())
+            .collect::<BTreeSet<_>>();
+        let requested_custom_keys = normalized_role_keys
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if current_custom_keys != requested_custom_keys {
+            return Err(UserDirectoryError::validation(
+                "role_reorder_custom_role_set_mismatch",
+            ));
+        }
+
+        for (index, role_key) in normalized_role_keys.iter().enumerate() {
+            let priority = FIRST_CUSTOM_ROLE_PRIORITY - index as i32;
+            transaction
+                .execute(
+                    "UPDATE guild_roles_v2
+                     SET priority = $3,
+                         updated_at = now()
+                     WHERE guild_id = $1
+                       AND role_key = $2",
+                    &[&guild_id, role_key, &priority],
+                )
+                .await
+                .map_err(|error| {
+                    UserDirectoryError::dependency_unavailable(format!(
+                        "user_directory_role_reorder_failed:{error}"
+                    ))
+                })?;
+
+            let updated = self.get_role_state(&transaction, guild_id, role_key).await?;
+            self.enqueue_guild_role_event(&transaction, "upsert", &updated, guild_id)
+                .await?;
+        }
+
+        let roles = self.load_guild_roles(&transaction, guild_id).await?;
+        transaction.commit().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_commit_failed:{error}"
+            ))
+        })?;
+        Ok(roles)
+    }
+
+    /// guild member への role 割当を置換する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param member_id 対象member_id
+    /// @param role_keys 最終 role 一覧
+    /// @returns 更新後 member
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn replace_member_roles(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        member_id: i64,
+        role_keys: Vec<String>,
+    ) -> Result<GuildMemberDirectoryEntry, UserDirectoryError> {
+        let mut normalized_role_keys = BTreeSet::new();
+        for role_key in role_keys {
+            normalized_role_keys.insert(self.normalize_role_key(&role_key)?);
+        }
+
+        if !normalized_role_keys.contains(MEMBER_ROLE_KEY) {
+            return Err(UserDirectoryError::validation("member_role_required"));
+        }
+
+        let mut client = self.connect_owned_client().await?;
+        let transaction = client.transaction().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_start_failed:{error}"
+            ))
+        })?;
+
+        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
+            .await?;
+        self.ensure_target_member_exists(&transaction, guild_id, member_id)
+            .await?;
+
+        let role_rows = self.load_guild_roles(&transaction, guild_id).await?;
+        let role_map = role_rows
+            .iter()
+            .map(|role| (role.role_key.clone(), role.clone()))
+            .collect::<std::collections::HashMap<_, _>>();
+        for role_key in &normalized_role_keys {
+            if !role_map.contains_key(role_key) {
+                return Err(UserDirectoryError::role_not_found("role_not_found"));
+            }
+        }
+
+        let owner_row = transaction
+            .query_one(
+                "SELECT owner_id
+                 FROM guilds
+                 WHERE id = $1",
                 &[&guild_id],
             )
             .await
             .map_err(|error| {
                 UserDirectoryError::dependency_unavailable(format!(
-                    "user_directory_list_roles_query_failed:{error}"
+                    "user_directory_guild_owner_query_failed:{error}"
                 ))
             })?;
+        let owner_id = owner_row.get::<&str, i64>("owner_id");
+        let target_is_owner = owner_id == member_id;
 
-        let mut roles = Vec::with_capacity(rows.len());
-        for row in rows {
-            roles.push(GuildRoleDirectoryEntry {
-                role_key: row.get::<&str, String>("role_key"),
-                name: row.get::<&str, String>("name"),
-                priority: row.get::<&str, i32>("priority"),
-                allow_manage: row.get::<&str, bool>("allow_manage"),
-                member_count: row.get::<&str, i64>("member_count"),
-            });
+        if target_is_owner && !normalized_role_keys.contains(OWNER_ROLE_KEY) {
+            return Err(UserDirectoryError::forbidden("owner_role_required"));
+        }
+        if !target_is_owner && normalized_role_keys.contains(OWNER_ROLE_KEY) {
+            return Err(UserDirectoryError::forbidden("owner_role_assignment_forbidden"));
         }
 
-        Ok(roles)
+        let current_rows = transaction
+            .query(
+                "SELECT role_key
+                 FROM guild_member_roles_v2
+                 WHERE guild_id = $1
+                   AND user_id = $2",
+                &[&guild_id, &member_id],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_member_roles_query_failed:{error}"
+                ))
+            })?;
+        let current_role_keys = current_rows
+            .into_iter()
+            .map(|row| row.get::<&str, String>("role_key"))
+            .collect::<BTreeSet<_>>();
+
+        for role_key in current_role_keys.difference(&normalized_role_keys) {
+            transaction
+                .execute(
+                    "DELETE FROM guild_member_roles_v2
+                     WHERE guild_id = $1
+                       AND user_id = $2
+                       AND role_key = $3",
+                    &[&guild_id, &member_id, role_key],
+                )
+                .await
+                .map_err(|error| {
+                    UserDirectoryError::dependency_unavailable(format!(
+                        "user_directory_member_role_delete_failed:{error}"
+                    ))
+                })?;
+            self.enqueue_guild_member_role_event(
+                &transaction,
+                "delete",
+                guild_id,
+                member_id,
+                role_key,
+            )
+            .await?;
+        }
+
+        for role_key in normalized_role_keys.difference(&current_role_keys) {
+            transaction
+                .execute(
+                    "INSERT INTO guild_member_roles_v2 (
+                        guild_id,
+                        user_id,
+                        role_key,
+                        assigned_by
+                     ) VALUES ($1, $2, $3, $4)",
+                    &[&guild_id, &member_id, role_key, &principal_id.0],
+                )
+                .await
+                .map_err(|error| {
+                    UserDirectoryError::dependency_unavailable(format!(
+                        "user_directory_member_role_insert_failed:{error}"
+                    ))
+                })?;
+            self.enqueue_guild_member_role_event(
+                &transaction,
+                "upsert",
+                guild_id,
+                member_id,
+                role_key,
+            )
+            .await?;
+        }
+
+        let member = self
+            .load_guild_member_entry(&transaction, guild_id, member_id)
+            .await?;
+        transaction.commit().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_commit_failed:{error}"
+            ))
+        })?;
+        Ok(member)
+    }
+
+    /// channel permission を返す。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param channel_id 対象channel_id
+    /// @returns permission 一覧
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn get_channel_permissions(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        channel_id: i64,
+    ) -> Result<ChannelPermissionDirectoryEntry, UserDirectoryError> {
+        let client = self.select_client().await?;
+        self.ensure_guild_manage_access(&*client, guild_id, principal_id)
+            .await?;
+        self.ensure_target_channel_exists(&*client, guild_id, channel_id)
+            .await?;
+        self.load_channel_permissions(&*client, guild_id, channel_id)
+            .await
+    }
+
+    /// channel permission を置換する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param channel_id 対象channel_id
+    /// @param input 最終 override 一覧
+    /// @returns 更新後 permission と invalidation 用情報
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn replace_channel_permissions(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        channel_id: i64,
+        input: ReplaceChannelPermissionsInput,
+    ) -> Result<ChannelPermissionUpdateResult, UserDirectoryError> {
+        let mut normalized_role_inputs = std::collections::HashMap::<String, (Option<bool>, Option<bool>)>::new();
+        for override_input in input.role_overrides {
+            let role_key = self.normalize_role_key(&override_input.role_key)?;
+            if normalized_role_inputs
+                .insert(
+                    role_key,
+                    (
+                        override_input.can_view.as_option_bool(),
+                        override_input.can_post.as_option_bool(),
+                    ),
+                )
+                .is_some()
+            {
+                return Err(UserDirectoryError::validation("duplicate_role_override_subject"));
+            }
+        }
+
+        let mut normalized_user_inputs = std::collections::HashMap::<i64, (Option<bool>, Option<bool>)>::new();
+        for override_input in input.user_overrides {
+            if override_input.user_id <= 0 {
+                return Err(UserDirectoryError::validation("user_id_invalid"));
+            }
+            if normalized_user_inputs
+                .insert(
+                    override_input.user_id,
+                    (
+                        override_input.can_view.as_option_bool(),
+                        override_input.can_post.as_option_bool(),
+                    ),
+                )
+                .is_some()
+            {
+                return Err(UserDirectoryError::validation("duplicate_user_override_subject"));
+            }
+        }
+
+        let mut client = self.connect_owned_client().await?;
+        let transaction = client.transaction().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_start_failed:{error}"
+            ))
+        })?;
+
+        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
+            .await?;
+        self.ensure_target_channel_exists(&transaction, guild_id, channel_id)
+            .await?;
+
+        for role_key in normalized_role_inputs.keys() {
+            self.get_role_state(&transaction, guild_id, role_key).await?;
+        }
+        for user_id in normalized_user_inputs.keys() {
+            self.ensure_target_member_exists(&transaction, guild_id, *user_id)
+                .await?;
+        }
+
+        let current_role_rows = transaction
+            .query(
+                "SELECT role_key, can_view, can_post
+                 FROM channel_role_permission_overrides_v2
+                 WHERE guild_id = $1
+                   AND channel_id = $2",
+                &[&guild_id, &channel_id],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_channel_role_override_query_failed:{error}"
+                ))
+            })?;
+        let current_role_map = current_role_rows
+            .into_iter()
+            .map(|row| {
+                (
+                    row.get::<&str, String>("role_key"),
+                    (
+                        row.get::<&str, Option<bool>>("can_view"),
+                        row.get::<&str, Option<bool>>("can_post"),
+                    ),
+                )
+            })
+            .collect::<std::collections::HashMap<_, _>>();
+
+        let current_user_rows = transaction
+            .query(
+                "SELECT user_id, can_view, can_post
+                 FROM channel_user_permission_overrides_v2
+                 WHERE guild_id = $1
+                   AND channel_id = $2",
+                &[&guild_id, &channel_id],
+            )
+            .await
+            .map_err(|error| {
+                UserDirectoryError::dependency_unavailable(format!(
+                    "user_directory_channel_user_override_query_failed:{error}"
+                ))
+            })?;
+        let current_user_map = current_user_rows
+            .into_iter()
+            .map(|row| {
+                (
+                    row.get::<&str, i64>("user_id"),
+                    (
+                        row.get::<&str, Option<bool>>("can_view"),
+                        row.get::<&str, Option<bool>>("can_post"),
+                    ),
+                )
+            })
+            .collect::<std::collections::HashMap<_, _>>();
+
+        let mut changed_role_overrides = false;
+        let mut changed_user_ids = BTreeSet::new();
+
+        let current_role_keys = current_role_map.keys().cloned().collect::<BTreeSet<_>>();
+        let requested_role_keys = normalized_role_inputs.keys().cloned().collect::<BTreeSet<_>>();
+        for role_key in current_role_keys.difference(&requested_role_keys) {
+            transaction
+                .execute(
+                    "DELETE FROM channel_role_permission_overrides_v2
+                     WHERE guild_id = $1
+                       AND channel_id = $2
+                       AND role_key = $3",
+                    &[&guild_id, &channel_id, role_key],
+                )
+                .await
+                .map_err(|error| {
+                    UserDirectoryError::dependency_unavailable(format!(
+                        "user_directory_channel_role_override_delete_failed:{error}"
+                    ))
+                })?;
+            self.enqueue_channel_role_override_event(
+                &transaction,
+                "delete",
+                guild_id,
+                channel_id,
+                role_key,
+                (None, None),
+            )
+            .await?;
+            changed_role_overrides = true;
+        }
+
+        for (role_key, values) in &normalized_role_inputs {
+            if values.0.is_none() && values.1.is_none() {
+                if current_role_map.contains_key(role_key) {
+                    transaction
+                        .execute(
+                            "DELETE FROM channel_role_permission_overrides_v2
+                             WHERE guild_id = $1
+                               AND channel_id = $2
+                               AND role_key = $3",
+                            &[&guild_id, &channel_id, role_key],
+                        )
+                        .await
+                        .map_err(|error| {
+                            UserDirectoryError::dependency_unavailable(format!(
+                                "user_directory_channel_role_override_delete_failed:{error}"
+                            ))
+                        })?;
+                    self.enqueue_channel_role_override_event(
+                        &transaction,
+                        "delete",
+                        guild_id,
+                        channel_id,
+                        role_key,
+                        (None, None),
+                    )
+                    .await?;
+                    changed_role_overrides = true;
+                }
+                continue;
+            }
+
+            let needs_write = current_role_map.get(role_key) != Some(values);
+            if !needs_write {
+                continue;
+            }
+
+            transaction
+                .execute(
+                    "INSERT INTO channel_role_permission_overrides_v2 (
+                        channel_id,
+                        guild_id,
+                        role_key,
+                        can_view,
+                        can_post
+                     ) VALUES ($1, $2, $3, $4, $5)
+                     ON CONFLICT (channel_id, role_key)
+                     DO UPDATE SET
+                        can_view = EXCLUDED.can_view,
+                        can_post = EXCLUDED.can_post,
+                        updated_at = now()",
+                    &[&channel_id, &guild_id, role_key, &values.0, &values.1],
+                )
+                .await
+                .map_err(|error| {
+                    UserDirectoryError::dependency_unavailable(format!(
+                        "user_directory_channel_role_override_upsert_failed:{error}"
+                    ))
+                })?;
+            self.enqueue_channel_role_override_event(
+                &transaction,
+                "upsert",
+                guild_id,
+                channel_id,
+                role_key,
+                *values,
+            )
+            .await?;
+            changed_role_overrides = true;
+        }
+
+        let current_user_ids = current_user_map.keys().cloned().collect::<BTreeSet<_>>();
+        let requested_user_ids = normalized_user_inputs.keys().cloned().collect::<BTreeSet<_>>();
+        for user_id in current_user_ids.difference(&requested_user_ids) {
+            transaction
+                .execute(
+                    "DELETE FROM channel_user_permission_overrides_v2
+                     WHERE guild_id = $1
+                       AND channel_id = $2
+                       AND user_id = $3",
+                    &[&guild_id, &channel_id, user_id],
+                )
+                .await
+                .map_err(|error| {
+                    UserDirectoryError::dependency_unavailable(format!(
+                        "user_directory_channel_user_override_delete_failed:{error}"
+                    ))
+                })?;
+            self.enqueue_channel_user_override_event(
+                &transaction,
+                "delete",
+                guild_id,
+                channel_id,
+                *user_id,
+                (None, None),
+            )
+            .await?;
+            changed_user_ids.insert(*user_id);
+        }
+
+        for (user_id, values) in &normalized_user_inputs {
+            if values.0.is_none() && values.1.is_none() {
+                if current_user_map.contains_key(user_id) {
+                    transaction
+                        .execute(
+                            "DELETE FROM channel_user_permission_overrides_v2
+                             WHERE guild_id = $1
+                               AND channel_id = $2
+                               AND user_id = $3",
+                            &[&guild_id, &channel_id, user_id],
+                        )
+                        .await
+                        .map_err(|error| {
+                            UserDirectoryError::dependency_unavailable(format!(
+                                "user_directory_channel_user_override_delete_failed:{error}"
+                            ))
+                        })?;
+                    self.enqueue_channel_user_override_event(
+                        &transaction,
+                        "delete",
+                        guild_id,
+                        channel_id,
+                        *user_id,
+                        (None, None),
+                    )
+                    .await?;
+                    changed_user_ids.insert(*user_id);
+                }
+                continue;
+            }
+
+            let needs_write = current_user_map.get(user_id) != Some(values);
+            if !needs_write {
+                continue;
+            }
+
+            transaction
+                .execute(
+                    "INSERT INTO channel_user_permission_overrides_v2 (
+                        channel_id,
+                        guild_id,
+                        user_id,
+                        can_view,
+                        can_post
+                     ) VALUES ($1, $2, $3, $4, $5)
+                     ON CONFLICT (channel_id, user_id)
+                     DO UPDATE SET
+                        can_view = EXCLUDED.can_view,
+                        can_post = EXCLUDED.can_post,
+                        updated_at = now()",
+                    &[&channel_id, &guild_id, user_id, &values.0, &values.1],
+                )
+                .await
+                .map_err(|error| {
+                    UserDirectoryError::dependency_unavailable(format!(
+                        "user_directory_channel_user_override_upsert_failed:{error}"
+                    ))
+                })?;
+            self.enqueue_channel_user_override_event(
+                &transaction,
+                "upsert",
+                guild_id,
+                channel_id,
+                *user_id,
+                *values,
+            )
+            .await?;
+            changed_user_ids.insert(*user_id);
+        }
+
+        let permissions = self
+            .load_channel_permissions(&transaction, guild_id, channel_id)
+            .await?;
+        transaction.commit().await.map_err(|error| {
+            UserDirectoryError::dependency_unavailable(format!(
+                "user_directory_transaction_commit_failed:{error}"
+            ))
+        })?;
+
+        Ok(ChannelPermissionUpdateResult {
+            permissions,
+            changed_role_overrides,
+            changed_user_ids: changed_user_ids.into_iter().collect(),
+        })
     }
 
     /// 他ユーザープロフィールを返す。

--- a/rust/apps/api/src/user_directory/service.rs
+++ b/rust/apps/api/src/user_directory/service.rs
@@ -16,8 +16,134 @@ pub struct GuildRoleDirectoryEntry {
     pub role_key: String,
     pub name: String,
     pub priority: i32,
+    pub allow_view: bool,
+    pub allow_post: bool,
     pub allow_manage: bool,
+    pub is_system: bool,
     pub member_count: i64,
+}
+
+/// guild role create input を表現する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateGuildRoleInput {
+    pub name: String,
+    pub allow_view: bool,
+    pub allow_post: bool,
+    pub allow_manage: bool,
+}
+
+/// guild role patch input を表現する。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GuildRolePatchInput {
+    pub name: Option<String>,
+    pub allow_view: Option<bool>,
+    pub allow_post: Option<bool>,
+    pub allow_manage: Option<bool>,
+}
+
+impl GuildRolePatchInput {
+    /// patch が空かどうかを判定する。
+    /// @param なし
+    /// @returns 変更がない場合は `true`
+    /// @throws なし
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none()
+            && self.allow_view.is_none()
+            && self.allow_post.is_none()
+            && self.allow_manage.is_none()
+    }
+}
+
+/// channel permission override transport value を表現する。
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionOverrideValue {
+    Allow,
+    Deny,
+    Inherit,
+}
+
+impl PermissionOverrideValue {
+    /// tri-state DB値から transport 値へ変換する。
+    /// @param value DB tri-state
+    /// @returns transport 値
+    /// @throws なし
+    pub fn from_option_bool(value: Option<bool>) -> Self {
+        match value {
+            Some(true) => Self::Allow,
+            Some(false) => Self::Deny,
+            None => Self::Inherit,
+        }
+    }
+
+    /// transport 値を tri-state DB値へ変換する。
+    /// @param なし
+    /// @returns DB tri-state
+    /// @throws なし
+    pub fn as_option_bool(self) -> Option<bool> {
+        match self {
+            Self::Allow => Some(true),
+            Self::Deny => Some(false),
+            Self::Inherit => None,
+        }
+    }
+}
+
+/// channel role override read model を表現する。
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ChannelRolePermissionOverrideEntry {
+    pub role_key: String,
+    pub subject_name: String,
+    pub is_system: bool,
+    pub can_view: PermissionOverrideValue,
+    pub can_post: PermissionOverrideValue,
+}
+
+/// channel user override read model を表現する。
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ChannelUserPermissionOverrideEntry {
+    pub user_id: i64,
+    pub subject_name: String,
+    pub can_view: PermissionOverrideValue,
+    pub can_post: PermissionOverrideValue,
+}
+
+/// channel permission read model を表現する。
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ChannelPermissionDirectoryEntry {
+    pub role_overrides: Vec<ChannelRolePermissionOverrideEntry>,
+    pub user_overrides: Vec<ChannelUserPermissionOverrideEntry>,
+}
+
+/// channel role override upsert input を表現する。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChannelRolePermissionOverrideInput {
+    pub role_key: String,
+    pub can_view: PermissionOverrideValue,
+    pub can_post: PermissionOverrideValue,
+}
+
+/// channel user override upsert input を表現する。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChannelUserPermissionOverrideInput {
+    pub user_id: i64,
+    pub can_view: PermissionOverrideValue,
+    pub can_post: PermissionOverrideValue,
+}
+
+/// channel permission replacement input を表現する。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReplaceChannelPermissionsInput {
+    pub role_overrides: Vec<ChannelRolePermissionOverrideInput>,
+    pub user_overrides: Vec<ChannelUserPermissionOverrideInput>,
+}
+
+/// channel permission update 結果を表現する。
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ChannelPermissionUpdateResult {
+    pub permissions: ChannelPermissionDirectoryEntry,
+    pub changed_role_overrides: bool,
+    pub changed_user_ids: Vec<i64>,
 }
 
 /// 他ユーザープロフィール read model を表現する。
@@ -55,6 +181,103 @@ pub trait UserDirectoryService: Send + Sync {
         principal_id: PrincipalId,
         guild_id: i64,
     ) -> Result<Vec<GuildRoleDirectoryEntry>, UserDirectoryError>;
+
+    /// guild role を作成する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param input 作成入力
+    /// @returns 作成済み role
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn create_guild_role(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        input: CreateGuildRoleInput,
+    ) -> Result<GuildRoleDirectoryEntry, UserDirectoryError>;
+
+    /// guild role を更新する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param role_key 対象role_key
+    /// @param patch 更新内容
+    /// @returns 更新済み role
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn update_guild_role(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        role_key: &str,
+        patch: GuildRolePatchInput,
+    ) -> Result<GuildRoleDirectoryEntry, UserDirectoryError>;
+
+    /// guild role を削除する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param role_key 対象role_key
+    /// @returns なし
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn delete_guild_role(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        role_key: &str,
+    ) -> Result<(), UserDirectoryError>;
+
+    /// guild custom role の順序を置換する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param role_keys custom role の新順序
+    /// @returns 更新後 role 一覧
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn reorder_guild_roles(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        role_keys: Vec<String>,
+    ) -> Result<Vec<GuildRoleDirectoryEntry>, UserDirectoryError>;
+
+    /// guild member への role 割当を置換する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param member_id 対象member_id
+    /// @param role_keys 最終 role 一覧
+    /// @returns 更新後 member
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn replace_member_roles(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        member_id: i64,
+        role_keys: Vec<String>,
+    ) -> Result<GuildMemberDirectoryEntry, UserDirectoryError>;
+
+    /// channel permission を返す。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param channel_id 対象channel_id
+    /// @returns permission 一覧
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn get_channel_permissions(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        channel_id: i64,
+    ) -> Result<ChannelPermissionDirectoryEntry, UserDirectoryError>;
+
+    /// channel permission を置換する。
+    /// @param principal_id 認証済みprincipal_id
+    /// @param guild_id 対象guild_id
+    /// @param channel_id 対象channel_id
+    /// @param input 最終 override 一覧
+    /// @returns 更新後 permission と invalidation 用情報
+    /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
+    async fn replace_channel_permissions(
+        &self,
+        principal_id: PrincipalId,
+        guild_id: i64,
+        channel_id: i64,
+        input: ReplaceChannelPermissionsInput,
+    ) -> Result<ChannelPermissionUpdateResult, UserDirectoryError>;
 
     /// 他ユーザープロフィールを返す。
     /// @param principal_id 認証済みprincipal_id
@@ -119,6 +342,117 @@ impl UserDirectoryService for UnavailableUserDirectoryService {
         _principal_id: PrincipalId,
         _guild_id: i64,
     ) -> Result<Vec<GuildRoleDirectoryEntry>, UserDirectoryError> {
+        Err(self.unavailable_error())
+    }
+
+    /// guild role を作成する。
+    /// @param _principal_id 認証済みprincipal_id
+    /// @param _guild_id 対象guild_id
+    /// @param _input 作成入力
+    /// @returns なし
+    /// @throws UserDirectoryError 常に依存障害
+    async fn create_guild_role(
+        &self,
+        _principal_id: PrincipalId,
+        _guild_id: i64,
+        _input: CreateGuildRoleInput,
+    ) -> Result<GuildRoleDirectoryEntry, UserDirectoryError> {
+        Err(self.unavailable_error())
+    }
+
+    /// guild role を更新する。
+    /// @param _principal_id 認証済みprincipal_id
+    /// @param _guild_id 対象guild_id
+    /// @param _role_key 対象role_key
+    /// @param _patch 更新内容
+    /// @returns なし
+    /// @throws UserDirectoryError 常に依存障害
+    async fn update_guild_role(
+        &self,
+        _principal_id: PrincipalId,
+        _guild_id: i64,
+        _role_key: &str,
+        _patch: GuildRolePatchInput,
+    ) -> Result<GuildRoleDirectoryEntry, UserDirectoryError> {
+        Err(self.unavailable_error())
+    }
+
+    /// guild role を削除する。
+    /// @param _principal_id 認証済みprincipal_id
+    /// @param _guild_id 対象guild_id
+    /// @param _role_key 対象role_key
+    /// @returns なし
+    /// @throws UserDirectoryError 常に依存障害
+    async fn delete_guild_role(
+        &self,
+        _principal_id: PrincipalId,
+        _guild_id: i64,
+        _role_key: &str,
+    ) -> Result<(), UserDirectoryError> {
+        Err(self.unavailable_error())
+    }
+
+    /// guild custom role の順序を置換する。
+    /// @param _principal_id 認証済みprincipal_id
+    /// @param _guild_id 対象guild_id
+    /// @param _role_keys custom role の新順序
+    /// @returns なし
+    /// @throws UserDirectoryError 常に依存障害
+    async fn reorder_guild_roles(
+        &self,
+        _principal_id: PrincipalId,
+        _guild_id: i64,
+        _role_keys: Vec<String>,
+    ) -> Result<Vec<GuildRoleDirectoryEntry>, UserDirectoryError> {
+        Err(self.unavailable_error())
+    }
+
+    /// guild member への role 割当を置換する。
+    /// @param _principal_id 認証済みprincipal_id
+    /// @param _guild_id 対象guild_id
+    /// @param _member_id 対象member_id
+    /// @param _role_keys 最終 role 一覧
+    /// @returns なし
+    /// @throws UserDirectoryError 常に依存障害
+    async fn replace_member_roles(
+        &self,
+        _principal_id: PrincipalId,
+        _guild_id: i64,
+        _member_id: i64,
+        _role_keys: Vec<String>,
+    ) -> Result<GuildMemberDirectoryEntry, UserDirectoryError> {
+        Err(self.unavailable_error())
+    }
+
+    /// channel permission を返す。
+    /// @param _principal_id 認証済みprincipal_id
+    /// @param _guild_id 対象guild_id
+    /// @param _channel_id 対象channel_id
+    /// @returns なし
+    /// @throws UserDirectoryError 常に依存障害
+    async fn get_channel_permissions(
+        &self,
+        _principal_id: PrincipalId,
+        _guild_id: i64,
+        _channel_id: i64,
+    ) -> Result<ChannelPermissionDirectoryEntry, UserDirectoryError> {
+        Err(self.unavailable_error())
+    }
+
+    /// channel permission を置換する。
+    /// @param _principal_id 認証済みprincipal_id
+    /// @param _guild_id 対象guild_id
+    /// @param _channel_id 対象channel_id
+    /// @param _input 最終 override 一覧
+    /// @returns なし
+    /// @throws UserDirectoryError 常に依存障害
+    async fn replace_channel_permissions(
+        &self,
+        _principal_id: PrincipalId,
+        _guild_id: i64,
+        _channel_id: i64,
+        _input: ReplaceChannelPermissionsInput,
+    ) -> Result<ChannelPermissionUpdateResult, UserDirectoryError> {
         Err(self.unavailable_error())
     }
 


### PR DESCRIPTION
## 概要
- `user_directory` 境界を拡張し、server role CRUD / reorder、member role assignment、channel role/user permission override の backend API を追加
- Postgres transaction 内で validation と write を行い、tuple sync 用 outbox event を同時生成
- handler 側で AuthZ cache invalidation を実行し、既存 event kind と整合する反映経路を固定

## 変更内容
- guild role の作成・更新・削除・並び替え API を追加
- guild member の role 置換 API を追加
- channel permission override の取得・置換 API を追加
- system role 保護、cross-guild 拒否、owner lock-out 防止を server 側 validation で強制
- handler テストを追加し、新規 endpoint の正常系レスポンスを固定

## 受け入れ条件
- [x] role CRUD / reorder が contract どおりに動く
- [x] member role assignment と channel permission read/write が contract どおりに動く
- [x] system role 保護 / cross-guild 拒否 / owner lock-out 防止が固定される
- [x] invalidation / tuple sync 用 event が write transaction と同時に生成される

## テスト
- `cargo test -p linklynx_backend -- --nocapture`
- `make rust-lint`
- `cd typescript && npm run typecheck`
- `make validate`

## UI チェック
- UI 変更なし。backend API のみのため UI review は対象外

## Runtime smoke
- backend API 変更であり、統合 smoke は `LIN-954` で end-to-end 回帰として実施予定

## ADR-001 チェック
- event contract の breaking change なし
- 既存 `authz.tuple.*.v1` event type と invalidation kind を再利用し、互換性を維持

Refs: LIN-951
