### PR TITLE
LIN-953 frontend 導線を role/member/channel permission API に接続する

### DIFF
--- a/docs/agent_runs/LIN-953/Documentation.md
+++ b/docs/agent_runs/LIN-953/Documentation.md
@@ -1,0 +1,28 @@
+# Documentation
+
+## Current status
+- Status: completed
+- Scope delivered:
+  - `ServerRoles` / `ServerMembers` を実 API の role/member role assignment に接続した
+  - `ChannelEditPermissions` を role/user override API と `channel:manage` guard に接続した
+  - frontend client/query/mutation に role reorder、member role replace、channel permission replace を追加した
+
+## Decisions
+- `member` system role は frontend では `@everyone` alias として表示する。
+- channel permissions modal は `RouteGuard` の `channel:manage` を source of truth にし、forbidden/unavailable では fail-close でガード画面を出す。
+- `PermissionToggle` の cross-slice import は FSD 違反になるため、modal 側には tri-state toggle を局所化した。
+- role metadata は backend 契約に合わせて `name` と `allowView/allowPost/allowManage` を primary editable fields に絞り、`color/hoist/mentionable` は read-only fallback 扱いにした。
+
+## How to run / demo
+- Validation:
+  - `cd typescript && npm run typecheck`
+  - `cd typescript && npx vitest run src/shared/api/guild-channel-api-client.test.ts src/shared/api/mutations/use-role-actions.test.ts src/features/settings/ui/server/server-members.test.tsx src/features/modals/ui/channel-edit-permissions.test.tsx`
+  - `make validate`
+- Manual demo:
+  - server settings の `roles` で role 作成、編集、並び替え、member assignment を確認する。
+  - server settings の `members` で member role assignment 保存を確認する。
+  - channel edit modal の `permissions` で role/user override の allow/deny/inherit 保存を確認する。
+
+## Known issues / follow-ups
+- settings 画面全体の UX polish や richer member picker は今回の scope 外。
+- end-to-end / local verification runbook の整理は `LIN-954` で扱う。

--- a/docs/agent_runs/LIN-953/Implement.md
+++ b/docs/agent_runs/LIN-953/Implement.md
@@ -1,0 +1,6 @@
+# Implement
+
+- Follow `Plan.md` as the execution order.
+- Query/mutation は boundary で DTO を parse し、UI には整形済み model を渡す。
+- permission snapshot による gate は既存 RouteGuard と整合する形で寄せる。
+- mock fallback を残す場合も backend available 時の実経路を優先する。

--- a/docs/agent_runs/LIN-953/Plan.md
+++ b/docs/agent_runs/LIN-953/Plan.md
@@ -1,0 +1,30 @@
+# Plan
+
+## Rules
+- Stop-and-fix: typecheck/test failure は次工程へ進めない。
+- Scope lock: LIN-953 は frontend settings 接続と fail-close UI に限定する。
+
+## Milestones
+### M1: 現行 mock 導線と API/permission snapshot 契約を整理する
+- Acceptance criteria:
+  - [x] 対象 slice と差し替え箇所が特定できている
+  - [x] RouteGuard / permission snapshot の再利用方針が明確
+- Validation:
+  - `cd typescript && npm run typecheck`
+  - Result: pass
+
+### M2: roles/members/channel permissions を実 API へ接続する
+- Acceptance criteria:
+  - [x] roles/members 導線で CRUD/assignment が実データで動く
+  - [x] channel permission editor で tri-state 読み書きが一致する
+- Validation:
+  - `cd typescript && npx vitest run src/shared/api/guild-channel-api-client.test.ts src/shared/api/mutations/use-role-actions.test.ts src/features/settings/ui/server/server-members.test.tsx src/features/modals/ui/channel-edit-permissions.test.tsx`
+  - Result: pass
+
+### M3: fail-close UI とテストを固定する
+- Acceptance criteria:
+  - [x] 禁止/依存障害時の disabled または guard が contract どおり
+  - [x] relevant tests と typecheck/validate が通る
+- Validation:
+  - `make validate`
+  - Result: pass

--- a/docs/agent_runs/LIN-953/Prompt.md
+++ b/docs/agent_runs/LIN-953/Prompt.md
@@ -1,0 +1,26 @@
+# Prompt
+
+## Goals
+- LIN-953 として frontend settings の roles/members/channel permissions 導線を実 API と permission snapshot に接続する。
+- mock 前提 state を最小限に置き換え、fail-close な disabled/guard 表現を contract に揃える。
+
+## Non-goals
+- settings 全体のリデザイン
+- backend contract の変更
+- E2E 回帰全体
+
+## Deliverables
+- LIN-953 実装に対応する frontend query/mutation/model/ui 差分
+- component/query/interaction test
+- docs/agent_runs/LIN-953/*
+
+## Done when
+- [x] roles/members/channel permissions が実 API で読めて更新できる
+- [x] permission snapshot / RouteGuard に沿って禁止・unavailable が fail-close で出る
+- [x] tri-state allow/deny/inherit と backend DTO が一致する
+- [x] relevant frontend tests と typecheck が通る
+
+## Constraints
+- FSD/Public API を破らない
+- deep import を増やさない
+- role 機能外の導線は触らない

--- a/typescript/src/features/modals/ui/channel-edit-modal.tsx
+++ b/typescript/src/features/modals/ui/channel-edit-modal.tsx
@@ -46,7 +46,9 @@ export function ChannelEditModal({
         {activeTab === "overview" && (
           <ChannelEditOverview channelId={channelId} onSaved={onClose} />
         )}
-        {activeTab === "permissions" && <ChannelEditPermissions channelId={channelId} />}
+        {activeTab === "permissions" && (
+          <ChannelEditPermissions channelId={channelId} serverId={serverId} />
+        )}
         {activeTab === "invites" && (
           <ChannelEditInvites serverId={serverId} channelId={channelId} />
         )}

--- a/typescript/src/features/modals/ui/channel-edit-permissions.test.tsx
+++ b/typescript/src/features/modals/ui/channel-edit-permissions.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { ChannelEditPermissions } from "./channel-edit-permissions";
+
+const useActionGuardMock = vi.hoisted(() => vi.fn());
+const useRolesMock = vi.hoisted(() => vi.fn());
+const useMembersMock = vi.hoisted(() => vi.fn());
+const useChannelPermissionsMock = vi.hoisted(() => vi.fn());
+const useReplaceChannelPermissionsMock = vi.hoisted(() => vi.fn());
+const mutateAsyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/shared/api/queries", () => ({
+  useActionGuard: useActionGuardMock,
+  useRoles: useRolesMock,
+  useMembers: useMembersMock,
+  useChannelPermissions: useChannelPermissionsMock,
+  getActionGuardScreenKind: (status: string) => {
+    if (status === "forbidden") {
+      return "forbidden";
+    }
+    if (status === "unavailable") {
+      return "service-unavailable";
+    }
+    return null;
+  },
+}));
+
+vi.mock("@/shared/api/mutations", () => ({
+  useReplaceChannelPermissions: useReplaceChannelPermissionsMock,
+}));
+
+describe("ChannelEditPermissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useActionGuardMock.mockReturnValue({
+      status: "allowed",
+      isAllowed: true,
+      message: null,
+    });
+    useRolesMock.mockReturnValue({
+      data: [
+        {
+          id: "member",
+          name: "Member",
+          color: "#99aab5",
+          position: 100,
+          permissions: 0,
+          hoist: false,
+          mentionable: false,
+          memberCount: 1,
+          allowView: true,
+          allowPost: true,
+          allowManage: false,
+          isSystem: true,
+        },
+      ],
+      isPending: false,
+      isError: false,
+    });
+    useMembersMock.mockReturnValue({
+      data: [
+        {
+          user: {
+            id: "1002",
+            username: "bob",
+            displayName: "Bob",
+            avatar: null,
+            status: "offline",
+            customStatus: null,
+            bot: false,
+          },
+          nick: null,
+          roles: ["member"],
+          joinedAt: "2026-03-03T00:00:00Z",
+          avatar: null,
+        },
+      ],
+      isPending: false,
+      isError: false,
+    });
+    useChannelPermissionsMock.mockReturnValue({
+      data: {
+        roleOverrides: [
+          {
+            roleKey: "member",
+            subjectName: "@everyone",
+            isSystem: true,
+            canView: "allow",
+            canPost: "deny",
+          },
+        ],
+        userOverrides: [],
+      },
+      isPending: false,
+      isError: false,
+    });
+    useReplaceChannelPermissionsMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: mutateAsyncMock,
+    });
+  });
+
+  test("saves current override draft with backend tri-state payload", async () => {
+    mutateAsyncMock.mockResolvedValue(undefined);
+
+    render(<ChannelEditPermissions serverId="2001" channelId="3001" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "変更を保存" }));
+
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledWith({
+        serverId: "2001",
+        channelId: "3001",
+        data: {
+          roleOverrides: [
+            {
+              roleKey: "member",
+              canView: "allow",
+              canPost: "deny",
+            },
+          ],
+          userOverrides: [],
+        },
+      });
+    });
+  });
+
+  test("renders route guard screen when permission is forbidden", () => {
+    useActionGuardMock.mockReturnValue({
+      status: "forbidden",
+      isAllowed: false,
+      message: "この操作を行う権限がありません。",
+    });
+
+    render(<ChannelEditPermissions serverId="2001" channelId="3001" />);
+
+    expect(screen.getByText("アクセス権限がありません")).not.toBeNull();
+  });
+});

--- a/typescript/src/features/modals/ui/channel-edit-permissions.tsx
+++ b/typescript/src/features/modals/ui/channel-edit-permissions.tsx
@@ -1,117 +1,397 @@
 "use client";
 
-import { useState } from "react";
-import { Plus, Shield, Users } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Search, Shield, Users } from "lucide-react";
+import { RouteGuardScreen } from "@/features/route-guard";
+import { useReplaceChannelPermissions } from "@/shared/api/mutations";
+import type { ChannelPermissions, PermissionOverrideValue } from "@/shared/api/api-client";
+import { toApiErrorText, toUpdateActionErrorText } from "@/shared/api/guild-channel-api-client";
+import {
+  getActionGuardScreenKind,
+  useActionGuard,
+  useChannelPermissions,
+  useMembers,
+  useRoles,
+} from "@/shared/api/queries";
 import { cn } from "@/shared/lib/cn";
+import { useUIStore } from "@/shared/model/stores/ui-store";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
 
-type Role = {
-  id: string;
-  name: string;
-  color?: string;
-};
+const STATE_STYLES = {
+  allow: "bg-discord-brand-green text-white",
+  inherit: "bg-discord-interactive-muted text-white",
+  deny: "bg-discord-brand-red text-white",
+} as const;
 
-type PermissionOverride = {
-  id: string;
-  label: string;
-  state: "allow" | "deny" | "inherit";
-};
-
-const mockRoles: Role[] = [];
-
-const defaultPermissions: PermissionOverride[] = [
-  { id: "send_messages", label: "メッセージを送信", state: "inherit" },
-  { id: "manage_messages", label: "メッセージの管理", state: "inherit" },
-  { id: "attach_files", label: "ファイルを添付", state: "inherit" },
-  { id: "add_reactions", label: "リアクションの追加", state: "inherit" },
-  { id: "manage_members", label: "メンバーを管理", state: "inherit" },
-];
-
-export function ChannelEditPermissions({ channelId }: { channelId?: string }) {
-  const [selectedRole, setSelectedRole] = useState<string>("");
-  const [permissions, setPermissions] = useState<Record<string, PermissionOverride[]>>(() => {
-    const map: Record<string, PermissionOverride[]> = {};
-    for (const role of mockRoles) {
-      map[role.id] = defaultPermissions.map((p) => ({ ...p }));
+type Subject =
+  | {
+      key: string;
+      kind: "role";
+      label: string;
+      subtitle: string;
+      roleKey: string;
+      isSystem: boolean;
     }
-    return map;
-  });
+  | {
+      key: string;
+      kind: "user";
+      label: string;
+      subtitle: string;
+      userId: string;
+    };
 
-  const currentPermissions = permissions[selectedRole] ?? [];
+type OverrideDraft = {
+  canView: PermissionOverrideValue;
+  canPost: PermissionOverrideValue;
+};
 
-  const cycleState = (permId: string) => {
-    setPermissions((prev) => {
-      const rolePerms = prev[selectedRole] ?? [];
-      return {
-        ...prev,
-        [selectedRole]: rolePerms.map((p) => {
-          if (p.id !== permId) return p;
-          const next = p.state === "inherit" ? "allow" : p.state === "allow" ? "deny" : "inherit";
-          return { ...p, state: next };
-        }),
-      };
-    });
+const DEFAULT_DRAFT: OverrideDraft = {
+  canView: "inherit",
+  canPost: "inherit",
+};
+
+function getRoleDisplayName(roleId: string, roleName: string): string {
+  if (roleId === "member") {
+    return "@everyone";
+  }
+  return roleName;
+}
+
+function buildDraftMap(permissions: ChannelPermissions | undefined) {
+  return {
+    role: Object.fromEntries(
+      (permissions?.roleOverrides ?? []).map((override) => [
+        override.roleKey,
+        { canView: override.canView, canPost: override.canPost },
+      ]),
+    ) as Record<string, OverrideDraft>,
+    user: Object.fromEntries(
+      (permissions?.userOverrides ?? []).map((override) => [
+        override.userId,
+        { canView: override.canView, canPost: override.canPost },
+      ]),
+    ) as Record<string, OverrideDraft>,
   };
+}
 
+function hasConcreteOverride(draft: OverrideDraft): boolean {
+  return draft.canView !== "inherit" || draft.canPost !== "inherit";
+}
+
+function PermissionToggle({
+  value,
+  onChange,
+  label,
+  description,
+}: {
+  value: PermissionOverrideValue;
+  onChange: (value: PermissionOverrideValue) => void;
+  label: string;
+  description: string;
+}) {
   return (
-    <div className="flex gap-4 min-h-[300px]">
-      {/* Left column: roles */}
-      <div className="w-[180px] shrink-0 space-y-1">
-        <div className="mb-2 flex items-center justify-between">
-          <span className="text-xs font-bold uppercase text-discord-header-secondary">
-            ロール / メンバー
-          </span>
-          <button className="text-discord-interactive-normal hover:text-discord-interactive-hover">
-            <Plus className="h-4 w-4" />
-          </button>
-        </div>
-        {mockRoles.map((role) => (
+    <div className="flex items-center justify-between border-b border-discord-divider py-3">
+      <div className="flex-1 pr-4">
+        <span className="text-sm text-discord-text-normal">{label}</span>
+        <p className="mt-0.5 text-xs text-discord-text-muted">{description}</p>
+      </div>
+      <div className="flex gap-0.5 rounded-[3px] bg-discord-bg-tertiary p-0.5">
+        {(["allow", "inherit", "deny"] as const).map((state) => (
           <button
-            key={role.id}
-            onClick={() => setSelectedRole(role.id)}
+            key={state}
+            onClick={() => onChange(state)}
+            aria-label={state === "allow" ? "許可" : state === "deny" ? "拒否" : "継承"}
             className={cn(
-              "flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors",
-              selectedRole === role.id
-                ? "bg-discord-bg-mod-selected text-discord-text-normal"
-                : "text-discord-interactive-normal hover:bg-discord-bg-mod-hover hover:text-discord-interactive-hover",
+              "rounded-sm px-2 py-1 text-xs font-medium transition-colors",
+              value === state
+                ? STATE_STYLES[state]
+                : "text-discord-text-muted hover:text-discord-text-normal",
             )}
           >
-            {role.id === "everyone" ? (
-              <Users className="h-4 w-4 shrink-0" />
-            ) : (
-              <Shield
-                className="h-4 w-4 shrink-0"
-                style={role.color ? { color: role.color } : undefined}
-              />
-            )}
-            <span className="truncate">{role.name}</span>
+            {state === "allow" ? "許可" : state === "deny" ? "拒否" : "継承"}
           </button>
         ))}
       </div>
+    </div>
+  );
+}
 
-      {/* Right column: permissions */}
-      <div className="flex-1 space-y-2">
-        <p className="mb-2 text-xs font-bold uppercase text-discord-header-secondary">
-          権限オーバーライド
-        </p>
-        {currentPermissions.map((perm) => (
-          <div
-            key={perm.id}
-            className="flex items-center justify-between rounded bg-discord-bg-secondary px-3 py-2"
-          >
-            <span className="text-sm text-discord-text-normal">{perm.label}</span>
+export function ChannelEditPermissions({
+  channelId,
+  serverId,
+}: {
+  channelId?: string;
+  serverId?: string;
+}) {
+  const addToast = useUIStore((state) => state.addToast);
+  const [selectedSubjectKey, setSelectedSubjectKey] = useState<string>("");
+  const [search, setSearch] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [roleDrafts, setRoleDrafts] = useState<Record<string, OverrideDraft>>({});
+  const [userDrafts, setUserDrafts] = useState<Record<string, OverrideDraft>>({});
+  const actionGuard = useActionGuard({
+    serverId: serverId ?? "",
+    channelId: channelId ?? null,
+    requirement: "channel:manage",
+    enabled: serverId !== undefined && channelId !== undefined,
+  });
+  const rolesQuery = useRoles(serverId ?? "");
+  const membersQuery = useMembers(serverId ?? "");
+  const permissionsQuery = useChannelPermissions(
+    serverId ?? "",
+    channelId ?? "",
+    actionGuard.isAllowed,
+  );
+  const replaceChannelPermissions = useReplaceChannelPermissions();
+
+  const subjects = useMemo<Subject[]>(() => {
+    const roleSubjects = (rolesQuery.data ?? []).map<Subject>((role) => ({
+      key: `role:${role.id}`,
+      kind: "role",
+      label: getRoleDisplayName(role.id, role.name),
+      subtitle: role.isSystem ? "system role" : "role",
+      roleKey: role.id,
+      isSystem: role.isSystem,
+    }));
+    const userSubjects = (membersQuery.data ?? []).map<Subject>((member) => ({
+      key: `user:${member.user.id}`,
+      kind: "user",
+      label: member.nick ?? member.user.displayName,
+      subtitle: member.user.username,
+      userId: member.user.id,
+    }));
+    return [...roleSubjects, ...userSubjects];
+  }, [membersQuery.data, rolesQuery.data]);
+
+  const filteredSubjects = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (query.length === 0) {
+      return subjects;
+    }
+    return subjects.filter((subject) => {
+      return (
+        subject.label.toLowerCase().includes(query) ||
+        subject.subtitle.toLowerCase().includes(query)
+      );
+    });
+  }, [search, subjects]);
+
+  useEffect(() => {
+    const draftMap = buildDraftMap(permissionsQuery.data);
+    setRoleDrafts(draftMap.role);
+    setUserDrafts(draftMap.user);
+  }, [permissionsQuery.data]);
+
+  useEffect(() => {
+    if (subjects.length === 0) {
+      setSelectedSubjectKey("");
+      return;
+    }
+    if (
+      selectedSubjectKey.length === 0 ||
+      !subjects.some((subject) => subject.key === selectedSubjectKey)
+    ) {
+      setSelectedSubjectKey(subjects[0]?.key ?? "");
+    }
+  }, [selectedSubjectKey, subjects]);
+
+  const selectedSubject = subjects.find((subject) => subject.key === selectedSubjectKey) ?? null;
+  const currentDraft =
+    selectedSubject === null
+      ? DEFAULT_DRAFT
+      : selectedSubject.kind === "role"
+        ? (roleDrafts[selectedSubject.roleKey] ?? DEFAULT_DRAFT)
+        : (userDrafts[selectedSubject.userId] ?? DEFAULT_DRAFT);
+
+  const overrideCount = useMemo(() => {
+    const roleCount = Object.values(roleDrafts).filter(hasConcreteOverride).length;
+    const userCount = Object.values(userDrafts).filter(hasConcreteOverride).length;
+    return roleCount + userCount;
+  }, [roleDrafts, userDrafts]);
+
+  function updateDraft(field: keyof OverrideDraft, value: PermissionOverrideValue) {
+    if (selectedSubject === null) {
+      return;
+    }
+
+    if (selectedSubject.kind === "role") {
+      setRoleDrafts((current) => ({
+        ...current,
+        [selectedSubject.roleKey]: {
+          ...(current[selectedSubject.roleKey] ?? DEFAULT_DRAFT),
+          [field]: value,
+        },
+      }));
+      return;
+    }
+
+    setUserDrafts((current) => ({
+      ...current,
+      [selectedSubject.userId]: {
+        ...(current[selectedSubject.userId] ?? DEFAULT_DRAFT),
+        [field]: value,
+      },
+    }));
+  }
+
+  const guardScreenKind = getActionGuardScreenKind(actionGuard.status);
+  if (actionGuard.status === "loading") {
+    return <p className="text-sm text-discord-text-muted">権限を確認中です...</p>;
+  }
+
+  if (guardScreenKind !== null) {
+    return <RouteGuardScreen kind={guardScreenKind} />;
+  }
+
+  if (rolesQuery.isPending || membersQuery.isPending || permissionsQuery.isPending) {
+    return <p className="text-sm text-discord-text-muted">権限オーバーライドを読み込み中です...</p>;
+  }
+
+  if (rolesQuery.isError) {
+    return (
+      <p className="text-sm text-discord-brand-red">
+        {toApiErrorText(rolesQuery.error, "ロール一覧の読み込みに失敗しました。")}
+      </p>
+    );
+  }
+
+  if (membersQuery.isError) {
+    return (
+      <p className="text-sm text-discord-brand-red">
+        {toApiErrorText(membersQuery.error, "メンバー一覧の読み込みに失敗しました。")}
+      </p>
+    );
+  }
+
+  if (permissionsQuery.isError) {
+    return (
+      <p className="text-sm text-discord-brand-red">
+        {toApiErrorText(permissionsQuery.error, "権限オーバーライドの読み込みに失敗しました。")}
+      </p>
+    );
+  }
+
+  if (channelId === undefined || serverId === undefined) {
+    return <p className="text-sm text-discord-text-muted">チャンネル情報を確認中です...</p>;
+  }
+
+  return (
+    <div className="flex min-h-[360px] gap-4">
+      <div className="w-[220px] shrink-0">
+        <Input
+          label="ロール / メンバー"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          fullWidth
+        />
+        <div className="mt-3 rounded bg-discord-bg-secondary px-3 py-2 text-xs text-discord-text-muted">
+          {overrideCount} 件の override が設定されています。
+        </div>
+        <div className="mt-3 space-y-1">
+          {filteredSubjects.map((subject) => (
             <button
-              onClick={() => cycleState(perm.id)}
+              key={subject.key}
+              onClick={() => setSelectedSubjectKey(subject.key)}
               className={cn(
-                "rounded px-3 py-1 text-xs font-medium transition-colors",
-                perm.state === "allow" && "bg-discord-brand-green/20 text-discord-brand-green",
-                perm.state === "deny" && "bg-discord-brand-red/20 text-discord-brand-red",
-                perm.state === "inherit" && "bg-discord-bg-tertiary text-discord-text-muted",
+                "flex w-full items-center gap-2 rounded px-2 py-2 text-left text-sm transition-colors",
+                subject.key === selectedSubjectKey
+                  ? "bg-discord-bg-mod-selected text-discord-text-normal"
+                  : "text-discord-interactive-normal hover:bg-discord-bg-mod-hover hover:text-discord-interactive-hover",
               )}
             >
-              {perm.state === "allow" ? "許可" : perm.state === "deny" ? "拒否" : "継承"}
+              {subject.kind === "role" ? (
+                subject.roleKey === "member" ? (
+                  <Users className="h-4 w-4 shrink-0" />
+                ) : (
+                  <Shield className="h-4 w-4 shrink-0" />
+                )
+              ) : (
+                <Users className="h-4 w-4 shrink-0" />
+              )}
+              <div className="min-w-0 flex-1">
+                <p className="truncate">{subject.label}</p>
+                <p className="truncate text-xs text-discord-text-muted">{subject.subtitle}</p>
+              </div>
             </button>
+          ))}
+          {filteredSubjects.length === 0 && (
+            <div className="rounded bg-discord-bg-secondary px-3 py-4 text-center text-sm text-discord-text-muted">
+              一致する対象がありません。
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1">
+        {selectedSubject === null ? (
+          <p className="text-sm text-discord-text-muted">左のリストから対象を選択してください。</p>
+        ) : (
+          <div className="space-y-4">
+            <div>
+              <p className="text-base font-semibold text-discord-header-primary">
+                {selectedSubject.label}
+              </p>
+              <p className="text-xs text-discord-text-muted">{selectedSubject.subtitle}</p>
+            </div>
+
+            <PermissionToggle
+              value={currentDraft.canView}
+              onChange={(value) => updateDraft("canView", value)}
+              label="チャンネルを見る"
+              description="閲覧可否を allow / deny / inherit で切り替えます。"
+            />
+            <PermissionToggle
+              value={currentDraft.canPost}
+              onChange={(value) => updateDraft("canPost", value)}
+              label="メッセージを送信"
+              description="投稿可否を allow / deny / inherit で切り替えます。"
+            />
+
+            {submitError !== null && (
+              <p className="text-sm text-discord-brand-red">{submitError}</p>
+            )}
+
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                disabled={replaceChannelPermissions.isPending}
+                onClick={async () => {
+                  setSubmitError(null);
+                  try {
+                    await replaceChannelPermissions.mutateAsync({
+                      serverId,
+                      channelId,
+                      data: {
+                        roleOverrides: Object.entries(roleDrafts)
+                          .map(([roleKey, draft]) => ({
+                            roleKey,
+                            canView: draft.canView,
+                            canPost: draft.canPost,
+                          }))
+                          .filter((draft) => hasConcreteOverride(draft)),
+                        userOverrides: Object.entries(userDrafts)
+                          .map(([userId, draft]) => ({
+                            userId,
+                            canView: draft.canView,
+                            canPost: draft.canPost,
+                          }))
+                          .filter((draft) => hasConcreteOverride(draft)),
+                      },
+                    });
+                    addToast({ message: "チャンネル権限を保存しました。", type: "success" });
+                  } catch (error: unknown) {
+                    setSubmitError(
+                      toUpdateActionErrorText(error, "チャンネル権限の保存に失敗しました。"),
+                    );
+                  }
+                }}
+              >
+                {replaceChannelPermissions.isPending ? "保存中..." : "変更を保存"}
+              </Button>
+            </div>
           </div>
-        ))}
+        )}
       </div>
     </div>
   );

--- a/typescript/src/features/settings/ui/server/role-edit-panel.tsx
+++ b/typescript/src/features/settings/ui/server/role-edit-panel.tsx
@@ -1,290 +1,293 @@
 "use client";
 
-import { useState } from "react";
-import { cn } from "@/shared/lib/cn";
-import { ArrowLeft, Search, UserPlus } from "lucide-react";
-import { Input } from "@/shared/ui/input";
+import { useMemo, useState } from "react";
+import { ArrowDown, ArrowLeft, ArrowUp, Shield, Trash2, Users } from "lucide-react";
+import type { Role, UpdateRoleInput } from "@/shared/api/api-client";
+import {
+  toDeleteActionErrorText,
+  toUpdateActionErrorText,
+} from "@/shared/api/guild-channel-api-client";
+import type { GuildMember } from "@/shared/model/types";
 import { Button } from "@/shared/ui/button";
-import { Toggle } from "@/shared/ui/toggle";
+import { Checkbox } from "@/shared/ui/checkbox";
+import { Input } from "@/shared/ui/input";
 import { Tabs } from "@/shared/ui/tabs-simple";
-import { PermissionToggle } from "./permission-toggle";
-import { RoleColorPicker } from "./role-color-picker";
-import { type MockRole, PERMISSION_FLAGS, hasPermission } from "@/shared/api/mock/data/roles";
+import { Toggle } from "@/shared/ui/toggle";
 
-type PermissionState = "allow" | "deny" | "inherit";
+type RoleEditTab = "display" | "permissions" | "members";
 
-const TABS = [
+const TABS: { id: RoleEditTab; label: string }[] = [
   { id: "display", label: "表示" },
   { id: "permissions", label: "権限" },
   { id: "members", label: "メンバー" },
-  { id: "links", label: "リンク" },
 ];
 
-type PermissionDef = {
-  flag: number;
-  label: string;
-  description: string;
-  category: string;
-};
+const ROLE_PERMISSION_FIELDS = [
+  {
+    key: "allowView",
+    label: "閲覧を許可",
+    description: "サーバーやチャンネルを表示できる基礎権限です。",
+  },
+  {
+    key: "allowPost",
+    label: "投稿を許可",
+    description: "メッセージ送信やリアクションなど投稿系の基礎権限です。",
+  },
+  {
+    key: "allowManage",
+    label: "管理を許可",
+    description: "設定、ロール、権限制御など管理系操作を許可します。",
+  },
+] as const;
 
-const PERMISSION_DEFS: PermissionDef[] = [
-  {
-    flag: PERMISSION_FLAGS.ADMINISTRATOR,
-    label: "管理者",
-    description: "すべての権限を持ち、チャンネル固有の権限を上書きします",
-    category: "一般",
-  },
-  {
-    flag: PERMISSION_FLAGS.MANAGE_CHANNELS,
-    label: "チャンネルの管理",
-    description: "チャンネルの作成、編集、削除ができます",
-    category: "一般",
-  },
-  {
-    flag: PERMISSION_FLAGS.MANAGE_GUILD,
-    label: "サーバーの管理",
-    description: "サーバー名やリージョンを変更できます",
-    category: "一般",
-  },
-  {
-    flag: PERMISSION_FLAGS.MANAGE_ROLES,
-    label: "ロールの管理",
-    description: "ロールの作成、編集、削除ができます",
-    category: "一般",
-  },
-  {
-    flag: PERMISSION_FLAGS.KICK_MEMBERS,
-    label: "メンバーをキック",
-    description: "メンバーをサーバーからキックできます",
-    category: "一般",
-  },
-  {
-    flag: PERMISSION_FLAGS.BAN_MEMBERS,
-    label: "メンバーをBAN",
-    description: "メンバーをサーバーからBANできます",
-    category: "一般",
-  },
-  {
-    flag: PERMISSION_FLAGS.VIEW_AUDIT_LOG,
-    label: "監査ログの表示",
-    description: "サーバーの監査ログを表示できます",
-    category: "一般",
-  },
-  {
-    flag: PERMISSION_FLAGS.VIEW_CHANNEL,
-    label: "チャンネルを見る",
-    description: "チャンネルを閲覧できます",
-    category: "テキスト",
-  },
-  {
-    flag: PERMISSION_FLAGS.SEND_MESSAGES,
-    label: "メッセージを送信",
-    description: "テキストチャンネルにメッセージを送信できます",
-    category: "テキスト",
-  },
-  {
-    flag: PERMISSION_FLAGS.MANAGE_MESSAGES,
-    label: "メッセージの管理",
-    description: "他のメンバーのメッセージを削除、ピン留めできます",
-    category: "テキスト",
-  },
-  {
-    flag: PERMISSION_FLAGS.EMBED_LINKS,
-    label: "埋め込みリンク",
-    description: "リンクのプレビューを送信できます",
-    category: "テキスト",
-  },
-  {
-    flag: PERMISSION_FLAGS.ATTACH_FILES,
-    label: "ファイルを添付",
-    description: "メッセージにファイルを添付できます",
-    category: "テキスト",
-  },
-  {
-    flag: PERMISSION_FLAGS.ADD_REACTIONS,
-    label: "リアクションの追加",
-    description: "メッセージにリアクションを追加できます",
-    category: "テキスト",
-  },
-  {
-    flag: PERMISSION_FLAGS.READ_MESSAGE_HISTORY,
-    label: "メッセージ履歴を読む",
-    description: "過去のメッセージを読むことができます",
-    category: "テキスト",
-  },
-  {
-    flag: PERMISSION_FLAGS.MENTION_EVERYONE,
-    label: "@everyoneにメンション",
-    description: "@everyone、@here、すべてのロールにメンションできます",
-    category: "テキスト",
-  },
-  {
-    flag: PERMISSION_FLAGS.CONNECT,
-    label: "接続",
-    description: "ボイスチャンネルに接続できます",
-    category: "ボイス",
-  },
-  {
-    flag: PERMISSION_FLAGS.SPEAK,
-    label: "発言",
-    description: "ボイスチャンネルで発言できます",
-    category: "ボイス",
-  },
-  {
-    flag: PERMISSION_FLAGS.MUTE_MEMBERS,
-    label: "メンバーをミュート",
-    description: "メンバーのマイクをミュートできます",
-    category: "ボイス",
-  },
-  {
-    flag: PERMISSION_FLAGS.DEAFEN_MEMBERS,
-    label: "メンバーのスピーカーをミュート",
-    description: "メンバーのスピーカーをオフにできます",
-    category: "ボイス",
-  },
-  {
-    flag: PERMISSION_FLAGS.MOVE_MEMBERS,
-    label: "メンバーを移動",
-    description: "メンバーを他のボイスチャンネルに移動できます",
-    category: "ボイス",
-  },
-];
+type RolePermissionField = (typeof ROLE_PERMISSION_FIELDS)[number]["key"];
 
-const MOCK_MEMBERS: {
-  id: string;
-  username: string;
-  avatar: string;
-  discriminator: string;
-}[] = [];
+function getRoleDisplayName(role: Role): string {
+  if (role.id === "member") {
+    return "@everyone";
+  }
+  return role.name;
+}
+
+function getMemberDisplayName(member: GuildMember): string {
+  return member.nick ?? member.user.displayName;
+}
 
 export function RoleEditPanel({
   role,
-  onSave,
+  members,
+  canMoveUp,
+  canMoveDown,
   onBack,
+  onSave,
+  onDelete,
+  onMove,
+  onUpdateMemberRoles,
 }: {
-  role: MockRole;
-  onSave?: (role: MockRole) => void;
-  onBack?: () => void;
+  role: Role;
+  members: GuildMember[];
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onBack: () => void;
+  onSave: (input: UpdateRoleInput) => Promise<Role>;
+  onDelete: (() => Promise<void>) | null;
+  onMove: (direction: "up" | "down") => Promise<void>;
+  onUpdateMemberRoles: (memberId: string, roleKeys: string[]) => Promise<void>;
 }) {
-  const [activeTab, setActiveTab] = useState("display");
+  const [activeTab, setActiveTab] = useState<RoleEditTab>("display");
   const [name, setName] = useState(role.name);
-  const [color, setColor] = useState(role.color);
-  const [hoist, setHoist] = useState(role.hoist);
-  const [mentionable, setMentionable] = useState(role.mentionable);
-  const [permissions, setPermissions] = useState(role.permissions);
+  const [allowView, setAllowView] = useState(role.allowView);
+  const [allowPost, setAllowPost] = useState(role.allowPost);
+  const [allowManage, setAllowManage] = useState(role.allowManage);
   const [memberSearch, setMemberSearch] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [saveSuccessMessage, setSaveSuccessMessage] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isReordering, setIsReordering] = useState(false);
+  const [pendingMemberId, setPendingMemberId] = useState<string | null>(null);
+
+  const filteredMembers = useMemo(() => {
+    const query = memberSearch.trim().toLowerCase();
+    return members
+      .filter((member) => {
+        if (query.length === 0) {
+          return true;
+        }
+        return (
+          getMemberDisplayName(member).toLowerCase().includes(query) ||
+          member.user.username.toLowerCase().includes(query)
+        );
+      })
+      .sort((left, right) => getMemberDisplayName(left).localeCompare(getMemberDisplayName(right)));
+  }, [memberSearch, members]);
 
   const hasChanges =
-    name !== role.name ||
-    color !== role.color ||
-    hoist !== role.hoist ||
-    mentionable !== role.mentionable ||
-    permissions !== role.permissions;
+    name.trim() !== role.name ||
+    allowView !== role.allowView ||
+    allowPost !== role.allowPost ||
+    allowManage !== role.allowManage;
+  const isBusy = isSaving || isDeleting || isReordering || pendingMemberId !== null;
 
-  function getPermState(flag: number): PermissionState {
-    if (hasPermission(permissions, flag)) return "allow";
-    return "inherit";
-  }
+  async function handleSave() {
+    const normalizedName = name.trim();
+    if (normalizedName.length === 0) {
+      setSubmitError("ロール名を入力してください。");
+      setSaveSuccessMessage(null);
+      return;
+    }
 
-  function setPermState(flag: number, state: PermissionState) {
-    if (state === "allow") {
-      setPermissions((prev) => prev | flag);
-    } else {
-      setPermissions((prev) => prev & ~flag);
+    setIsSaving(true);
+    setSubmitError(null);
+    setSaveSuccessMessage(null);
+    try {
+      await onSave({
+        name: normalizedName,
+        allowView,
+        allowPost,
+        allowManage,
+      });
+      setSaveSuccessMessage("ロール設定を保存しました。");
+    } catch (error: unknown) {
+      setSubmitError(toUpdateActionErrorText(error, "ロール設定の保存に失敗しました。"));
+    } finally {
+      setIsSaving(false);
     }
   }
 
-  function handleSave() {
-    onSave?.({
-      ...role,
-      name,
-      color,
-      hoist,
-      mentionable,
-      permissions,
-    });
+  async function handleDelete() {
+    if (onDelete === null) {
+      return;
+    }
+
+    setIsDeleting(true);
+    setSubmitError(null);
+    setSaveSuccessMessage(null);
+    try {
+      await onDelete();
+    } catch (error: unknown) {
+      setSubmitError(toDeleteActionErrorText(error, "ロールの削除に失敗しました。"));
+    } finally {
+      setIsDeleting(false);
+    }
   }
 
-  const categories = Array.from(new Set(PERMISSION_DEFS.map((p) => p.category)));
+  async function handleMove(direction: "up" | "down") {
+    setIsReordering(true);
+    setSubmitError(null);
+    setSaveSuccessMessage(null);
+    try {
+      await onMove(direction);
+    } catch (error: unknown) {
+      setSubmitError(toUpdateActionErrorText(error, "ロール順序の更新に失敗しました。"));
+    } finally {
+      setIsReordering(false);
+    }
+  }
 
-  const filteredMembers = MOCK_MEMBERS.filter((m) =>
-    m.username.toLowerCase().includes(memberSearch.toLowerCase()),
-  );
+  async function handleMemberToggle(member: GuildMember, checked: boolean) {
+    const hasRole = member.roles.includes(role.id);
+    if (hasRole === checked) {
+      return;
+    }
+
+    setPendingMemberId(member.user.id);
+    setSubmitError(null);
+    setSaveSuccessMessage(null);
+    try {
+      const nextRoleKeys = checked
+        ? [...member.roles, role.id]
+        : member.roles.filter((roleKey) => roleKey !== role.id);
+      await onUpdateMemberRoles(member.user.id, nextRoleKeys);
+    } catch (error: unknown) {
+      setSubmitError(toUpdateActionErrorText(error, "メンバー権限の更新に失敗しました。"));
+    } finally {
+      setPendingMemberId(null);
+    }
+  }
 
   return (
     <div className="flex-1">
-      {/* Header with back button */}
-      <div className="mb-4 flex items-center gap-3">
-        <button
-          onClick={onBack}
-          className="flex items-center gap-1 text-sm text-discord-text-link hover:underline"
-          aria-label="戻る"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          戻る
-        </button>
-        <span className="text-sm text-discord-text-muted">—</span>
-        <h3 className="text-base font-semibold text-discord-header-primary">
-          ロールの編集 — {role.name}
-        </h3>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1 text-sm text-discord-text-link hover:underline"
+            aria-label="戻る"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            戻る
+          </button>
+          <h3 className="text-base font-semibold text-discord-header-primary">
+            ロールの編集 - {getRoleDisplayName(role)}
+          </h3>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={!canMoveUp || isBusy}
+            onClick={() => void handleMove("up")}
+          >
+            <ArrowUp className="mr-1.5 h-4 w-4" />
+            上へ
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={!canMoveDown || isBusy}
+            onClick={() => void handleMove("down")}
+          >
+            <ArrowDown className="mr-1.5 h-4 w-4" />
+            下へ
+          </Button>
+        </div>
       </div>
 
-      {/* Tabs */}
-      <Tabs tabs={TABS} activeTab={activeTab} onChange={setActiveTab} className="mb-4" />
+      <Tabs
+        tabs={TABS}
+        activeTab={activeTab}
+        onChange={(id) => setActiveTab(id as RoleEditTab)}
+        className="mb-4"
+      />
 
-      {/* Tab content */}
+      {submitError !== null && <p className="mb-4 text-sm text-discord-brand-red">{submitError}</p>}
+      {saveSuccessMessage !== null && (
+        <p className="mb-4 text-sm text-discord-brand-green">{saveSuccessMessage}</p>
+      )}
+
       {activeTab === "display" && (
         <div className="space-y-6">
           <Input
             label="ロール名"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(event) => setName(event.target.value)}
             fullWidth
           />
 
-          <div>
-            <label className="mb-2 block text-xs font-bold uppercase text-discord-header-secondary">
-              ロールの色
-            </label>
-            <RoleColorPicker value={color} onChange={setColor} />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div>
-              <p className="text-sm text-discord-text-normal">ロールをメンバーリストで分ける</p>
-              <p className="text-xs text-discord-text-muted">
-                このロールのメンバーをメンバーリストで別のグループとして表示します
+          <div className="rounded-lg bg-discord-bg-secondary p-4">
+            <p className="text-sm font-medium text-discord-text-normal">metadata 互換</p>
+            <p className="mt-1 text-xs text-discord-text-muted">
+              `color` / `hoist` / `mentionable` は v2 backend contract の保存対象外です。
+              この画面では role 名と権限のみを編集します。
+            </p>
+            {role.isSystem && (
+              <p className="mt-3 text-xs text-discord-text-muted">
+                system role は削除できません。`member` は UI 上 `@everyone` として表示します。
               </p>
-            </div>
-            <Toggle checked={hoist} onChange={setHoist} />
-          </div>
-
-          <div className="flex items-center justify-between py-2">
-            <div>
-              <p className="text-sm text-discord-text-normal">このロールに@mentionを許可</p>
-              <p className="text-xs text-discord-text-muted">
-                メンバーがこのロールに@mentionできるようになります
-              </p>
-            </div>
-            <Toggle checked={mentionable} onChange={setMentionable} />
+            )}
           </div>
         </div>
       )}
 
       {activeTab === "permissions" && (
-        <div>
-          {categories.map((cat) => (
-            <div key={cat} className="mb-6">
-              <h4 className="mb-2 text-xs font-bold uppercase text-discord-text-muted">{cat}</h4>
-              {PERMISSION_DEFS.filter((p) => p.category === cat).map((perm) => (
-                <PermissionToggle
-                  key={perm.flag}
-                  value={getPermState(perm.flag)}
-                  onChange={(state) => setPermState(perm.flag, state)}
-                  label={perm.label}
-                  description={perm.description}
-                />
-              ))}
+        <div className="space-y-4">
+          {ROLE_PERMISSION_FIELDS.map((field) => (
+            <div
+              key={field.key}
+              className="flex items-center justify-between rounded-lg bg-discord-bg-secondary px-4 py-3"
+            >
+              <div className="pr-4">
+                <p className="text-sm text-discord-text-normal">{field.label}</p>
+                <p className="mt-1 text-xs text-discord-text-muted">{field.description}</p>
+              </div>
+              <Toggle
+                checked={
+                  field.key === "allowView"
+                    ? allowView
+                    : field.key === "allowPost"
+                      ? allowPost
+                      : allowManage
+                }
+                onChange={(checked) => {
+                  const setter: Record<RolePermissionField, (value: boolean) => void> = {
+                    allowView: setAllowView,
+                    allowPost: setAllowPost,
+                    allowManage: setAllowManage,
+                  };
+                  setter[field.key](checked);
+                }}
+              />
             </div>
           ))}
         </div>
@@ -292,94 +295,80 @@ export function RoleEditPanel({
 
       {activeTab === "members" && (
         <div>
-          <div className="mb-4 flex items-center gap-3">
-            <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-discord-text-muted" />
-              <input
-                type="text"
-                placeholder="メンバーを検索..."
-                value={memberSearch}
-                onChange={(e) => setMemberSearch(e.target.value)}
-                className="h-8 w-full rounded-[3px] bg-discord-input-bg pl-9 pr-3 text-sm text-discord-text-normal outline-none focus:outline-2 focus:outline-discord-brand-blurple"
-              />
-            </div>
-            <Button size="sm">
-              <UserPlus className="mr-1.5 h-4 w-4" />
-              メンバーを追加
-            </Button>
-          </div>
+          <Input
+            label="メンバーを検索"
+            value={memberSearch}
+            onChange={(event) => setMemberSearch(event.target.value)}
+            fullWidth
+          />
 
-          <div className="space-y-1">
-            {filteredMembers.map((member) => (
-              <div
-                key={member.id}
-                className="flex items-center gap-3 rounded px-3 py-2 hover:bg-discord-bg-mod-hover"
-              >
+          <div className="mt-4 space-y-2">
+            {filteredMembers.map((member) => {
+              const hasRole = member.roles.includes(role.id);
+              const isPending = pendingMemberId === member.user.id;
+
+              return (
                 <div
-                  className="flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium text-white"
-                  style={{ backgroundColor: color }}
+                  key={member.user.id}
+                  className="flex items-center gap-3 rounded-lg bg-discord-bg-secondary px-4 py-3"
                 >
-                  {member.avatar}
+                  <Checkbox
+                    checked={hasRole}
+                    disabled={isPending || isBusy}
+                    onChange={(checked) => void handleMemberToggle(member, checked)}
+                  />
+                  <div
+                    className="flex h-8 w-8 items-center justify-center rounded-full bg-discord-bg-tertiary text-discord-text-normal"
+                    aria-hidden="true"
+                  >
+                    {role.id === "member" ? (
+                      <Users className="h-4 w-4" />
+                    ) : (
+                      <Shield className="h-4 w-4" />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm text-discord-text-normal">
+                      {getMemberDisplayName(member)}
+                    </p>
+                    <p className="truncate text-xs text-discord-text-muted">
+                      {member.user.username}
+                    </p>
+                  </div>
+                  {isPending && <span className="text-xs text-discord-text-muted">更新中...</span>}
                 </div>
-                <div className="flex-1">
-                  <span className="text-sm text-discord-text-normal">{member.username}</span>
-                  <span className="ml-1 text-xs text-discord-text-muted">
-                    #{member.discriminator}
-                  </span>
-                </div>
-                <button className="text-xs text-discord-text-muted hover:text-discord-brand-red">
-                  削除
-                </button>
-              </div>
-            ))}
+              );
+            })}
             {filteredMembers.length === 0 && (
               <p className="py-4 text-center text-sm text-discord-text-muted">
-                メンバーが見つかりません
+                対象メンバーが見つかりません。
               </p>
             )}
           </div>
         </div>
       )}
 
-      {activeTab === "links" && (
-        <div>
-          <div className="rounded-lg bg-discord-bg-secondary p-6 text-center">
-            <h4 className="mb-2 text-sm font-semibold text-discord-header-primary">
-              リンクされたロール
-            </h4>
-            <p className="mb-4 text-sm text-discord-text-muted">
-              外部サービスとの連携でロールを自動的に付与できます。
-              ボットやインテグレーションを使ってリンクされたロールを設定してください。
-            </p>
-            <Button variant="secondary" size="sm">
-              インテグレーションを管理
+      <div className="mt-6 flex items-center justify-between gap-3 rounded-lg bg-discord-bg-tertiary p-3">
+        <div className="text-sm text-discord-text-normal">
+          {hasChanges ? "変更が保存されていません" : "保存済みの状態です"}
+        </div>
+        <div className="flex items-center gap-2">
+          {onDelete !== null && (
+            <Button
+              variant="danger"
+              size="sm"
+              disabled={isBusy}
+              onClick={() => void handleDelete()}
+            >
+              <Trash2 className="mr-1.5 h-4 w-4" />
+              削除
             </Button>
-          </div>
-        </div>
-      )}
-
-      {/* Save bar */}
-      {hasChanges && (
-        <div className="mt-6 flex items-center justify-end gap-3 rounded-lg bg-discord-bg-tertiary p-3">
-          <span className="mr-auto text-sm text-discord-text-normal">変更が保存されていません</span>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => {
-              setName(role.name);
-              setColor(role.color);
-              setHoist(role.hoist);
-              setMentionable(role.mentionable);
-              setPermissions(role.permissions);
-            }}
-          >
-            リセット
-          </Button>
-          <Button size="sm" onClick={handleSave}>
-            変更を保存
+          )}
+          <Button size="sm" disabled={!hasChanges || isBusy} onClick={() => void handleSave()}>
+            {isSaving ? "保存中..." : "変更を保存"}
           </Button>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/typescript/src/features/settings/ui/server/server-members.test.tsx
+++ b/typescript/src/features/settings/ui/server/server-members.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { ServerMembers } from "./server-members";
+
+const useMembersMock = vi.hoisted(() => vi.fn());
+const useRolesMock = vi.hoisted(() => vi.fn());
+const useReplaceMemberRolesMock = vi.hoisted(() => vi.fn());
+const mutateAsyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/shared/api/queries", () => ({
+  useMembers: useMembersMock,
+  useRoles: useRolesMock,
+}));
+
+vi.mock("@/shared/api/mutations", () => ({
+  useReplaceMemberRoles: useReplaceMemberRolesMock,
+}));
+
+describe("ServerMembers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useMembersMock.mockReturnValue({
+      data: [
+        {
+          user: {
+            id: "1001",
+            username: "alice",
+            displayName: "Alice",
+            avatar: null,
+            status: "offline",
+            customStatus: null,
+            bot: false,
+          },
+          nick: "alice-owner",
+          roles: ["member"],
+          joinedAt: "2026-03-03T00:00:00Z",
+          avatar: null,
+        },
+      ],
+      isPending: false,
+      isError: false,
+    });
+    useRolesMock.mockReturnValue({
+      data: [
+        {
+          id: "member",
+          name: "Member",
+          color: "#99aab5",
+          position: 100,
+          permissions: 0,
+          hoist: false,
+          mentionable: false,
+          memberCount: 1,
+          allowView: true,
+          allowPost: true,
+          allowManage: false,
+          isSystem: true,
+        },
+        {
+          id: "reviewer",
+          name: "Reviewer",
+          color: "#99aab5",
+          position: 90,
+          permissions: 0,
+          hoist: false,
+          mentionable: false,
+          memberCount: 0,
+          allowView: true,
+          allowPost: true,
+          allowManage: false,
+          isSystem: false,
+        },
+      ],
+      isPending: false,
+      isError: false,
+    });
+    useReplaceMemberRolesMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: mutateAsyncMock,
+    });
+  });
+
+  test("saves selected member role assignment", async () => {
+    mutateAsyncMock.mockResolvedValue(undefined);
+
+    render(<ServerMembers serverId="2001" />);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    await userEvent.click(checkboxes[1] as HTMLButtonElement);
+    await userEvent.click(screen.getByRole("button", { name: "ロールを保存" }));
+
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledWith({
+        serverId: "2001",
+        memberId: "1001",
+        roleKeys: ["member", "reviewer"],
+      });
+    });
+  });
+});

--- a/typescript/src/features/settings/ui/server/server-members.tsx
+++ b/typescript/src/features/settings/ui/server/server-members.tsx
@@ -1,30 +1,96 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Search } from "lucide-react";
+import { useReplaceMemberRoles } from "@/shared/api/mutations";
+import { toUpdateActionErrorText } from "@/shared/api/guild-channel-api-client";
+import { useMembers, useRoles } from "@/shared/api/queries";
+import type { GuildMember } from "@/shared/model/types/server";
+import { useUIStore } from "@/shared/model/stores/ui-store";
 import { Avatar } from "@/shared/ui/avatar";
 import { Button } from "@/shared/ui/button";
-import { useMembers } from "@/shared/api/queries/use-members";
-import { useRoles } from "@/shared/api/queries/use-roles";
-import type { GuildMember } from "@/shared/model/types/server";
+import { Checkbox } from "@/shared/ui/checkbox";
 
-const mockMembers: GuildMember[] = [];
+function getRoleDisplayName(roleId: string, roleName: string): string {
+  if (roleId === "member") {
+    return "@everyone";
+  }
+  return roleName;
+}
+
+function getMemberDisplayName(member: GuildMember): string {
+  return member.nick ?? member.user.displayName;
+}
 
 export function ServerMembers({ serverId }: { serverId: string }) {
+  const addToast = useUIStore((state) => state.addToast);
   const [search, setSearch] = useState("");
-  const { data: apiMembers } = useMembers(serverId);
-  const { data: roles = [] } = useRoles(serverId);
-  const members = apiMembers ?? mockMembers;
-  const roleMap = new Map(roles.map((role) => [role.id, role]));
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+  const [draftRoleKeys, setDraftRoleKeys] = useState<string[]>([]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const {
+    data: apiMembers = [],
+    isPending: isMembersPending,
+    isError,
+    error,
+  } = useMembers(serverId);
+  const {
+    data: roles = [],
+    isPending: isRolesPending,
+    isError: isRolesError,
+    error: rolesError,
+  } = useRoles(serverId);
+  const replaceMemberRoles = useReplaceMemberRoles();
 
-  const filtered = members.filter((m) => {
-    const q = search.toLowerCase();
-    return (
-      m.user.username.toLowerCase().includes(q) ||
-      m.user.displayName.toLowerCase().includes(q) ||
-      (m.nick?.toLowerCase().includes(q) ?? false)
-    );
-  });
+  const filteredMembers = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return apiMembers.filter((member) => {
+      if (query.length === 0) {
+        return true;
+      }
+      return (
+        member.user.username.toLowerCase().includes(query) ||
+        member.user.displayName.toLowerCase().includes(query) ||
+        (member.nick?.toLowerCase().includes(query) ?? false)
+      );
+    });
+  }, [apiMembers, search]);
+
+  const selectedMember =
+    filteredMembers.find((member) => member.user.id === selectedMemberId) ??
+    apiMembers.find((member) => member.user.id === selectedMemberId) ??
+    null;
+
+  useEffect(() => {
+    if (apiMembers.length === 0) {
+      setSelectedMemberId(null);
+      return;
+    }
+    if (
+      selectedMemberId === null ||
+      !apiMembers.some((member) => member.user.id === selectedMemberId)
+    ) {
+      setSelectedMemberId(apiMembers[0]?.user.id ?? null);
+    }
+  }, [apiMembers, selectedMemberId]);
+
+  useEffect(() => {
+    if (selectedMember !== null) {
+      setDraftRoleKeys(selectedMember.roles);
+    }
+  }, [selectedMember]);
+
+  if (isMembersPending || isRolesPending) {
+    return <p className="text-sm text-discord-text-muted">メンバー設定を読み込み中です...</p>;
+  }
+
+  if (isError) {
+    return <p className="text-sm text-discord-brand-red">{error.message}</p>;
+  }
+
+  if (isRolesError) {
+    return <p className="text-sm text-discord-brand-red">{rolesError.message}</p>;
+  }
 
   return (
     <div>
@@ -33,77 +99,153 @@ export function ServerMembers({ serverId }: { serverId: string }) {
       <div className="relative mb-4">
         <Search
           size={16}
-          className="absolute top-1/2 left-3 -translate-y-1/2 text-discord-text-muted"
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-discord-text-muted"
         />
         <input
           type="text"
           placeholder="メンバーを検索"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(event) => setSearch(event.target.value)}
           className="h-10 w-full rounded-[3px] bg-discord-input-bg pl-9 pr-3 text-sm text-discord-text-normal placeholder:text-discord-text-muted outline-none focus:outline-2 focus:outline-discord-brand-blurple"
         />
       </div>
 
-      <div className="text-sm text-discord-text-muted mb-3">メンバー — {filtered.length}</div>
+      <div className="text-sm text-discord-text-muted mb-3">
+        メンバー - {filteredMembers.length}
+      </div>
 
-      <div>
-        {filtered.map((member) => (
-          <div
-            key={member.user.id}
-            className="group flex items-center gap-3 rounded px-3 py-2 hover:bg-discord-bg-mod-hover"
-          >
-            <Avatar
-              src={member.avatar ?? member.user.avatar ?? undefined}
-              alt={member.user.displayName}
-              size={40}
-            />
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="truncate text-sm font-medium text-discord-text-normal">
-                  {member.nick ?? member.user.displayName}
-                </span>
-                <span className="truncate text-xs text-discord-text-muted">
+      <div className="flex gap-4">
+        <div className="w-[320px] shrink-0 space-y-1">
+          {filteredMembers.map((member) => (
+            <button
+              key={member.user.id}
+              onClick={() => {
+                setSelectedMemberId(member.user.id);
+                setSubmitError(null);
+              }}
+              className={`flex w-full items-center gap-3 rounded px-3 py-2 text-left transition-colors ${
+                selectedMemberId === member.user.id
+                  ? "bg-discord-bg-mod-active"
+                  : "hover:bg-discord-bg-mod-hover"
+              }`}
+            >
+              <Avatar
+                src={member.avatar ?? member.user.avatar ?? undefined}
+                alt={member.user.displayName}
+                size={40}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium text-discord-text-normal">
+                  {getMemberDisplayName(member)}
+                </div>
+                <div className="truncate text-xs text-discord-text-muted">
                   {member.user.username}
-                </span>
+                </div>
               </div>
-              <div className="flex items-center gap-1.5 mt-0.5">
-                {member.roles.map((role) => {
-                  const roleEntry = roleMap.get(role);
-                  const roleName = roleEntry?.name ?? role;
-                  const roleColor = "#95a5a6";
+            </button>
+          ))}
+        </div>
+
+        <div className="flex-1">
+          {selectedMember === null ? (
+            <p className="text-sm text-discord-text-muted">
+              左のリストからメンバーを選択してください。
+            </p>
+          ) : (
+            <div className="rounded-lg bg-discord-bg-secondary p-4">
+              <div className="mb-4 flex items-center gap-3">
+                <Avatar
+                  src={selectedMember.avatar ?? selectedMember.user.avatar ?? undefined}
+                  alt={selectedMember.user.displayName}
+                  size={40}
+                />
+                <div>
+                  <p className="text-base font-semibold text-discord-text-normal">
+                    {getMemberDisplayName(selectedMember)}
+                  </p>
+                  <p className="text-sm text-discord-text-muted">{selectedMember.user.username}</p>
+                </div>
+              </div>
+
+              <p className="mb-3 text-xs font-bold uppercase text-discord-header-secondary">
+                ロール割当
+              </p>
+              <div className="space-y-2">
+                {roles.map((role) => {
+                  const checked = draftRoleKeys.includes(role.id);
+                  const isLockedMemberRole = role.id === "member";
 
                   return (
-                    <span
-                      key={role}
-                      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium"
-                      style={{
-                        backgroundColor: `${roleColor}20`,
-                        color: roleColor,
-                      }}
+                    <div
+                      key={role.id}
+                      className="flex items-center gap-3 rounded bg-discord-bg-tertiary px-3 py-2"
                     >
-                      <span
-                        className="h-2 w-2 rounded-full"
-                        style={{ backgroundColor: roleColor }}
+                      <Checkbox
+                        checked={checked || isLockedMemberRole}
+                        disabled={replaceMemberRoles.isPending || isLockedMemberRole}
+                        onChange={(nextChecked) => {
+                          setDraftRoleKeys((current) => {
+                            const set = new Set(current);
+                            if (nextChecked) {
+                              set.add(role.id);
+                            } else {
+                              set.delete(role.id);
+                            }
+                            set.add("member");
+                            return Array.from(set);
+                          });
+                        }}
                       />
-                      {roleName}
-                    </span>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm text-discord-text-normal">
+                          {getRoleDisplayName(role.id, role.name)}
+                        </p>
+                        <p className="text-xs text-discord-text-muted">
+                          {role.allowManage ? "Manage" : role.allowPost ? "Post" : "View"}
+                        </p>
+                      </div>
+                    </div>
                   );
                 })}
               </div>
+
+              {submitError !== null && (
+                <p className="mt-4 text-sm text-discord-brand-red">{submitError}</p>
+              )}
+
+              <div className="mt-4 flex justify-end">
+                <Button
+                  size="sm"
+                  disabled={
+                    replaceMemberRoles.isPending ||
+                    selectedMember.roles.slice().sort().join(",") ===
+                      draftRoleKeys.slice().sort().join(",")
+                  }
+                  onClick={async () => {
+                    setSubmitError(null);
+                    try {
+                      await replaceMemberRoles.mutateAsync({
+                        serverId,
+                        memberId: selectedMember.user.id,
+                        roleKeys: Array.from(new Set([...draftRoleKeys, "member"])),
+                      });
+                      addToast({ message: "メンバーのロールを更新しました。", type: "success" });
+                    } catch (updateError: unknown) {
+                      setSubmitError(
+                        toUpdateActionErrorText(
+                          updateError,
+                          "メンバーのロール更新に失敗しました。",
+                        ),
+                      );
+                    }
+                  }}
+                >
+                  {replaceMemberRoles.isPending ? "保存中..." : "ロールを保存"}
+                </Button>
+              </div>
             </div>
-            <span className="hidden text-xs text-discord-text-muted sm:block">
-              {new Date(member.joinedAt).toLocaleDateString("ja-JP")}
-            </span>
-            <div className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-              <Button variant="secondary" size="sm">
-                キック
-              </Button>
-              <Button variant="danger" size="sm">
-                BAN
-              </Button>
-            </div>
-          </div>
-        ))}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/typescript/src/features/settings/ui/server/server-roles.tsx
+++ b/typescript/src/features/settings/ui/server/server-roles.tsx
@@ -1,35 +1,124 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Plus, Shield } from "lucide-react";
+import {
+  useCreateRole,
+  useDeleteRole,
+  useReorderRoles,
+  useReplaceMemberRoles,
+  useUpdateRole,
+} from "@/shared/api/mutations";
+import {
+  toCreateActionErrorText,
+  toDeleteActionErrorText,
+  toUpdateActionErrorText,
+} from "@/shared/api/guild-channel-api-client";
+import { useMembers, useRoles } from "@/shared/api/queries";
 import { cn } from "@/shared/lib/cn";
+import { useUIStore } from "@/shared/model/stores/ui-store";
 import { Button } from "@/shared/ui/button";
-import { GripVertical, Plus, Shield } from "lucide-react";
 import { RoleEditPanel } from "./role-edit-panel";
-import { mockRoles as initialMockRoles, type MockRole } from "@/shared/api/mock/data/roles";
+
+function getRoleDisplayName(roleId: string, roleName: string): string {
+  if (roleId === "member") {
+    return "@everyone";
+  }
+  return roleName;
+}
 
 export function ServerRoles({ serverId }: { serverId: string }) {
-  const [roles, setRoles] = useState<MockRole[]>(initialMockRoles);
+  const addToast = useUIStore((state) => state.addToast);
+  const rolesQuery = useRoles(serverId);
+  const membersQuery = useMembers(serverId);
+  const createRole = useCreateRole();
+  const updateRole = useUpdateRole();
+  const deleteRole = useDeleteRole();
+  const reorderRoles = useReorderRoles();
+  const replaceMemberRoles = useReplaceMemberRoles();
   const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
 
-  const selectedRole = roles.find((r) => r.id === selectedRoleId) ?? null;
+  const roles = useMemo(
+    () =>
+      [...(rolesQuery.data ?? [])].sort(
+        (left, right) => right.position - left.position || left.name.localeCompare(right.name),
+      ),
+    [rolesQuery.data],
+  );
+  const members = membersQuery.data ?? [];
 
-  function handleCreateRole() {
-    const newRole: MockRole = {
-      id: `role-${Date.now()}`,
-      name: "新しいロール",
-      color: "#95a5a6",
-      position: roles.length,
-      permissions: 0,
-      hoist: false,
-      mentionable: false,
-      memberCount: 0,
-    };
-    setRoles((prev) => [newRole, ...prev]);
-    setSelectedRoleId(newRole.id);
+  useEffect(() => {
+    if (roles.length === 0) {
+      setSelectedRoleId(null);
+      return;
+    }
+    if (selectedRoleId === null) {
+      setSelectedRoleId(roles[0]?.id ?? null);
+      return;
+    }
+    if (!roles.some((role) => role.id === selectedRoleId)) {
+      setSelectedRoleId(roles[0]?.id ?? null);
+    }
+  }, [roles, selectedRoleId]);
+
+  const selectedRole = roles.find((role) => role.id === selectedRoleId) ?? null;
+
+  async function handleCreateRole() {
+    setCreateError(null);
+    try {
+      const created = await createRole.mutateAsync({
+        serverId,
+        data: {
+          name: "新しいロール",
+          allowView: true,
+          allowPost: true,
+          allowManage: false,
+        },
+      });
+      setSelectedRoleId(created.id);
+      addToast({ message: "ロールを作成しました。", type: "success" });
+    } catch (error: unknown) {
+      setCreateError(toCreateActionErrorText(error, "ロールの作成に失敗しました。"));
+    }
   }
 
-  function handleSaveRole(updated: MockRole) {
-    setRoles((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+  async function handleMoveRole(roleId: string, direction: "up" | "down") {
+    const customRoles = roles.filter((role) => !role.isSystem);
+    const currentIndex = customRoles.findIndex((role) => role.id === roleId);
+    const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
+    if (
+      currentIndex < 0 ||
+      targetIndex < 0 ||
+      targetIndex >= customRoles.length ||
+      customRoles[targetIndex] === undefined
+    ) {
+      return;
+    }
+
+    const nextCustomRoles = [...customRoles];
+    const [currentRole] = nextCustomRoles.splice(currentIndex, 1);
+    if (currentRole === undefined) {
+      return;
+    }
+    nextCustomRoles.splice(targetIndex, 0, currentRole);
+    await reorderRoles.mutateAsync({
+      serverId,
+      roleKeys: nextCustomRoles.map((role) => role.id),
+    });
+    addToast({ message: "ロール順序を更新しました。", type: "success" });
+  }
+
+  if (rolesQuery.isPending || membersQuery.isPending) {
+    return <p className="text-sm text-discord-text-muted">ロール設定を読み込み中です...</p>;
+  }
+
+  if (rolesQuery.isError) {
+    return <p className="text-sm text-discord-brand-red">{rolesQuery.error.message}</p>;
+  }
+
+  if (membersQuery.isError) {
+    return <p className="text-sm text-discord-brand-red">{membersQuery.error.message}</p>;
   }
 
   return (
@@ -41,54 +130,111 @@ export function ServerRoles({ serverId }: { serverId: string }) {
             {roles.length}
           </span>
         </div>
-        <Button onClick={handleCreateRole} size="sm">
+        <Button onClick={() => void handleCreateRole()} size="sm" disabled={createRole.isPending}>
           <Plus className="mr-1.5 h-4 w-4" />
-          ロールを作成
+          {createRole.isPending ? "作成中..." : "ロールを作成"}
         </Button>
       </div>
 
+      <p className="mb-4 text-xs text-discord-text-muted">
+        system role は固定されます。custom role だけを並び替えできます。
+      </p>
+      {createError !== null && <p className="mb-4 text-sm text-discord-brand-red">{createError}</p>}
+
       <div className="flex gap-4">
-        {/* Left - Role list */}
-        <div className="w-[220px] shrink-0">
-          <p className="mb-2 text-xs text-discord-text-muted">
-            ロールをドラッグして順序を変更できます。上位のロールが優先されます。
-          </p>
-          {roles.map((role) => (
-            <button
-              key={role.id}
-              onClick={() => setSelectedRoleId(role.id)}
-              className={cn(
-                "group flex w-full items-center gap-2 rounded px-2 py-2 text-sm transition-colors",
-                role.id === selectedRoleId
-                  ? "bg-discord-bg-mod-active text-discord-interactive-active"
-                  : "text-discord-interactive-normal hover:bg-discord-bg-mod-hover",
-              )}
-            >
-              <GripVertical className="h-4 w-4 shrink-0 text-discord-text-muted opacity-0 group-hover:opacity-100" />
-              <span
-                className="h-3 w-3 shrink-0 rounded-full"
-                style={{ backgroundColor: role.color }}
-              />
-              <span className="flex-1 truncate text-left">{role.name}</span>
-              {role.hoist && <Shield className="h-3 w-3 shrink-0 text-discord-text-muted" />}
-              <span className="text-xs text-discord-text-muted">{role.memberCount}</span>
-            </button>
-          ))}
+        <div className="w-[240px] shrink-0">
+          <div className="space-y-1">
+            {roles.map((role) => (
+              <button
+                key={role.id}
+                onClick={() => setSelectedRoleId(role.id)}
+                className={cn(
+                  "group flex w-full items-center gap-2 rounded px-2 py-2 text-sm transition-colors",
+                  role.id === selectedRoleId
+                    ? "bg-discord-bg-mod-active text-discord-interactive-active"
+                    : "text-discord-interactive-normal hover:bg-discord-bg-mod-hover",
+                )}
+              >
+                <Shield className="h-4 w-4 shrink-0 text-discord-text-muted" />
+                <span className="flex-1 truncate text-left">
+                  {getRoleDisplayName(role.id, role.name)}
+                </span>
+                {role.isSystem && (
+                  <span className="rounded bg-discord-bg-secondary px-1.5 py-0.5 text-[10px] uppercase text-discord-text-muted">
+                    system
+                  </span>
+                )}
+                <span className="text-xs text-discord-text-muted">{role.memberCount}</span>
+              </button>
+            ))}
+          </div>
         </div>
 
-        {/* Right - Role edit panel or placeholder */}
-        {selectedRole ? (
+        {selectedRole !== null ? (
           <RoleEditPanel
+            key={selectedRole.id}
             role={selectedRole}
-            onSave={handleSaveRole}
+            members={members}
+            canMoveUp={
+              !selectedRole.isSystem &&
+              roles
+                .filter((role) => !role.isSystem)
+                .findIndex((role) => role.id === selectedRole.id) > 0
+            }
+            canMoveDown={
+              !selectedRole.isSystem &&
+              roles
+                .filter((role) => !role.isSystem)
+                .findIndex((role) => role.id === selectedRole.id) <
+                roles.filter((role) => !role.isSystem).length - 1
+            }
             onBack={() => setSelectedRoleId(null)}
+            onSave={async (data) => {
+              const updated = await updateRole.mutateAsync({
+                serverId,
+                roleId: selectedRole.id,
+                data,
+              });
+              addToast({ message: "ロール設定を保存しました。", type: "success" });
+              return updated;
+            }}
+            onDelete={
+              selectedRole.isSystem
+                ? null
+                : async () => {
+                    try {
+                      await deleteRole.mutateAsync({ serverId, roleId: selectedRole.id });
+                      addToast({ message: "ロールを削除しました。", type: "success" });
+                      setSelectedRoleId(null);
+                    } catch (error: unknown) {
+                      throw new Error(
+                        toDeleteActionErrorText(error, "ロールの削除に失敗しました。"),
+                      );
+                    }
+                  }
+            }
+            onMove={async (direction) => {
+              try {
+                await handleMoveRole(selectedRole.id, direction);
+              } catch (error: unknown) {
+                throw new Error(toUpdateActionErrorText(error, "ロール順序の更新に失敗しました。"));
+              }
+            }}
+            onUpdateMemberRoles={async (memberId, roleKeys) => {
+              const uniqueRoleKeys = Array.from(new Set(roleKeys));
+              await replaceMemberRoles.mutateAsync({
+                serverId,
+                memberId,
+                roleKeys: uniqueRoleKeys,
+              });
+            }}
           />
         ) : (
           <div className="flex flex-1 items-center justify-center">
             <div className="text-center">
               <Shield className="mx-auto mb-3 h-12 w-12 text-discord-text-muted" />
               <p className="text-sm text-discord-text-muted">
-                左のリストからロールを選択して編集してください
+                左のリストからロールを選択して編集してください。
               </p>
             </div>
           </div>

--- a/typescript/src/shared/api/api-client.ts
+++ b/typescript/src/shared/api/api-client.ts
@@ -140,6 +140,59 @@ export type Role = {
   hoist: boolean;
   mentionable: boolean;
   memberCount: number;
+  allowView: boolean;
+  allowPost: boolean;
+  allowManage: boolean;
+  isSystem: boolean;
+};
+
+export type PermissionOverrideValue = "allow" | "deny" | "inherit";
+
+export type ChannelRolePermissionOverride = {
+  roleKey: string;
+  subjectName: string;
+  isSystem: boolean;
+  canView: PermissionOverrideValue;
+  canPost: PermissionOverrideValue;
+};
+
+export type ChannelUserPermissionOverride = {
+  userId: string;
+  subjectName: string;
+  canView: PermissionOverrideValue;
+  canPost: PermissionOverrideValue;
+};
+
+export type ChannelPermissions = {
+  roleOverrides: ChannelRolePermissionOverride[];
+  userOverrides: ChannelUserPermissionOverride[];
+};
+
+export type CreateRoleInput = {
+  name: string;
+  allowView: boolean;
+  allowPost: boolean;
+  allowManage: boolean;
+};
+
+export type UpdateRoleInput = {
+  name?: string;
+  allowView?: boolean;
+  allowPost?: boolean;
+  allowManage?: boolean;
+};
+
+export type ReplaceChannelPermissionsInput = {
+  roleOverrides: Array<{
+    roleKey: string;
+    canView: PermissionOverrideValue;
+    canPost: PermissionOverrideValue;
+  }>;
+  userOverrides: Array<{
+    userId: string;
+    canView: PermissionOverrideValue;
+    canPost: PermissionOverrideValue;
+  }>;
 };
 
 export type Webhook = {
@@ -301,13 +354,17 @@ export type APIClient = {
 
   // Roles
   getRoles(serverId: string): Promise<Role[]>;
-  createRole(
-    serverId: string,
-    data: { name: string; color?: string; permissions?: number },
-  ): Promise<Role>;
-  updateRole(serverId: string, roleId: string, data: Partial<Role>): Promise<Role>;
+  createRole(serverId: string, data: CreateRoleInput): Promise<Role>;
+  updateRole(serverId: string, roleId: string, data: UpdateRoleInput): Promise<Role>;
   deleteRole(serverId: string, roleId: string): Promise<void>;
-  reorderRoles(serverId: string, roles: { id: string; position: number }[]): Promise<void>;
+  reorderRoles(serverId: string, roleKeys: string[]): Promise<Role[]>;
+  replaceMemberRoles(serverId: string, memberId: string, roleKeys: string[]): Promise<GuildMember>;
+  getChannelPermissions(serverId: string, channelId: string): Promise<ChannelPermissions>;
+  replaceChannelPermissions(
+    serverId: string,
+    channelId: string,
+    data: ReplaceChannelPermissionsInput,
+  ): Promise<ChannelPermissions>;
 
   // Webhooks
   getWebhooks(channelId: string): Promise<Webhook[]>;

--- a/typescript/src/shared/api/guild-channel-api-client.test.ts
+++ b/typescript/src/shared/api/guild-channel-api-client.test.ts
@@ -612,7 +612,10 @@ describe("GuildChannelAPIClient", () => {
               role_key: "admin",
               name: "Admin",
               priority: 200,
+              allow_view: true,
+              allow_post: true,
               allow_manage: true,
+              is_system: true,
               member_count: 3,
             },
           ],
@@ -634,11 +637,194 @@ describe("GuildChannelAPIClient", () => {
         mentionable: false,
         hoist: true,
         memberCount: 3,
+        allowView: true,
+        allowPost: true,
+        allowManage: true,
+        isSystem: true,
       },
     ]);
 
     const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("http://localhost:8080/v1/guilds/2001/roles");
+  });
+
+  test("createRole sends guild role contract and maps response", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          role: {
+            role_key: "reviewer",
+            name: "Reviewer",
+            priority: 120,
+            allow_view: true,
+            allow_post: true,
+            allow_manage: false,
+            is_system: false,
+            member_count: 1,
+          },
+        }),
+        { status: 201 },
+      ),
+    );
+
+    const client = new GuildChannelAPIClient();
+    const role = await client.createRole("2001", {
+      name: "Reviewer",
+      allowView: true,
+      allowPost: true,
+      allowManage: false,
+    });
+
+    expect(role).toMatchObject({
+      id: "reviewer",
+      name: "Reviewer",
+      allowView: true,
+      allowPost: true,
+      allowManage: false,
+      isSystem: false,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:8080/v1/guilds/2001/roles");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(
+      JSON.stringify({
+        name: "Reviewer",
+        allow_view: true,
+        allow_post: true,
+        allow_manage: false,
+      }),
+    );
+  });
+
+  test("replaceMemberRoles sends put request and maps member response", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          member: {
+            user_id: 1001,
+            display_name: "Alice",
+            avatar_key: null,
+            status_text: null,
+            nickname: "alice-owner",
+            joined_at: "2026-03-03T00:00:00Z",
+            role_keys: ["member", "reviewer"],
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const client = new GuildChannelAPIClient();
+    const member = await client.replaceMemberRoles("2001", "1001", ["member", "reviewer"]);
+
+    expect(member.roles).toEqual(["member", "reviewer"]);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:8080/v1/guilds/2001/members/1001/roles");
+    expect(init.method).toBe("PUT");
+    expect(init.body).toBe(JSON.stringify({ role_keys: ["member", "reviewer"] }));
+  });
+
+  test("getChannelPermissions maps role and user overrides", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          permissions: {
+            role_overrides: [
+              {
+                role_key: "member",
+                subject_name: "@everyone",
+                is_system: true,
+                can_view: "allow",
+                can_post: "deny",
+              },
+            ],
+            user_overrides: [
+              {
+                user_id: 1002,
+                subject_name: "Bob",
+                can_view: "inherit",
+                can_post: "allow",
+              },
+            ],
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const client = new GuildChannelAPIClient();
+    const permissions = await client.getChannelPermissions("2001", "3001");
+
+    expect(permissions).toEqual({
+      roleOverrides: [
+        {
+          roleKey: "member",
+          subjectName: "@everyone",
+          isSystem: true,
+          canView: "allow",
+          canPost: "deny",
+        },
+      ],
+      userOverrides: [
+        {
+          userId: "1002",
+          subjectName: "Bob",
+          canView: "inherit",
+          canPost: "allow",
+        },
+      ],
+    });
+  });
+
+  test("replaceChannelPermissions sends tri-state payload", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          permissions: {
+            role_overrides: [
+              {
+                role_key: "member",
+                subject_name: "@everyone",
+                is_system: true,
+                can_view: "allow",
+                can_post: "deny",
+              },
+            ],
+            user_overrides: [],
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const client = new GuildChannelAPIClient();
+    await client.replaceChannelPermissions("2001", "3001", {
+      roleOverrides: [
+        {
+          roleKey: "member",
+          canView: "allow",
+          canPost: "deny",
+        },
+      ],
+      userOverrides: [],
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:8080/v1/guilds/2001/channels/3001/permissions");
+    expect(init.method).toBe("PUT");
+    expect(init.body).toBe(
+      JSON.stringify({
+        role_overrides: [
+          {
+            role_key: "member",
+            can_view: "allow",
+            can_post: "deny",
+          },
+        ],
+        user_overrides: [],
+      }),
+    );
   });
 
   test("getUserProfile maps shared user profile response", async () => {

--- a/typescript/src/shared/api/guild-channel-api-client.ts
+++ b/typescript/src/shared/api/guild-channel-api-client.ts
@@ -11,7 +11,11 @@ import type {
 } from "@/shared/model/types";
 import { useAuthStore } from "@/shared/model/stores/auth-store";
 import type {
+  ChannelPermissions,
+  ChannelRolePermissionOverride,
+  ChannelUserPermissionOverride,
   CreateMyProfileMediaUploadUrlInput,
+  CreateRoleInput,
   ChannelPermissionSnapshot,
   CreateChannelData,
   CreateGuildData,
@@ -29,9 +33,12 @@ import type {
   ModerationMute,
   ModerationReport,
   PermissionSnapshot,
+  PermissionOverrideValue,
   ProfileMediaTarget,
+  ReplaceChannelPermissionsInput,
   Role,
   SendMessageParams,
+  UpdateRoleInput,
   UpdateGuildData,
   UpdateMyProfileInput,
 } from "./api-client";
@@ -156,11 +163,40 @@ const GUILD_ROLE_SCHEMA = z.object({
   role_key: z.string().trim().min(1),
   name: z.string().trim().min(1),
   priority: z.number().int(),
+  allow_view: z.boolean(),
+  allow_post: z.boolean(),
   allow_manage: z.boolean(),
+  is_system: z.boolean(),
   member_count: z.number().int().nonnegative(),
 });
 const GUILD_ROLES_RESPONSE_SCHEMA = z.object({
   roles: z.array(GUILD_ROLE_SCHEMA),
+});
+const GUILD_ROLE_RESPONSE_SCHEMA = z.object({
+  role: GUILD_ROLE_SCHEMA,
+});
+const GUILD_MEMBER_RESPONSE_SCHEMA = z.object({
+  member: GUILD_MEMBER_SCHEMA,
+});
+const PERMISSION_OVERRIDE_VALUE_SCHEMA = z.enum(["allow", "deny", "inherit"]);
+const CHANNEL_ROLE_PERMISSION_OVERRIDE_SCHEMA = z.object({
+  role_key: z.string().trim().min(1),
+  subject_name: z.string().trim().min(1),
+  is_system: z.boolean(),
+  can_view: PERMISSION_OVERRIDE_VALUE_SCHEMA,
+  can_post: PERMISSION_OVERRIDE_VALUE_SCHEMA,
+});
+const CHANNEL_USER_PERMISSION_OVERRIDE_SCHEMA = z.object({
+  user_id: z.number().int().positive(),
+  subject_name: z.string().trim().min(1),
+  can_view: PERMISSION_OVERRIDE_VALUE_SCHEMA,
+  can_post: PERMISSION_OVERRIDE_VALUE_SCHEMA,
+});
+const CHANNEL_PERMISSIONS_RESPONSE_SCHEMA = z.object({
+  permissions: z.object({
+    role_overrides: z.array(CHANNEL_ROLE_PERMISSION_OVERRIDE_SCHEMA),
+    user_overrides: z.array(CHANNEL_USER_PERMISSION_OVERRIDE_SCHEMA),
+  }),
 });
 const USER_PROFILE_RESPONSE_SCHEMA = z.object({
   profile: z.object({
@@ -335,7 +371,10 @@ type ChannelSummaryResponse = z.infer<typeof CHANNEL_SUMMARY_SCHEMA>;
 type DmChannelListResponse = z.infer<typeof DM_CHANNEL_LIST_RESPONSE_SCHEMA>;
 type MyProfileResponse = z.infer<typeof MY_PROFILE_RESPONSE_SCHEMA>;
 type GuildMembersResponse = z.infer<typeof GUILD_MEMBERS_RESPONSE_SCHEMA>;
+type GuildMemberResponse = z.infer<typeof GUILD_MEMBER_RESPONSE_SCHEMA>;
 type GuildRolesResponse = z.infer<typeof GUILD_ROLES_RESPONSE_SCHEMA>;
+type GuildRoleResponse = z.infer<typeof GUILD_ROLE_RESPONSE_SCHEMA>;
+type ChannelPermissionsResponse = z.infer<typeof CHANNEL_PERMISSIONS_RESPONSE_SCHEMA>;
 type UserProfileResponse = z.infer<typeof USER_PROFILE_RESPONSE_SCHEMA>;
 type ProfileMediaUploadResponse = z.infer<typeof PROFILE_MEDIA_UPLOAD_RESPONSE_SCHEMA>;
 type ProfileMediaDownloadResponse = z.infer<typeof PROFILE_MEDIA_DOWNLOAD_RESPONSE_SCHEMA>;
@@ -787,6 +826,40 @@ function mapRole(entry: GuildRolesResponse["roles"][number]): Role {
     mentionable: false,
     hoist: entry.priority > 100,
     memberCount: entry.member_count,
+    allowView: entry.allow_view,
+    allowPost: entry.allow_post,
+    allowManage: entry.allow_manage,
+    isSystem: entry.is_system,
+  };
+}
+
+function mapChannelRolePermissionOverride(
+  entry: ChannelPermissionsResponse["permissions"]["role_overrides"][number],
+): ChannelRolePermissionOverride {
+  return {
+    roleKey: entry.role_key,
+    subjectName: entry.subject_name,
+    isSystem: entry.is_system,
+    canView: entry.can_view,
+    canPost: entry.can_post,
+  };
+}
+
+function mapChannelUserPermissionOverride(
+  entry: ChannelPermissionsResponse["permissions"]["user_overrides"][number],
+): ChannelUserPermissionOverride {
+  return {
+    userId: String(entry.user_id),
+    subjectName: entry.subject_name,
+    canView: entry.can_view,
+    canPost: entry.can_post,
+  };
+}
+
+function mapChannelPermissions(response: ChannelPermissionsResponse): ChannelPermissions {
+  return {
+    roleOverrides: response.permissions.role_overrides.map(mapChannelRolePermissionOverride),
+    userOverrides: response.permissions.user_overrides.map(mapChannelUserPermissionOverride),
   };
 }
 
@@ -989,7 +1062,7 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
 
   private async requestJson<T>(params: {
     path: string;
-    method: "GET" | "POST" | "PATCH" | "DELETE";
+    method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
     schema: z.ZodType<T>;
     expectedStatus: number;
     body?: Record<string, unknown>;
@@ -1107,6 +1180,22 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
     return this.requestJson({
       path,
       method: "PATCH",
+      body,
+      schema,
+      expectedStatus: 200,
+      parseResponseText: options?.parseResponseText,
+    });
+  }
+
+  private async putJson<T>(
+    path: string,
+    body: Record<string, unknown>,
+    schema: z.ZodType<T>,
+    options?: { parseResponseText?: (rawText: string) => unknown },
+  ): Promise<T> {
+    return this.requestJson({
+      path,
+      method: "PUT",
       body,
       schema,
       expectedStatus: 200,
@@ -1724,6 +1813,199 @@ export class GuildChannelAPIClient extends NoDataAPIClient {
     );
 
     return response.roles.map(mapRole);
+  }
+
+  async createRole(serverId: string, data: CreateRoleInput): Promise<Role> {
+    const normalizedServerId = serverId.trim();
+    const normalizedName = data.name.trim();
+    if (normalizedServerId.length === 0 || normalizedName.length === 0) {
+      throw new GuildChannelApiError(CREATE_ERROR_MESSAGES.validation, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    const response = await this.postJson(
+      `/v1/guilds/${encodeURIComponent(normalizedServerId)}/roles`,
+      {
+        name: normalizedName,
+        allow_view: data.allowView,
+        allow_post: data.allowPost,
+        allow_manage: data.allowManage,
+      },
+      GUILD_ROLE_RESPONSE_SCHEMA,
+    );
+
+    return mapRole(response.role);
+  }
+
+  async updateRole(serverId: string, roleId: string, data: UpdateRoleInput): Promise<Role> {
+    const normalizedServerId = serverId.trim();
+    const normalizedRoleId = roleId.trim();
+    const normalizedName = data.name?.trim();
+    if (
+      normalizedServerId.length === 0 ||
+      normalizedRoleId.length === 0 ||
+      (data.name !== undefined && normalizedName !== undefined && normalizedName.length === 0)
+    ) {
+      throw new GuildChannelApiError(UPDATE_ERROR_MESSAGES.validation, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    const body: Record<string, unknown> = {};
+    if (normalizedName !== undefined) {
+      body.name = normalizedName;
+    }
+    if (data.allowView !== undefined) {
+      body.allow_view = data.allowView;
+    }
+    if (data.allowPost !== undefined) {
+      body.allow_post = data.allowPost;
+    }
+    if (data.allowManage !== undefined) {
+      body.allow_manage = data.allowManage;
+    }
+    if (Object.keys(body).length === 0) {
+      throw new GuildChannelApiError(UPDATE_ERROR_MESSAGES.validation, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    const response = await this.patchJson(
+      `/v1/guilds/${encodeURIComponent(normalizedServerId)}/roles/${encodeURIComponent(
+        normalizedRoleId,
+      )}`,
+      body,
+      GUILD_ROLE_RESPONSE_SCHEMA,
+    );
+
+    return mapRole(response.role);
+  }
+
+  async deleteRole(serverId: string, roleId: string): Promise<void> {
+    const normalizedServerId = serverId.trim();
+    const normalizedRoleId = roleId.trim();
+    if (normalizedServerId.length === 0 || normalizedRoleId.length === 0) {
+      throw new GuildChannelApiError(DELETE_ERROR_MESSAGES.validation, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    await this.deleteNoContent(
+      `/v1/guilds/${encodeURIComponent(normalizedServerId)}/roles/${encodeURIComponent(
+        normalizedRoleId,
+      )}`,
+    );
+  }
+
+  async reorderRoles(serverId: string, roleKeys: string[]): Promise<Role[]> {
+    const normalizedServerId = serverId.trim();
+    const normalizedRoleKeys = roleKeys
+      .map((roleKey) => roleKey.trim())
+      .filter((roleKey) => roleKey.length > 0);
+    if (normalizedServerId.length === 0 || normalizedRoleKeys.length === 0) {
+      throw new GuildChannelApiError(UPDATE_ERROR_MESSAGES.validation, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    const response = await this.putJson(
+      `/v1/guilds/${encodeURIComponent(normalizedServerId)}/roles/reorder`,
+      {
+        role_keys: normalizedRoleKeys,
+      },
+      GUILD_ROLES_RESPONSE_SCHEMA,
+    );
+
+    return response.roles.map(mapRole);
+  }
+
+  async replaceMemberRoles(
+    serverId: string,
+    memberId: string,
+    roleKeys: string[],
+  ): Promise<GuildMember> {
+    const normalizedServerId = serverId.trim();
+    const normalizedMemberId = memberId.trim();
+    const normalizedRoleKeys = roleKeys
+      .map((roleKey) => roleKey.trim())
+      .filter((roleKey) => roleKey.length > 0);
+    if (normalizedServerId.length === 0 || normalizedMemberId.length === 0) {
+      throw new GuildChannelApiError(UPDATE_ERROR_MESSAGES.validation, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    const response = await this.putJson(
+      `/v1/guilds/${encodeURIComponent(normalizedServerId)}/members/${encodeURIComponent(
+        normalizedMemberId,
+      )}/roles`,
+      {
+        role_keys: normalizedRoleKeys,
+      },
+      GUILD_MEMBER_RESPONSE_SCHEMA,
+    );
+
+    return mapGuildMember(response.member);
+  }
+
+  async getChannelPermissions(serverId: string, channelId: string): Promise<ChannelPermissions> {
+    const normalizedServerId = serverId.trim();
+    const normalizedChannelId = channelId.trim();
+    if (normalizedServerId.length === 0 || normalizedChannelId.length === 0) {
+      return { roleOverrides: [], userOverrides: [] };
+    }
+
+    const response = await this.getJson(
+      `/v1/guilds/${encodeURIComponent(normalizedServerId)}/channels/${encodeURIComponent(
+        normalizedChannelId,
+      )}/permissions`,
+      CHANNEL_PERMISSIONS_RESPONSE_SCHEMA,
+    );
+
+    return mapChannelPermissions(response);
+  }
+
+  async replaceChannelPermissions(
+    serverId: string,
+    channelId: string,
+    data: ReplaceChannelPermissionsInput,
+  ): Promise<ChannelPermissions> {
+    const normalizedServerId = serverId.trim();
+    const normalizedChannelId = channelId.trim();
+    if (normalizedServerId.length === 0 || normalizedChannelId.length === 0) {
+      throw new GuildChannelApiError(UPDATE_ERROR_MESSAGES.validation, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+    }
+
+    const response = await this.putJson(
+      `/v1/guilds/${encodeURIComponent(normalizedServerId)}/channels/${encodeURIComponent(
+        normalizedChannelId,
+      )}/permissions`,
+      {
+        role_overrides: data.roleOverrides.map((override) => ({
+          role_key: override.roleKey,
+          can_view: override.canView,
+          can_post: override.canPost,
+        })),
+        user_overrides: data.userOverrides.map((override) => ({
+          user_id: Number(override.userId),
+          can_view: override.canView,
+          can_post: override.canPost,
+        })),
+      },
+      CHANNEL_PERMISSIONS_RESPONSE_SCHEMA,
+    );
+
+    return mapChannelPermissions(response);
   }
 
   /**

--- a/typescript/src/shared/api/mock/mock-api-client.ts
+++ b/typescript/src/shared/api/mock/mock-api-client.ts
@@ -1,5 +1,7 @@
 import type {
   APIClient,
+  ChannelPermissions,
+  CreateRoleInput,
   CreateMyProfileMediaUploadUrlInput,
   CreateModerationMuteData,
   CreateModerationReportData,
@@ -19,6 +21,7 @@ import type {
   ModerationReportStatus,
   MyProfile,
   PermissionSnapshot,
+  ReplaceChannelPermissionsInput,
   Role,
   UpdateMyProfileInput,
   Webhook,
@@ -588,39 +591,129 @@ export class MockAPIClient implements APIClient {
       hoist: r.hoist,
       mentionable: r.mentionable,
       memberCount: r.memberCount,
+      allowView: true,
+      allowPost: true,
+      allowManage: r.permissions > 0,
+      isSystem: r.id === "owner" || r.id === "admin" || r.id === "member",
     }));
   }
 
-  async createRole(
-    _serverId: string,
-    data: { name: string; color?: string; permissions?: number },
-  ): Promise<Role> {
+  async createRole(_serverId: string, data: CreateRoleInput): Promise<Role> {
     await this.simulateDelay();
     return {
       id: this.generateId(),
       name: data.name,
-      color: data.color ?? "#95a5a6",
+      color: "#95a5a6",
       position: mockRolesData.length,
-      permissions: data.permissions ?? 0,
+      permissions: data.allowManage ? 1 : 0,
       hoist: false,
       mentionable: false,
       memberCount: 0,
+      allowView: data.allowView,
+      allowPost: data.allowPost,
+      allowManage: data.allowManage,
+      isSystem: false,
     };
   }
 
-  async updateRole(_serverId: string, roleId: string, data: Partial<Role>): Promise<Role> {
+  async updateRole(
+    _serverId: string,
+    roleId: string,
+    data: {
+      name?: string;
+      allowView?: boolean;
+      allowPost?: boolean;
+      allowManage?: boolean;
+    },
+  ): Promise<Role> {
     await this.simulateDelay();
     const role = mockRolesData.find((r) => r.id === roleId);
     if (!role) throw new Error("Role not found");
-    return { ...role, ...data } as Role;
+    return {
+      id: role.id,
+      name: data.name ?? role.name,
+      color: role.color,
+      position: role.position,
+      permissions: (data.allowManage ?? false) ? 1 : role.permissions,
+      hoist: role.hoist,
+      mentionable: role.mentionable,
+      memberCount: role.memberCount,
+      allowView: data.allowView ?? true,
+      allowPost: data.allowPost ?? true,
+      allowManage: data.allowManage ?? role.permissions > 0,
+      isSystem: role.id === "owner" || role.id === "admin" || role.id === "member",
+    };
   }
 
   async deleteRole(_serverId: string, _roleId: string): Promise<void> {
     await this.simulateDelay();
   }
 
-  async reorderRoles(_serverId: string, _roles: { id: string; position: number }[]): Promise<void> {
+  async reorderRoles(_serverId: string, roleKeys: string[]): Promise<Role[]> {
     await this.simulateDelay();
+    const order = new Map(roleKeys.map((roleKey, index) => [roleKey, roleKeys.length - index]));
+    return mockRolesData
+      .map((role) => ({
+        id: role.id,
+        name: role.name,
+        color: role.color,
+        position: order.get(role.id) ?? role.position,
+        permissions: role.permissions,
+        hoist: role.hoist,
+        mentionable: role.mentionable,
+        memberCount: role.memberCount,
+        allowView: true,
+        allowPost: true,
+        allowManage: role.permissions > 0,
+        isSystem: role.id === "owner" || role.id === "admin" || role.id === "member",
+      }))
+      .sort((left, right) => right.position - left.position);
+  }
+
+  async replaceMemberRoles(
+    serverId: string,
+    memberId: string,
+    roleKeys: string[],
+  ): Promise<GuildMember> {
+    await this.simulateDelay();
+    const member = (mockMembers[serverId] ?? []).find(
+      (candidate) => candidate.user.id === memberId,
+    );
+    if (!member) {
+      throw new Error("Member not found");
+    }
+    return {
+      ...member,
+      roles: roleKeys,
+    };
+  }
+
+  async getChannelPermissions(_serverId: string, _channelId: string): Promise<ChannelPermissions> {
+    await this.simulateDelay();
+    return { roleOverrides: [], userOverrides: [] };
+  }
+
+  async replaceChannelPermissions(
+    _serverId: string,
+    _channelId: string,
+    data: ReplaceChannelPermissionsInput,
+  ): Promise<ChannelPermissions> {
+    await this.simulateDelay();
+    return {
+      roleOverrides: data.roleOverrides.map((override) => ({
+        roleKey: override.roleKey,
+        subjectName: override.roleKey,
+        isSystem: override.roleKey === "member",
+        canView: override.canView,
+        canPost: override.canPost,
+      })),
+      userOverrides: data.userOverrides.map((override) => ({
+        userId: override.userId,
+        subjectName: override.userId,
+        canView: override.canView,
+        canPost: override.canPost,
+      })),
+    };
   }
 
   // Webhooks

--- a/typescript/src/shared/api/mutations/index.ts
+++ b/typescript/src/shared/api/mutations/index.ts
@@ -36,3 +36,7 @@ export { useCreateRole, useUpdateRole, useDeleteRole, useReorderRoles } from "./
 export { useCreateInvite, useRevokeInvite } from "./use-invite-actions";
 export { useUpdateChannel } from "./use-channel-update";
 export { useUpdateMyProfile } from "./use-my-profile";
+export {
+  useReplaceMemberRoles,
+  useReplaceChannelPermissions,
+} from "./use-guild-permission-actions";

--- a/typescript/src/shared/api/mutations/use-guild-permission-actions.ts
+++ b/typescript/src/shared/api/mutations/use-guild-permission-actions.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getAPIClient } from "@/shared/api/api-client";
+import type { ReplaceChannelPermissionsInput } from "@/shared/api/api-client";
+
+export function useReplaceMemberRoles() {
+  const queryClient = useQueryClient();
+  const api = getAPIClient();
+
+  return useMutation({
+    mutationFn: ({
+      serverId,
+      memberId,
+      roleKeys,
+    }: {
+      serverId: string;
+      memberId: string;
+      roleKeys: string[];
+    }) => api.replaceMemberRoles(serverId, memberId, roleKeys),
+    onSuccess: (member, { serverId, memberId }) => {
+      queryClient.setQueryData(["member", serverId, memberId], member);
+      queryClient.invalidateQueries({ queryKey: ["members", serverId] });
+      queryClient.invalidateQueries({ queryKey: ["roles", serverId] });
+    },
+  });
+}
+
+export function useReplaceChannelPermissions() {
+  const queryClient = useQueryClient();
+  const api = getAPIClient();
+
+  return useMutation({
+    mutationFn: ({
+      serverId,
+      channelId,
+      data,
+    }: {
+      serverId: string;
+      channelId: string;
+      data: ReplaceChannelPermissionsInput;
+    }) => api.replaceChannelPermissions(serverId, channelId, data),
+    onSuccess: (permissions, { serverId, channelId }) => {
+      queryClient.setQueryData(["channel-permissions", serverId, channelId], permissions);
+      queryClient.invalidateQueries({ queryKey: ["permission-snapshot", serverId] });
+      queryClient.invalidateQueries({ queryKey: ["permission-snapshot", serverId, channelId] });
+    },
+  });
+}

--- a/typescript/src/shared/api/mutations/use-role-actions.test.ts
+++ b/typescript/src/shared/api/mutations/use-role-actions.test.ts
@@ -13,6 +13,10 @@ const mockCreateRole = vi.fn().mockResolvedValue({
   hoist: false,
   mentionable: false,
   memberCount: 0,
+  allowView: true,
+  allowPost: true,
+  allowManage: false,
+  isSystem: false,
 });
 
 const mockUpdateRole = vi.fn().mockResolvedValue({
@@ -24,6 +28,10 @@ const mockUpdateRole = vi.fn().mockResolvedValue({
   hoist: true,
   mentionable: false,
   memberCount: 2,
+  allowView: true,
+  allowPost: true,
+  allowManage: true,
+  isSystem: false,
 });
 
 vi.mock("@/shared/api/api-client", () => ({
@@ -54,7 +62,7 @@ describe("useRoleActions", () => {
 
     result.current.mutate({
       serverId: "server-1",
-      data: { name: "New Role", color: "#ff0000" },
+      data: { name: "New Role", allowView: true, allowPost: true, allowManage: false },
     });
 
     await waitFor(() => {
@@ -63,12 +71,14 @@ describe("useRoleActions", () => {
 
     expect(mockCreateRole).toHaveBeenCalledWith("server-1", {
       name: "New Role",
-      color: "#ff0000",
+      allowView: true,
+      allowPost: true,
+      allowManage: false,
     });
 
     expect(result.current.data).toMatchObject({
       name: "New Role",
-      color: "#ff0000",
+      allowManage: false,
     });
   });
 

--- a/typescript/src/shared/api/mutations/use-role-actions.ts
+++ b/typescript/src/shared/api/mutations/use-role-actions.ts
@@ -2,20 +2,15 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { getAPIClient } from "@/shared/api/api-client";
-import type { Role } from "@/shared/api/api-client";
+import type { CreateRoleInput, Role, UpdateRoleInput } from "@/shared/api/api-client";
 
 export function useCreateRole() {
   const queryClient = useQueryClient();
   const api = getAPIClient();
 
   return useMutation({
-    mutationFn: ({
-      serverId,
-      data,
-    }: {
-      serverId: string;
-      data: { name: string; color?: string; permissions?: number };
-    }) => api.createRole(serverId, data),
+    mutationFn: ({ serverId, data }: { serverId: string; data: CreateRoleInput }) =>
+      api.createRole(serverId, data),
     onSuccess: (_, { serverId }) => {
       queryClient.invalidateQueries({ queryKey: ["roles", serverId] });
     },
@@ -34,7 +29,7 @@ export function useUpdateRole() {
     }: {
       serverId: string;
       roleId: string;
-      data: Partial<Role>;
+      data: UpdateRoleInput;
     }) => api.updateRole(serverId, roleId, data),
     onSuccess: (_, { serverId }) => {
       queryClient.invalidateQueries({ queryKey: ["roles", serverId] });
@@ -60,13 +55,8 @@ export function useReorderRoles() {
   const api = getAPIClient();
 
   return useMutation({
-    mutationFn: ({
-      serverId,
-      roles,
-    }: {
-      serverId: string;
-      roles: { id: string; position: number }[];
-    }) => api.reorderRoles(serverId, roles),
+    mutationFn: ({ serverId, roleKeys }: { serverId: string; roleKeys: string[] }) =>
+      api.reorderRoles(serverId, roleKeys),
     onSuccess: (_, { serverId }) => {
       queryClient.invalidateQueries({ queryKey: ["roles", serverId] });
     },

--- a/typescript/src/shared/api/no-data-api-client.ts
+++ b/typescript/src/shared/api/no-data-api-client.ts
@@ -10,10 +10,13 @@ import type {
   CreateMyProfileMediaUploadUrlInput,
   CreateModerationMuteData,
   CreateModerationReportData,
+  CreateRoleInput,
   CreateChannelData,
   CreateGuildData,
+  ChannelPermissions,
   MyProfileMediaDownload,
   MyProfileMediaUpload,
+  ReplaceChannelPermissionsInput,
   UpdateGuildData,
   CreateInviteData,
   Invite,
@@ -310,14 +313,20 @@ export class NoDataAPIClient implements APIClient {
     return Promise.resolve([]);
   }
 
-  createRole(
-    _serverId: string,
-    _data: { name: string; color?: string; permissions?: number },
-  ): Promise<Role> {
+  createRole(_serverId: string, _data: CreateRoleInput): Promise<Role> {
     return unsupportedPromise("createRole");
   }
 
-  updateRole(_serverId: string, _roleId: string, _data: Partial<Role>): Promise<Role> {
+  updateRole(
+    _serverId: string,
+    _roleId: string,
+    _data: {
+      name?: string;
+      allowView?: boolean;
+      allowPost?: boolean;
+      allowManage?: boolean;
+    },
+  ): Promise<Role> {
     return unsupportedPromise("updateRole");
   }
 
@@ -325,8 +334,28 @@ export class NoDataAPIClient implements APIClient {
     return unsupportedPromise("deleteRole");
   }
 
-  reorderRoles(_serverId: string, _roles: { id: string; position: number }[]): Promise<void> {
+  reorderRoles(_serverId: string, _roleKeys: string[]): Promise<Role[]> {
     return unsupportedPromise("reorderRoles");
+  }
+
+  replaceMemberRoles(
+    _serverId: string,
+    _memberId: string,
+    _roleKeys: string[],
+  ): Promise<GuildMember> {
+    return unsupportedPromise("replaceMemberRoles");
+  }
+
+  getChannelPermissions(_serverId: string, _channelId: string): Promise<ChannelPermissions> {
+    return Promise.resolve({ roleOverrides: [], userOverrides: [] });
+  }
+
+  replaceChannelPermissions(
+    _serverId: string,
+    _channelId: string,
+    _data: ReplaceChannelPermissionsInput,
+  ): Promise<ChannelPermissions> {
+    return unsupportedPromise("replaceChannelPermissions");
   }
 
   getWebhooks(_channelId: string): Promise<Webhook[]> {

--- a/typescript/src/shared/api/queries/index.ts
+++ b/typescript/src/shared/api/queries/index.ts
@@ -10,6 +10,7 @@ export { useRoles } from "./use-roles";
 export { useInvites } from "./use-invites";
 export { useWebhooks } from "./use-webhooks";
 export { useAuditLog } from "./use-audit-log";
+export { useChannelPermissions } from "./use-channel-permissions";
 export { useModerationReports, useModerationReport } from "./use-moderation-reports";
 export {
   getActionGuardMessage,

--- a/typescript/src/shared/api/queries/use-channel-permissions.ts
+++ b/typescript/src/shared/api/queries/use-channel-permissions.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getAPIClient } from "@/shared/api/api-client";
+
+/**
+ * channel permission override 一覧を取得する。
+ */
+export function useChannelPermissions(serverId: string, channelId: string, enabled = true) {
+  const api = getAPIClient();
+
+  return useQuery({
+    queryKey: ["channel-permissions", serverId, channelId],
+    queryFn: () => api.getChannelPermissions(serverId, channelId),
+    enabled: enabled && serverId.trim().length > 0 && channelId.trim().length > 0,
+  });
+}


### PR DESCRIPTION
## 概要
- settings の roles/members 導線を実 API に接続し、mock state を置き換えました。
- channel permissions modal を role/user override API と `channel:manage` guard に接続しました。
- frontend client/query/mutation と回帰テストを追加し、tri-state allow/deny/inherit を backend DTO に揃えました。

## 変更点
- `ServerRoles` / `RoleEditPanel` を role CRUD・reorder・member assignment に接続
- `ServerMembers` を member role assignment editor に更新
- `ChannelEditPermissions` を role/user override API と fail-close guard へ接続
- `GuildChannelAPIClient` に role/member/channel permission 契約を追加し、関連 query/mutation/test を整備
- LIN-953 の run memory を追加

## 検証
- `cd typescript && npm run typecheck`
- `cd typescript && npx vitest run src/shared/api/guild-channel-api-client.test.ts src/shared/api/mutations/use-role-actions.test.ts src/features/settings/ui/server/server-members.test.tsx src/features/modals/ui/channel-edit-permissions.test.tsx`
- `make validate`

## ADR-001 チェック
- Event contract 変更: なし
- 互換性判断: frontend から既存 backend contract を利用する接続変更のみで、event schema / tuple sync contract への破壊的変更はありません。
