### PR TITLE
LIN-954 回帰試験とローカル検証手順を整理する

### DIFF
--- a/docs/agent_runs/LIN-954/Documentation.md
+++ b/docs/agent_runs/LIN-954/Documentation.md
@@ -1,0 +1,25 @@
+# Documentation
+
+## Current status
+- Now: LIN-954 の実装と検証は完了
+- Next: commit / PR / Linear 更新
+
+## Decisions
+- `AUTHZ_UNAVAILABLE` は frontend settings 導線でも guard screen として観測できるよう、`ChannelEditPermissions` の回帰で固定した。
+- local 検証手順は新しい runbook を増やさず、既存の runtime runbook と tuple sync operations runbook へ追記する構成を採用した。
+- 切り分けは `write -> invalidation -> tuple sync -> read path` の順で追う。
+
+## How to run / demo
+- `cd typescript && npx vitest run src/features/modals/ui/channel-edit-permissions.test.tsx`
+- `make authz-spicedb-up`
+- `make authz-spicedb-health`
+- API を `AUTHZ_PROVIDER=spicedb` で起動する。
+- `ServerRoles` / `ServerMembers` / `ChannelEditPermissions` で role または override を更新し、permission snapshot と実操作の allow/deny 反転を確認する。
+
+## Known issues / follow-ups
+- local smoke は手動手順なので、将来的に full integration 化する余地は残る。
+- 今回は runbook と targeted regression に限定し、新しい E2E 基盤追加は行っていない。
+
+## Validation
+- `cd typescript && npx vitest run src/features/modals/ui/channel-edit-permissions.test.tsx`
+- `make validate`

--- a/docs/agent_runs/LIN-954/Implement.md
+++ b/docs/agent_runs/LIN-954/Implement.md
@@ -1,0 +1,6 @@
+# Implement
+
+- Follow `Plan.md` as the execution order.
+- 追加テストは brittle edge に限定し、既存の主経路テストを重複させない。
+- runbook 追記は local 再現性と fail-close 切り分けを優先する。
+- `AUTHZ_UNAVAILABLE` / guard / invalidation 観察ポイントは absolute command sequence で書く。

--- a/docs/agent_runs/LIN-954/Plan.md
+++ b/docs/agent_runs/LIN-954/Plan.md
@@ -1,0 +1,28 @@
+# Plan
+
+## Rules
+- Stop-and-fix: validation failure を残したまま次工程へ進まない。
+- Scope lock: LIN-954 は回帰試験とローカル検証手順に限定する。
+
+## Milestones
+### M1: 既存回帰の不足を埋める
+- Acceptance criteria:
+  - [x] unavailable / guard / role protection まわりの追加回帰が入っている
+  - [x] 既存 LIN-952/LIN-953 の導線と重複せずに brittle edge を補完できている
+- Result:
+  - `useActionGuard` が `unavailable` を返すときの guard screen 表示を固定した。
+
+### M2: ローカル検証手順を runbook に落とす
+- Acceptance criteria:
+  - [x] role 更新 -> tuple sync / invalidation -> permission snapshot / 実操作反映の手順が残っている
+  - [x] failure triage と観察ポイントが追記されている
+- Result:
+  - local runtime runbook に propagation smoke を追加し、tuple sync runbook に失敗時の切り分け順を追記した。
+
+### M3: 検証結果を固定する
+- Acceptance criteria:
+  - [x] relevant tests と `make validate` が通る
+  - [x] Documentation.md に decisions と validation が残っている
+- Result:
+  - `cd typescript && npx vitest run src/features/modals/ui/channel-edit-permissions.test.tsx`
+  - `make validate`

--- a/docs/agent_runs/LIN-954/Prompt.md
+++ b/docs/agent_runs/LIN-954/Prompt.md
@@ -1,0 +1,31 @@
+# Prompt
+
+## Goals
+- LIN-954 として role/member override/authz apply の主要回帰を自動テストとローカル検証手順へ落とし込む。
+- `AUTHZ_PROVIDER=spicedb` 前提の role 更新 -> tuple sync / invalidation -> permission snapshot / 実操作反映の確認手順を明文化する。
+
+## Non-goals
+- 新しい E2E 基盤導入
+- runbook の全面刷新
+- role 機能と無関係な既存テスト整理
+
+## Deliverables
+- brittle edge を固定する追加テスト
+- runbook / Documentation 更新
+- docs/agent_runs/LIN-954/*
+
+## Done when
+- [x] allow / deny / unavailable の主要境界が自動テストで検知できる
+- [x] local SpiceDB を使った最小検証手順が runbook に残っている
+- [x] role 更新から snapshot / 実操作反映までの観察ポイントが追える
+- [x] relevant validation が通る
+
+## Constraints
+- 既存 runbook 構造は維持する
+- backend/frontend の既存 contract を変えない
+- 実装済み child issue の scope を巻き戻さない
+
+## Outcome
+- `channel-edit-permissions.test.tsx` に `AUTHZ_UNAVAILABLE` 時の guard screen 回帰を追加した。
+- local runtime runbook に role/member/override 更新後の propagation smoke を追記した。
+- tuple sync operations runbook に LIN-949 flow 向け triage を追記した。

--- a/docs/runbooks/authz-spicedb-local-ci-runtime-runbook.md
+++ b/docs/runbooks/authz-spicedb-local-ci-runtime-runbook.md
@@ -160,6 +160,48 @@ Recommended end-to-end verification:
    - `make authz-spicedb-up`
    - `make authz-spicedb-health`
 
+### 6.4 Role change propagation smoke
+
+Use this sequence after role/member/channel override changes land in the current branch.
+
+1. Start dependencies and API:
+
+```bash
+make authz-spicedb-up
+make authz-spicedb-health
+AUTHZ_PROVIDER=spicedb \
+SPICEDB_ENDPOINT=http://localhost:50051 \
+SPICEDB_CHECK_ENDPOINT=http://localhost:8443 \
+SPICEDB_PRESHARED_KEY=replace-with-dev-spicedb-key \
+make rust-dev
+```
+
+2. Open server settings and prepare two principals:
+   - principal A: has `Manage`
+   - principal B: currently does not have the target capability
+3. For role baseline verification:
+   - create or update a custom role from `ServerRoles`
+   - assign the role to principal B from `ServerRoles` or `ServerMembers`
+4. For channel override verification:
+   - open `ChannelEditPermissions`
+   - update `can_view` / `can_post` to `allow`, `deny`, or `inherit`
+5. After each write, confirm in this order:
+   - permission snapshot changes for principal B
+   - target REST/UI operation flips to allow or deny as expected
+   - no stale allow remains after `deny`
+
+Expected observations:
+- role/member changes invalidate `guild_role_changed` / `guild_member_role_changed`
+- channel overrides invalidate `channel_role_override_changed` / `channel_user_override_changed`
+- frontend guard and operation state converge without manual cache clearing
+
+If propagation does not happen:
+- inspect API logs for `AUTHZ_UNAVAILABLE` or tuple sync write failures
+- confirm SpiceDB health is still ready
+- rerun the same update once and compare permission snapshot before/after
+- if snapshot changes but operation does not, treat as frontend/query cache bug
+- if neither changes, continue with tuple sync triage in `authz-spicedb-tuple-sync-operations-runbook.md`
+
 ## 7. Exit criteria for LIN-863 + LIN-876
 
 All items must be true:

--- a/docs/runbooks/authz-spicedb-tuple-sync-operations-runbook.md
+++ b/docs/runbooks/authz-spicedb-tuple-sync-operations-runbook.md
@@ -124,3 +124,26 @@ Failure triage checkpoints:
 2. tuple mapping tests pass for role/user override canonical relations.
 3. sync service tests pass for success/failure/full-resync paths.
 4. runtime logs include tuple sync env configuration when `AUTHZ_PROVIDER=spicedb`.
+
+## 8. Role change triage for LIN-949 flow
+
+When validating server role rollout locally, check these checkpoints in order:
+
+1. Write path completed:
+   - role CRUD / member role assignment / channel override API returned success
+2. Invalidation path fired:
+   - corresponding cache invalidation event kind was emitted
+3. Tuple sync path updated SpiceDB:
+   - outbox event moved to sent
+   - no repeated `mark_outbox_event_failed` loop for the same aggregate
+4. Read path converged:
+   - permission snapshot changed
+   - target operation allow/deny matched the snapshot
+
+Common failure signatures:
+- permission snapshot unchanged after write:
+  - check outbox claim/ack and tuple sync mutation failures first
+- snapshot changed but UI button/guard stayed stale:
+  - inspect frontend query invalidation around `permission-snapshot` and settings/channel permission queries
+- write succeeds but SpiceDB is unavailable:
+  - request-time checks should fail-close with `AUTHZ_UNAVAILABLE`; do not treat this as an allow fallback

--- a/typescript/src/features/modals/ui/channel-edit-permissions.test.tsx
+++ b/typescript/src/features/modals/ui/channel-edit-permissions.test.tsx
@@ -137,4 +137,16 @@ describe("ChannelEditPermissions", () => {
 
     expect(screen.getByText("アクセス権限がありません")).not.toBeNull();
   });
+
+  test("renders service unavailable guard screen when authz is unavailable", () => {
+    useActionGuardMock.mockReturnValue({
+      status: "unavailable",
+      isAllowed: false,
+      message: "認可基盤が一時的に利用できません。",
+    });
+
+    render(<ChannelEditPermissions serverId="2001" channelId="3001" />);
+
+    expect(screen.getByText("認証基盤が一時的に利用できません")).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## 概要
- `ChannelEditPermissions` に `AUTHZ_UNAVAILABLE` 時の guard screen 回帰を追加
- local runtime runbook に role/member/override 更新後の propagation smoke を追記
- tuple sync operations runbook に LIN-949 flow 向け triage 手順を追記
- `docs/agent_runs/LIN-954/` に実行記録を追加

## なぜ必要か
- LIN-952 / LIN-953 で接続した role/member/channel permissions 導線について、壊れやすい unavailable 境界とローカル再現手順を固定するため
- role 更新から tuple sync / invalidation / permission snapshot / 実操作反映までを、次の実装者とレビュアが同じ手順で追えるようにするため

## Acceptance Criteria 対応
- role / override / authz の主要回帰が自動テストで検知できる
  - unavailable guard の回帰を追加
- `AUTHZ_PROVIDER=spicedb` で role 変更後の権限反映シナリオがローカルで再現できる
  - runbook に propagation smoke を追加
- allow / deny / unavailable と system role / owner 保護の境界が確認可能になっている
  - unavailable は test で固定、role change triage は runbook に整理
- 検証手順と観察ポイントが issue/Documentation だけで追える
  - `docs/agent_runs/LIN-954/` と runbook へ記録

## 変更ファイル
- `typescript/src/features/modals/ui/channel-edit-permissions.test.tsx`
- `docs/runbooks/authz-spicedb-local-ci-runtime-runbook.md`
- `docs/runbooks/authz-spicedb-tuple-sync-operations-runbook.md`
- `docs/agent_runs/LIN-954/*`

## テスト
- `cd typescript && npx vitest run src/features/modals/ui/channel-edit-permissions.test.tsx`
- `make validate`

## Review / UI / Runtime Smoke
- review gate: reviewer agent はこのセッションの委譲制約で未実施。差分セルフレビューと validation 結果で代替
- UI gate: UI 実装変更はなく、対象は test と runbook のみ
- runtime smoke: 実行コードの挙動変更がないため skip

## ADR-001 チェック
- イベント契約変更: なし
- 互換性判断: additive な test / documentation 変更のみで、既存契約への影響なし

## Linear
- LIN-954
