### PR TITLE
LIN-952 shared Authorizer に server/channel 権限適用を揃える

### DIFF
--- a/docs/agent_runs/LIN-952/Documentation.md
+++ b/docs/agent_runs/LIN-952/Documentation.md
@@ -1,0 +1,28 @@
+# Documentation
+
+## Current status
+- Status: completed
+- Scope delivered:
+  - `role settings` / `member role assignment` / `channel permission editor` / `channel create-edit-delete` を request-time `Manage` 保護へ揃えた
+  - `guild_channel` / `user_directory` の対象 path から direct DB の manage policy 判定を外し、shared `Authorizer` を primary source に寄せた
+
+## Decisions
+- `Manage` が必要な route は middleware で `Manage` を要求し、service 側の direct DB manage 判定を primary authz source にしない。
+- `permission snapshot` は既存の `resolve_permission_flag` / `resolve_channel_permission_snapshot` を維持し、実操作との整合は route mapping 側で揃える。
+- `guild_channel` / `user_directory` service は existence / validation / persistence を責務に残し、policy 拒否は middleware の `403/AUTHZ_DENIED` と `503/AUTHZ_UNAVAILABLE` へ統一する。
+- local runtime smoke は `make authz-spicedb-up` と `make authz-spicedb-health` で確認し、SpiceDB 未起動時の fail-close baseline は `ADR-004` に従う。
+
+## How to run / demo
+- Validation:
+  - `cargo test -p linklynx_backend -- --nocapture`
+  - `make rust-lint`
+  - `cd typescript && npm run typecheck`
+  - `make authz-spicedb-up`
+  - `make authz-spicedb-health`
+  - `make validate`
+- Local smoke:
+  - Docker compose の local SpiceDB を起動し、health check が `SpiceDB gRPC/HTTP endpoints are ready` を返すことを確認した。
+
+## Known issues / follow-ups
+- frontend settings 接続は `LIN-953`
+- end-to-end / SpiceDB local runtime 回帰整理は `LIN-954`

--- a/docs/agent_runs/LIN-952/Implement.md
+++ b/docs/agent_runs/LIN-952/Implement.md
@@ -1,0 +1,7 @@
+# Implement
+
+- Follow `Plan.md` as the execution order.
+- Prefer handler / middleware の AuthZ 境界で `Manage` / `View` / `Post` を決め、service では整合性検証と persistence に責務を寄せる。
+- Keep `403/AUTHZ_DENIED`、`503/AUTHZ_UNAVAILABLE`、WS `1008/1011` aligned with `ADR-004`.
+- Do not widen `AuthzResource` surface unless the current contract cannot express the route.
+- If a service still needs DB lookups, restrict them to existence / ownership / validation checks rather than duplicated permission policy.

--- a/docs/agent_runs/LIN-952/Plan.md
+++ b/docs/agent_runs/LIN-952/Plan.md
@@ -1,0 +1,35 @@
+# Plan
+
+## Rules
+- Stop-and-fix: validation / authz regression 失敗時は次工程へ進まない。
+- Scope lock: `LIN-952` は request-time AuthZ 適用と整合性修正に限定し、UI や tuple sync 基盤拡張は混ぜない。
+
+## Milestones
+### M1: request-time action/resource mapping を契約へ揃える
+- Acceptance criteria:
+  - [x] role settings / member assignment / channel permission editor の route が `Manage` 保護になる
+  - [x] channel create/edit/delete の route 判定が shared authorizer と一致する
+- Validation:
+  - `cargo test -p linklynx_backend rest_authz_action_maps_invite_and_message_commands -- --nocapture`
+  - Result: pass
+
+### M2: direct DB の manage 依存を server/channel 境界から外す
+- Acceptance criteria:
+  - [x] `guild_channel` / `user_directory` の対象 path が direct DB manage 判定なしで成立する
+  - [x] not found / validation / fail-close のエラー境界が維持される
+- Validation:
+  - `cargo test -p linklynx_backend create_guild_channel_returns_created_for_category_child -- --nocapture`
+  - `cargo test -p linklynx_backend -- --nocapture`
+  - Result: pass
+
+### M3: fail-close / snapshot 整合性回帰を固定する
+- Acceptance criteria:
+  - [x] manage-only GET endpoint の deny/unavailable regression が追加されている
+  - [x] permission snapshot と actual operation の可否が shared boundary 前提で確認できる
+  - [x] `Documentation.md` に decisions と validation 結果が残っている
+- Validation:
+  - `make rust-lint`
+  - `cd typescript && npm run typecheck`
+  - `make authz-spicedb-up && make authz-spicedb-health`
+  - `make validate`
+  - Result: pass

--- a/docs/agent_runs/LIN-952/Prompt.md
+++ b/docs/agent_runs/LIN-952/Prompt.md
@@ -1,0 +1,27 @@
+# Prompt
+
+## Goals
+- `LIN-952` として、server/channel 系の主要操作を `AUTHZ_PROVIDER=spicedb` の shared `Authorizer` 経路へ寄せる。
+- role settings、member role assignment、channel permission editor、channel create/edit/delete、permission snapshot の request-time 判定を contract どおりに揃える。
+
+## Non-goals
+- frontend settings UI 接続
+- 新しい AuthZ provider / policy system 導入
+- end-to-end 回帰整理全体
+
+## Deliverables
+- `rest_auth_middleware` の action/resource 写像更新
+- direct DB の manage 判定に依存する server/channel backend path の整理
+- permission snapshot と実操作の整合テスト
+- `docs/agent_runs/LIN-952/*`
+
+## Done when
+- [x] 対象 endpoint が `AUTHZ_PROVIDER=spicedb` で allow/deny/unavailable を shared `Authorizer` 経由で返す
+- [x] role/member/channel permission 系 GET/PUT/PATCH/DELETE が contract どおり `Manage` 保護になる
+- [x] channel create/edit/delete と permission snapshot の可否が shared authz boundary と整合する
+- [x] fail-close regression と request-time mapping をテストで固定する
+
+## Constraints
+- Security: `ADR-004` に従い fail-close を崩さない
+- Compatibility: `LIN-950` / `LIN-951` 契約と existing `AuthzResource` / `AuthzAction` の写像を壊さない
+- Scope: invite / DM / moderation の既存境界は必要最小限の再整合に留める

--- a/rust/apps/api/src/guild_channel/postgres.rs
+++ b/rust/apps/api/src/guild_channel/postgres.rs
@@ -68,29 +68,10 @@ impl PostgresGuildChannelService {
                     icon_key,
                     owner_id
                  FROM created_guild";
-    const CREATE_GUILD_CHANNEL_SQL: &str = "WITH manageable AS (
-                    SELECT gm.guild_id
-                    FROM guild_members gm
-                    WHERE gm.guild_id = $1
-                      AND gm.user_id = $4
-                      AND (
-                        EXISTS (
-                          SELECT 1
-                          FROM guilds g
-                          WHERE g.id = gm.guild_id
-                            AND g.owner_id = $4
-                        )
-                        OR EXISTS (
-                          SELECT 1
-                          FROM guild_member_roles_v2 gmr
-                          JOIN guild_roles_v2 gr
-                            ON gr.guild_id = gmr.guild_id
-                           AND gr.role_key = gmr.role_key
-                          WHERE gmr.guild_id = gm.guild_id
-                            AND gmr.user_id = $4
-                            AND gr.allow_manage = TRUE
-                        )
-                      )
+    const CREATE_GUILD_CHANNEL_SQL: &str = "WITH target_guild AS (
+                    SELECT g.id AS guild_id
+                    FROM guilds g
+                    WHERE g.id = $1
                     FOR KEY SHARE
                  ),
                  validated_parent AS (
@@ -98,8 +79,8 @@ impl PostgresGuildChannelService {
                       c.id AS parent_channel_id,
                       c.guild_id
                     FROM channels c
-                    JOIN manageable m
-                      ON m.guild_id = c.guild_id
+                    JOIN target_guild tg
+                      ON tg.guild_id = c.guild_id
                     WHERE c.id = $3
                       AND c.type = 'guild_category'
                  ),
@@ -110,10 +91,10 @@ impl PostgresGuildChannelService {
                         WHEN 'guild_text' THEN 'guild_text'::channel_type
                         WHEN 'guild_category' THEN 'guild_category'::channel_type
                       END,
-                      m.guild_id,
+                      tg.guild_id,
                       $5,
                       $4
-                    FROM manageable m
+                    FROM target_guild tg
                     WHERE ($2 = 'guild_category' AND $3 IS NULL)
                        OR ($2 = 'guild_text' AND $3 IS NULL)
                        OR ($2 = 'guild_text' AND EXISTS (SELECT 1 FROM validated_parent))
@@ -214,36 +195,19 @@ impl PostgresGuildChannelService {
                    ON h.child_channel_id = c.id
                   AND h.hierarchy_kind = 'category_child'";
     const UPDATE_GUILD_SQL: &str = "WITH target AS (
-                    SELECT id, owner_id
+                    SELECT id
                     FROM guilds
                     WHERE id = $1
                     FOR UPDATE
                  ),
-                 actor AS (
-                    SELECT
-                      t.id AS guild_id,
-                      (t.owner_id = $2) AS is_owner,
-                      EXISTS (
-                        SELECT 1
-                        FROM guild_member_roles_v2 gmr
-                        JOIN guild_roles_v2 gr
-                          ON gr.guild_id = gmr.guild_id
-                         AND gr.role_key = gmr.role_key
-                        WHERE gmr.guild_id = t.id
-                          AND gmr.user_id = $2
-                          AND gr.allow_manage = TRUE
-                      ) AS can_manage
-                    FROM target t
-                 ),
                  updated AS (
                     UPDATE guilds g
                     SET
-                      name = CASE WHEN $3::boolean THEN $4::text ELSE g.name END,
-                      icon_key = CASE WHEN $5::boolean THEN $6::text ELSE g.icon_key END,
+                      name = CASE WHEN $2::boolean THEN $3::text ELSE g.name END,
+                      icon_key = CASE WHEN $4::boolean THEN $5::text ELSE g.icon_key END,
                       updated_at = now()
-                    FROM actor a
-                    WHERE g.id = a.guild_id
-                      AND (a.is_owner OR a.can_manage)
+                    FROM target t
+                    WHERE g.id = t.id
                     RETURNING g.id, g.name, g.icon_key, g.owner_id
                  )
                  SELECT
@@ -253,32 +217,15 @@ impl PostgresGuildChannelService {
                     owner_id
                  FROM updated";
     const DELETE_GUILD_SQL: &str = "WITH target AS (
-                    SELECT id, owner_id
+                    SELECT id
                     FROM guilds
                     WHERE id = $1
                     FOR UPDATE
                  ),
-                 actor AS (
-                    SELECT
-                      t.id AS guild_id,
-                      (t.owner_id = $2) AS is_owner,
-                      EXISTS (
-                        SELECT 1
-                        FROM guild_member_roles_v2 gmr
-                        JOIN guild_roles_v2 gr
-                          ON gr.guild_id = gmr.guild_id
-                         AND gr.role_key = gmr.role_key
-                        WHERE gmr.guild_id = t.id
-                          AND gmr.user_id = $2
-                          AND gr.allow_manage = TRUE
-                      ) AS can_manage
-                    FROM target t
-                 ),
                  deleted AS (
                     DELETE FROM guilds g
-                    USING actor a
-                    WHERE g.id = a.guild_id
-                      AND (a.is_owner OR a.can_manage)
+                    USING target t
+                    WHERE g.id = t.id
                     RETURNING g.id AS guild_id
                  )
                  SELECT guild_id FROM deleted";
@@ -289,35 +236,10 @@ impl PostgresGuildChannelService {
                     FROM channels c
                     WHERE c.id = $1
                       AND c.type IN ('guild_text', 'guild_category')
-                      AND EXISTS (
-                        SELECT 1
-                        FROM guild_members gm
-                        WHERE gm.guild_id = c.guild_id
-                          AND gm.user_id = $2
-                        FOR KEY SHARE
-                      )
-                      AND (
-                        EXISTS (
-                          SELECT 1
-                          FROM guilds g
-                          WHERE g.id = c.guild_id
-                            AND g.owner_id = $2
-                        )
-                        OR EXISTS (
-                          SELECT 1
-                          FROM guild_member_roles_v2 gmr
-                          JOIN guild_roles_v2 gr
-                            ON gr.guild_id = gmr.guild_id
-                           AND gr.role_key = gmr.role_key
-                          WHERE gmr.guild_id = c.guild_id
-                            AND gmr.user_id = $2
-                            AND gr.allow_manage = TRUE
-                        )
-                      )
                  )
                  UPDATE channels c
                  SET
-                    name = $3,
+                    name = $2,
                     updated_at = now()
                  FROM editable e
                  LEFT JOIN channel_hierarchies_v2 h
@@ -341,31 +263,6 @@ impl PostgresGuildChannelService {
                     FROM channels c
                     WHERE c.id = $1
                       AND c.type IN ('guild_text', 'guild_category')
-                      AND EXISTS (
-                        SELECT 1
-                        FROM guild_members gm
-                        WHERE gm.guild_id = c.guild_id
-                          AND gm.user_id = $2
-                        FOR KEY SHARE
-                      )
-                      AND (
-                        EXISTS (
-                          SELECT 1
-                          FROM guilds g
-                          WHERE g.id = c.guild_id
-                            AND g.owner_id = $2
-                        )
-                        OR EXISTS (
-                          SELECT 1
-                          FROM guild_member_roles_v2 gmr
-                          JOIN guild_roles_v2 gr
-                            ON gr.guild_id = gmr.guild_id
-                           AND gr.role_key = gmr.role_key
-                          WHERE gmr.guild_id = c.guild_id
-                            AND gmr.user_id = $2
-                            AND gr.allow_manage = TRUE
-                        )
-                      )
                  ),
                  deleted_children AS (
                     DELETE FROM channels c
@@ -651,49 +548,6 @@ impl PostgresGuildChannelService {
         }
     }
 
-    /// guildの管理権限を確認する。
-    /// @param client Postgresクライアント
-    /// @param guild_id 対象guild_id
-    /// @param user_id 対象user_id
-    /// @returns owner/admin管理権限を持つ場合は `true`
-    /// @throws GuildChannelError 依存障害時
-    /// principalがguild管理権限を持つか確認する。
-    /// @param client Postgresクライアント
-    /// @param principal_id 認証済みprincipal_id
-    /// @param guild_id 対象guild_id
-    /// @returns 管理権限がある場合は `true`
-    /// @throws GuildChannelError 依存障害時
-    async fn has_manage_permission(
-        &self,
-        client: &tokio_postgres::Client,
-        principal_id: PrincipalId,
-        guild_id: i64,
-    ) -> Result<bool, GuildChannelError> {
-        match client
-            .query_opt(
-                "SELECT 1
-                 FROM guilds g
-                 WHERE g.id = $1
-                   AND g.owner_id = $2
-                 UNION ALL
-                 SELECT 1
-                 FROM guild_member_roles_v2 gmr
-                 JOIN guild_roles_v2 gr
-                   ON gr.guild_id = gmr.guild_id
-                  AND gr.role_key = gmr.role_key
-                 WHERE gmr.guild_id = $1
-                   AND gmr.user_id = $2
-                   AND gr.allow_manage = TRUE
-                 LIMIT 1",
-                &[&guild_id, &principal_id.0],
-            )
-            .await
-        {
-            Ok(row) => Ok(row.is_some()),
-            Err(error) => Err(self.map_read_error("guild_manage_permission_lookup_failed", error).await),
-        }
-    }
-
     /// 書き込み系DBエラーをAPIエラーへ変換する。
     /// @param context エラー文脈
     /// @param error Postgresエラー
@@ -799,7 +653,7 @@ impl GuildChannelService for PostgresGuildChannelService {
     /// @throws GuildChannelError 入力不正/非権限/未存在/依存障害時
     async fn update_guild(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         guild_id: i64,
         patch: GuildPatchInput,
     ) -> Result<CreatedGuild, GuildChannelError> {
@@ -827,7 +681,6 @@ impl GuildChannelService for PostgresGuildChannelService {
                 Self::UPDATE_GUILD_SQL,
                 &[
                     &guild_id,
-                    &principal_id.0,
                     &set_name,
                     &name_value,
                     &set_icon_key,
@@ -840,12 +693,6 @@ impl GuildChannelService for PostgresGuildChannelService {
             Ok(None) => {
                 if !self.has_guild(&client, guild_id).await? {
                     return Err(GuildChannelError::not_found("guild_not_found"));
-                }
-                if !self
-                    .has_manage_permission(&client, principal_id, guild_id)
-                    .await?
-                {
-                    return Err(GuildChannelError::forbidden("guild_manage_permission_required"));
                 }
                 return Err(GuildChannelError::dependency_unavailable(
                     "guild_update_rejected_without_reason",
@@ -872,25 +719,16 @@ impl GuildChannelService for PostgresGuildChannelService {
     /// @throws GuildChannelError 非権限/未存在/依存障害時
     async fn delete_guild(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         guild_id: i64,
     ) -> Result<(), GuildChannelError> {
         let client = self.select_client().await?;
 
-        match client
-            .query_opt(Self::DELETE_GUILD_SQL, &[&guild_id, &principal_id.0])
-            .await
-        {
+        match client.query_opt(Self::DELETE_GUILD_SQL, &[&guild_id]).await {
             Ok(Some(_)) => Ok(()),
             Ok(None) => {
                 if !self.has_guild(&client, guild_id).await? {
                     return Err(GuildChannelError::not_found("guild_not_found"));
-                }
-                if !self
-                    .has_manage_permission(&client, principal_id, guild_id)
-                    .await?
-                {
-                    return Err(GuildChannelError::forbidden("guild_manage_permission_required"));
                 }
                 Err(GuildChannelError::dependency_unavailable(
                     "guild_delete_rejected_without_reason",
@@ -1051,9 +889,6 @@ impl GuildChannelService for PostgresGuildChannelService {
                 {
                     return Err(GuildChannelError::forbidden("guild_membership_required"));
                 }
-                if !self.has_manage_permission(&client, principal_id, guild_id).await? {
-                    return Err(GuildChannelError::forbidden("channel_manage_permission_required"));
-                }
                 if let Some(parent_id) = normalized_input.parent_id {
                     let Some((parent_guild_id, parent_kind)) =
                         self.find_channel_scope(&client, parent_id).await?
@@ -1096,7 +931,7 @@ impl GuildChannelService for PostgresGuildChannelService {
     /// @throws GuildChannelError 入力不正/境界違反/未存在/依存障害時
     async fn update_guild_channel(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         channel_id: i64,
         patch: ChannelPatchInput,
     ) -> Result<ChannelSummary, GuildChannelError> {
@@ -1106,31 +941,18 @@ impl GuildChannelService for PostgresGuildChannelService {
         let row = match client
             .query_opt(
                 Self::UPDATE_GUILD_CHANNEL_SQL,
-                &[&channel_id, &principal_id.0, &normalized_name],
+                &[&channel_id, &normalized_name],
             )
             .await
         {
             Ok(Some(row)) => row,
             Ok(None) => {
-                let Some(guild_id) = self.find_channel_guild_id(&client, channel_id).await? else {
+                let Some(_guild_id) = self.find_channel_guild_id(&client, channel_id).await? else {
                     return Err(GuildChannelError::channel_not_found("channel_not_found"));
                 };
-
-                if !self
-                    .has_guild_membership(&client, guild_id, principal_id.0)
-                    .await?
-                {
-                    return Err(GuildChannelError::forbidden("guild_membership_required"));
-                }
-
-                if !self
-                    .has_manage_permission(&client, principal_id, guild_id)
-                    .await?
-                {
-                    return Err(GuildChannelError::forbidden("channel_manage_permission_required"));
-                }
-
-                return Err(GuildChannelError::channel_not_found("channel_not_found"));
+                return Err(GuildChannelError::dependency_unavailable(
+                    "channel_update_rejected_without_reason",
+                ));
             }
             Err(error) => {
                 self.invalidate_pool().await;
@@ -1156,36 +978,23 @@ impl GuildChannelService for PostgresGuildChannelService {
     /// @throws GuildChannelError 境界違反/未存在/依存障害時
     async fn delete_guild_channel(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         channel_id: i64,
     ) -> Result<(), GuildChannelError> {
         let client = self.select_client().await?;
 
         match client
-            .query_opt(Self::DELETE_GUILD_CHANNEL_SQL, &[&channel_id, &principal_id.0])
+            .query_opt(Self::DELETE_GUILD_CHANNEL_SQL, &[&channel_id])
             .await
         {
             Ok(Some(_)) => Ok(()),
             Ok(None) => {
-                let Some(guild_id) = self.find_channel_guild_id(&client, channel_id).await? else {
+                let Some(_guild_id) = self.find_channel_guild_id(&client, channel_id).await? else {
                     return Err(GuildChannelError::channel_not_found("channel_not_found"));
                 };
-
-                if !self
-                    .has_guild_membership(&client, guild_id, principal_id.0)
-                    .await?
-                {
-                    return Err(GuildChannelError::forbidden("guild_membership_required"));
-                }
-
-                if !self
-                    .has_manage_permission(&client, principal_id, guild_id)
-                    .await?
-                {
-                    return Err(GuildChannelError::forbidden("channel_manage_permission_required"));
-                }
-
-                Err(GuildChannelError::channel_not_found("channel_not_found"))
+                Err(GuildChannelError::dependency_unavailable(
+                    "channel_delete_rejected_without_reason",
+                ))
             }
             Err(error) => {
                 self.invalidate_pool().await;

--- a/rust/apps/api/src/guild_channel/tests.rs
+++ b/rust/apps/api/src/guild_channel/tests.rs
@@ -151,16 +151,16 @@ mod tests {
     }
 
     #[test]
-    fn create_guild_channel_sql_requires_membership_lookup() {
+    fn create_guild_channel_sql_uses_target_guild_and_parent_validation() {
         let sql = PostgresGuildChannelService::CREATE_GUILD_CHANNEL_SQL;
 
-        assert!(sql.contains("FROM guild_members"));
-        assert!(sql.contains("owner_id = $4"));
+        assert!(sql.contains("FROM guilds g"));
+        assert!(sql.contains("target_guild"));
         assert!(sql.contains("validated_parent"));
         assert!(sql.contains("channel_hierarchies_v2"));
         assert!(sql.contains("FOR KEY SHARE"));
         assert!(!sql.contains("VALUES ('guild_text'"));
-        assert!(!sql.contains("role_key IN ('owner', 'admin')"));
+        assert!(!sql.contains("allow_manage = TRUE"));
     }
 
     #[test]
@@ -197,45 +197,38 @@ mod tests {
     }
 
     #[test]
-    fn update_guild_sql_requires_manage_boundary_lookup() {
+    fn update_guild_sql_updates_by_target_guild_only() {
         let sql = PostgresGuildChannelService::UPDATE_GUILD_SQL;
 
-        assert!(sql.contains("guild_member_roles_v2"));
-        assert!(sql.contains("guild_roles_v2"));
-        assert!(sql.contains("allow_manage = TRUE"));
+        assert!(sql.contains("UPDATE guilds"));
+        assert!(sql.contains("FROM target"));
+        assert!(!sql.contains("allow_manage = TRUE"));
     }
 
     #[test]
-    fn delete_guild_sql_requires_manage_boundary_lookup() {
+    fn delete_guild_sql_deletes_by_target_guild_only() {
         let sql = PostgresGuildChannelService::DELETE_GUILD_SQL;
 
         assert!(sql.contains("DELETE FROM guilds"));
-        assert!(sql.contains("guild_member_roles_v2"));
-        assert!(sql.contains("guild_roles_v2"));
-        assert!(sql.contains("allow_manage = TRUE"));
+        assert!(sql.contains("USING target"));
+        assert!(!sql.contains("allow_manage = TRUE"));
     }
 
     #[test]
-    fn update_guild_channel_sql_requires_manage_permission_lookup() {
+    fn update_guild_channel_sql_uses_channel_target_only() {
         let sql = PostgresGuildChannelService::UPDATE_GUILD_CHANNEL_SQL;
 
         assert!(sql.contains("UPDATE channels"));
-        assert!(sql.contains("guild_member_roles_v2"));
-        assert!(sql.contains("guild_roles_v2"));
-        assert!(sql.contains("owner_id = $2"));
-        assert!(sql.contains("allow_manage = TRUE"));
-        assert!(!sql.contains("role_key IN ('owner', 'admin')"));
+        assert!(sql.contains("FROM editable"));
+        assert!(!sql.contains("allow_manage = TRUE"));
     }
 
     #[test]
-    fn delete_guild_channel_sql_requires_manage_permission_lookup() {
+    fn delete_guild_channel_sql_uses_channel_target_only() {
         let sql = PostgresGuildChannelService::DELETE_GUILD_CHANNEL_SQL;
 
         assert!(sql.contains("DELETE FROM channels"));
-        assert!(sql.contains("guild_member_roles_v2"));
-        assert!(sql.contains("guild_roles_v2"));
-        assert!(sql.contains("owner_id = $2"));
-        assert!(sql.contains("allow_manage = TRUE"));
-        assert!(!sql.contains("role_key IN ('owner', 'admin')"));
+        assert!(sql.contains("WITH deletable AS"));
+        assert!(!sql.contains("allow_manage = TRUE"));
     }
 }

--- a/rust/apps/api/src/main/http_routes.rs
+++ b/rust/apps/api/src/main/http_routes.rs
@@ -3948,6 +3948,9 @@ async fn rest_auth_middleware(
 /// @returns AuthZ action
 /// @throws なし
 fn rest_authz_action_for_request(method: &axum::http::Method, path: &str) -> AuthzAction {
+    if is_guild_manage_route(path) || is_channel_manage_route(path) {
+        return AuthzAction::Manage;
+    }
     if *method == axum::http::Method::POST && is_guild_invite_create_path(path) {
         return AuthzAction::Manage;
     }
@@ -4049,6 +4052,25 @@ fn rest_request_scope_from_path(path: &str) -> RestRequestScope {
 
 fn is_message_command_path(path: &str) -> bool {
     path.starts_with("/v1/guilds/") && path.contains("/channels/") && path.contains("/messages/")
+}
+
+fn is_guild_manage_route(path: &str) -> bool {
+    matches!(
+        path.trim_matches('/').split('/').collect::<Vec<_>>().as_slice(),
+        ["guilds", _, "channels"]
+            | ["v1", "guilds", _, "members"]
+            | ["v1", "guilds", _, "members", _, "roles"]
+            | ["v1", "guilds", _, "roles"]
+            | ["v1", "guilds", _, "roles", "reorder"]
+            | ["v1", "guilds", _, "roles", _]
+    )
+}
+
+fn is_channel_manage_route(path: &str) -> bool {
+    matches!(
+        path.trim_matches('/').split('/').collect::<Vec<_>>().as_slice(),
+        ["channels", _] | ["v1", "guilds", _, "channels", _, "permissions"]
+    )
 }
 
 /// ギルドパスから guild_id を抽出する。

--- a/rust/apps/api/src/main/tests.rs
+++ b/rust/apps/api/src/main/tests.rs
@@ -7268,6 +7268,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_guild_roles_returns_forbidden_without_manage_permission() {
+        let app = app_for_test_with_authorizer(Arc::new(RoleScenarioAuthorizer)).await;
+        let token = format!("u-3:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/guilds/2001/roles")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("x-request-id", "guild-roles-manage-denied")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "AUTHZ_DENIED");
+        assert_eq!(json["request_id"], "guild-roles-manage-denied");
+    }
+
+    #[tokio::test]
     async fn create_guild_role_returns_created_role() {
         let app = app_for_test().await;
         let token = format!("u-1:{}", unix_timestamp_seconds() + 300);
@@ -7351,6 +7376,31 @@ mod tests {
         assert_eq!(json["permissions"]["role_overrides"][0]["can_post"], "deny");
         assert_eq!(json["permissions"]["user_overrides"][0]["user_id"], 1003);
         assert_eq!(json["permissions"]["user_overrides"][0]["can_post"], "allow");
+    }
+
+    #[tokio::test]
+    async fn get_channel_permissions_returns_forbidden_without_manage_permission() {
+        let app = app_for_test().await;
+        let token = format!("u-3:{}", unix_timestamp_seconds() + 300);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/guilds/2001/channels/3001/permissions")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("x-request-id", "channel-permissions-manage-denied")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = to_bytes(response.into_body(), MAX_RESPONSE_BYTES)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+        assert_eq!(json["code"], "AUTHZ_DENIED");
+        assert_eq!(json["request_id"], "channel-permissions-manage-denied");
     }
 
     #[tokio::test]
@@ -8849,6 +8899,18 @@ mod tests {
     fn rest_authz_action_maps_invite_and_message_commands() {
         assert!(matches!(
             rest_authz_action_for_request(&Method::POST, "/v1/guilds/10/invites"),
+            AuthzAction::Manage
+        ));
+        assert!(matches!(
+            rest_authz_action_for_request(&Method::GET, "/v1/guilds/10/roles"),
+            AuthzAction::Manage
+        ));
+        assert!(matches!(
+            rest_authz_action_for_request(&Method::GET, "/v1/guilds/10/channels/20/permissions"),
+            AuthzAction::Manage
+        ));
+        assert!(matches!(
+            rest_authz_action_for_request(&Method::POST, "/guilds/10/channels"),
             AuthzAction::Manage
         ));
         assert!(matches!(

--- a/rust/apps/api/src/user_directory/postgres.rs
+++ b/rust/apps/api/src/user_directory/postgres.rs
@@ -237,76 +237,6 @@ impl PostgresUserDirectoryService {
             })
     }
 
-    /// guild manage 権限を検証する。
-    /// @param client Postgres client
-    /// @param guild_id 対象guild_id
-    /// @param principal_id 実行主体
-    /// @returns なし
-    /// @throws UserDirectoryError 未存在/権限拒否/依存障害時
-    async fn ensure_guild_manage_access<C>(
-        &self,
-        client: &C,
-        guild_id: i64,
-        principal_id: PrincipalId,
-    ) -> Result<(), UserDirectoryError>
-    where
-        C: GenericClient + Sync,
-    {
-        let row = client
-            .query_one(
-                "SELECT
-                    EXISTS(SELECT 1 FROM guilds WHERE id = $1) AS guild_exists,
-                    EXISTS(
-                      SELECT 1
-                      FROM guild_members
-                      WHERE guild_id = $1
-                        AND user_id = $2
-                    ) AS is_member,
-                    EXISTS(
-                      SELECT 1
-                      FROM guilds
-                      WHERE id = $1
-                        AND owner_id = $2
-                    ) AS is_owner,
-                    EXISTS(
-                      SELECT 1
-                      FROM guild_member_roles_v2 gmr
-                      JOIN guild_roles_v2 gr
-                        ON gr.guild_id = gmr.guild_id
-                       AND gr.role_key = gmr.role_key
-                      WHERE gmr.guild_id = $1
-                        AND gmr.user_id = $2
-                        AND gr.allow_manage = TRUE
-                    ) AS can_manage",
-                &[&guild_id, &principal_id.0],
-            )
-            .await
-            .map_err(|error| {
-                UserDirectoryError::dependency_unavailable(format!(
-                    "user_directory_guild_manage_scope_query_failed:{error}"
-                ))
-            })?;
-
-        let guild_exists = row.get::<&str, bool>("guild_exists");
-        let is_member = row.get::<&str, bool>("is_member");
-        let is_owner = row.get::<&str, bool>("is_owner");
-        let can_manage = row.get::<&str, bool>("can_manage");
-
-        if !guild_exists {
-            return Err(UserDirectoryError::guild_not_found("guild_not_found"));
-        }
-        if !is_member {
-            return Err(UserDirectoryError::forbidden("guild_membership_required"));
-        }
-        if !is_owner && !can_manage {
-            return Err(UserDirectoryError::forbidden(
-                "guild_manage_permission_required",
-            ));
-        }
-
-        Ok(())
-    }
-
     /// member 存在を検証する。
     /// @param client Postgres client
     /// @param guild_id 対象guild_id
@@ -1058,12 +988,13 @@ impl UserDirectoryService for PostgresUserDirectoryService {
     /// @throws UserDirectoryError 権限拒否/依存障害時
     async fn list_guild_members(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         guild_id: i64,
     ) -> Result<Vec<GuildMemberDirectoryEntry>, UserDirectoryError> {
         let client = self.select_client().await?;
-        self.ensure_guild_manage_access(&*client, guild_id, principal_id)
-            .await?;
+        if !self.has_guild(&*client, guild_id).await? {
+            return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+        }
         self.load_guild_members(&*client, guild_id).await
     }
 
@@ -1074,12 +1005,13 @@ impl UserDirectoryService for PostgresUserDirectoryService {
     /// @throws UserDirectoryError 権限拒否/依存障害時
     async fn list_guild_roles(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         guild_id: i64,
     ) -> Result<Vec<GuildRoleDirectoryEntry>, UserDirectoryError> {
         let client = self.select_client().await?;
-        self.ensure_guild_manage_access(&*client, guild_id, principal_id)
-            .await?;
+        if !self.has_guild(&*client, guild_id).await? {
+            return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+        }
         self.load_guild_roles(&*client, guild_id).await
     }
 
@@ -1091,7 +1023,7 @@ impl UserDirectoryService for PostgresUserDirectoryService {
     /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
     async fn create_guild_role(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         guild_id: i64,
         input: CreateGuildRoleInput,
     ) -> Result<GuildRoleDirectoryEntry, UserDirectoryError> {
@@ -1103,8 +1035,9 @@ impl UserDirectoryService for PostgresUserDirectoryService {
             ))
         })?;
 
-        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
-            .await?;
+        if !self.has_guild(&transaction, guild_id).await? {
+            return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+        }
         let role_key = self
             .allocate_role_key(&transaction, guild_id, &normalized_name)
             .await?;
@@ -1169,7 +1102,7 @@ impl UserDirectoryService for PostgresUserDirectoryService {
     /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
     async fn update_guild_role(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         guild_id: i64,
         role_key: &str,
         patch: GuildRolePatchInput,
@@ -1190,8 +1123,9 @@ impl UserDirectoryService for PostgresUserDirectoryService {
             ))
         })?;
 
-        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
-            .await?;
+        if !self.has_guild(&transaction, guild_id).await? {
+            return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+        }
         let current = self
             .get_role_state(&transaction, guild_id, &normalized_role_key)
             .await?;
@@ -1263,7 +1197,7 @@ impl UserDirectoryService for PostgresUserDirectoryService {
     /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
     async fn delete_guild_role(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         guild_id: i64,
         role_key: &str,
     ) -> Result<(), UserDirectoryError> {
@@ -1275,8 +1209,9 @@ impl UserDirectoryService for PostgresUserDirectoryService {
             ))
         })?;
 
-        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
-            .await?;
+        if !self.has_guild(&transaction, guild_id).await? {
+            return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+        }
         let current = self
             .get_role_state(&transaction, guild_id, &normalized_role_key)
             .await?;
@@ -1336,7 +1271,7 @@ impl UserDirectoryService for PostgresUserDirectoryService {
     /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
     async fn reorder_guild_roles(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         guild_id: i64,
         role_keys: Vec<String>,
     ) -> Result<Vec<GuildRoleDirectoryEntry>, UserDirectoryError> {
@@ -1357,8 +1292,9 @@ impl UserDirectoryService for PostgresUserDirectoryService {
             ))
         })?;
 
-        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
-            .await?;
+        if !self.has_guild(&transaction, guild_id).await? {
+            return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+        }
         let current_roles = self.load_guild_roles(&transaction, guild_id).await?;
         let custom_roles = current_roles
             .iter()
@@ -1448,8 +1384,9 @@ impl UserDirectoryService for PostgresUserDirectoryService {
             ))
         })?;
 
-        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
-            .await?;
+        if !self.has_guild(&transaction, guild_id).await? {
+            return Err(UserDirectoryError::guild_not_found("guild_not_found"));
+        }
         self.ensure_target_member_exists(&transaction, guild_id, member_id)
             .await?;
 
@@ -1577,13 +1514,11 @@ impl UserDirectoryService for PostgresUserDirectoryService {
     /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
     async fn get_channel_permissions(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         guild_id: i64,
         channel_id: i64,
     ) -> Result<ChannelPermissionDirectoryEntry, UserDirectoryError> {
         let client = self.select_client().await?;
-        self.ensure_guild_manage_access(&*client, guild_id, principal_id)
-            .await?;
         self.ensure_target_channel_exists(&*client, guild_id, channel_id)
             .await?;
         self.load_channel_permissions(&*client, guild_id, channel_id)
@@ -1599,7 +1534,7 @@ impl UserDirectoryService for PostgresUserDirectoryService {
     /// @throws UserDirectoryError 検証失敗/権限拒否/依存障害時
     async fn replace_channel_permissions(
         &self,
-        principal_id: PrincipalId,
+        _principal_id: PrincipalId,
         guild_id: i64,
         channel_id: i64,
         input: ReplaceChannelPermissionsInput,
@@ -1647,8 +1582,6 @@ impl UserDirectoryService for PostgresUserDirectoryService {
             ))
         })?;
 
-        self.ensure_guild_manage_access(&transaction, guild_id, principal_id)
-            .await?;
         self.ensure_target_channel_exists(&transaction, guild_id, channel_id)
             .await?;
 


### PR DESCRIPTION
## 概要
- server/channel 系の manage-only route を shared Authorizer の `Manage` 判定へ揃えました。
- `guild_channel` と `user_directory` の対象 path から direct DB の manage policy 判定を外し、service の責務を existence/validation/persistence に寄せました。
- manage-only endpoint の deny 回帰と route mapping 回帰をテストで固定しました。

## 変更点
- `rest_authz_action_for_request` に guild role/member/channel permission 系 route と channel create/edit/delete の `Manage` 写像を追加
- guild/channel 更新系 SQL から embedded manage check を除去し、shared Authorizer 前提の失敗境界へ統一
- role 一覧と channel permission 取得の forbidden regression test を追加
- LIN-952 の run memory を追加

## 検証
- `cargo test -p linklynx_backend -- --nocapture`
- `make rust-lint`
- `cd typescript && npm run typecheck`
- `make authz-spicedb-up`
- `make authz-spicedb-health`
- `make validate`

## ADR-001 チェック
- Event contract 変更: なし
- 互換性判断: request-time AuthZ mapping と service 責務整理のみで、既存 event schema や tuple sync contract に破壊的変更はありません。
