### PR TITLE
docs: LIN-961 Phase 1 edge baseline を GCP native edge に固定

### DIFF
--- a/docs/adr/ADR-006-phase1-edge-baseline-gcp-native-edge.md
+++ b/docs/adr/ADR-006-phase1-edge-baseline-gcp-native-edge.md
@@ -1,0 +1,153 @@
+# ADR-006 Phase 1 Edge Baseline on GCP Native Edge
+
+- Status: Accepted
+- Date: 2026-03-27
+- Related:
+  - [LIN-960](https://linear.app/linklynx-ai/issue/LIN-960/インフラ基盤-phase-0-2-実行計画)
+  - [LIN-961](https://linear.app/linklynx-ai/issue/LIN-961/01-edge-戦略-adr-を確定する)
+  - [LIN-963](https://linear.app/linklynx-ai/issue/LIN-963/03-vpc-サブネット-ingress-dns-tls-基盤を-terraform-化する)
+  - [LIN-973](https://linear.app/linklynx-ai/issue/LIN-973/13-セキュリティ統制-baseline-を整備する)
+  - [Edge REST/WS Routing and WS Drain Runbook](../runbooks/edge-rest-ws-routing-drain-runbook.md)
+
+## Context
+
+Phase 1 baseline was re-evaluated under the following constraints:
+
+- single cloud is acceptable for now
+- future migration to physical servers remains possible
+- current priority is operational simplicity over premature multi-cloud design
+- portability must still be preserved through IaC, Kubernetes, and standard protocols
+
+The accepted Phase 1 runtime baseline is:
+
+- `GCP / us-east1`
+- `staging + prod`
+- one GKE cluster per environment
+- applications run on Kubernetes
+- databases and messaging prioritize operational ease for now
+
+LIN-961 must fix one edge baseline before VPC / DNS / TLS / ingress work proceeds.
+Without one decision, infrastructure documents can diverge between:
+
+1. `Cloudflare front door -> GCLB -> GKE`
+2. `GCP native edge -> GKE`
+
+## Scope
+
+In scope:
+
+- public DNS ownership
+- public TLS certificate ownership
+- WAF / DDoS protection point for Phase 1
+- L7 routing and health-check ownership
+- CDN usage boundary for Phase 1
+- REST / WebSocket edge traffic path
+- rollback boundary for edge configuration incidents
+
+Out of scope:
+
+- multi-region or multi-cloud DR implementation
+- future physical-server front door design
+- service mesh or internal east-west traffic policy
+- application runtime or database implementation details
+
+## Decision
+
+### 1. Phase 1 adopts GCP native edge
+
+The Phase 1 edge baseline is fixed as:
+
+- `Cloud DNS` for authoritative public DNS
+- `Certificate Manager` for public TLS certificate management
+- `GCP External Application Load Balancer (GCLB)` for L7 routing, TLS termination, WebSocket upgrade support, and backend health checks
+- `Cloud Armor` for WAF and edge protection policy
+- `Cloud CDN` only for static asset delivery when explicitly enabled
+
+`Cloudflare front door` is not part of the Phase 1 runtime baseline.
+
+### 2. Fixed traffic paths
+
+#### 2.1 REST
+
+`client -> Cloud DNS -> GCLB (+ Cloud Armor, optional Cloud CDN for static assets) -> GKE Ingress -> backend service`
+
+#### 2.2 WebSocket
+
+`client -> Cloud DNS -> GCLB (+ Cloud Armor) -> GKE Ingress -> API /ws`
+
+Rules:
+
+- WebSocket routes must not use CDN caching.
+- API routes must not use CDN caching by default.
+- CDN enablement is limited to static assets and other explicitly cacheable routes.
+
+### 3. Responsibility boundaries
+
+| boundary | owner | responsibility |
+| --- | --- | --- |
+| Public DNS | Cloud DNS | Hostname ownership and resolution to the active GCLB frontend |
+| Public TLS | Certificate Manager + GCLB | Certificate issuance/attachment and HTTPS termination |
+| Edge protection | Cloud Armor | WAF policy and edge request filtering |
+| L7 routing / health | GCLB | Host/path routing, backend health judgment, new connection distribution |
+| App ingress | GKE Ingress | Route mapping from LB to Kubernetes services |
+| App health / WS lifecycle | API | `GET /health`, `GET /ws`, heartbeat, reconnect, and drain semantics |
+
+### 4. Rollback baseline
+
+Rollback authority stays inside GCP for Phase 1.
+The rollback order is:
+
+1. revert the last validated GCLB / Ingress routing change
+2. revert Certificate Manager attachment or target-proxy change if TLS is impacted
+3. revert Cloud DNS record only when frontend endpoint selection changed
+4. pause rollout and restore the last validated backend revision if routing is healthy but the release is not
+
+Operational rule:
+
+- prefer rollback of LB / ingress / release configuration before DNS changes
+- DNS rollback is a last resort because propagation delay is larger and operationally noisier
+
+### 5. Why Cloudflare is not selected now
+
+Cloudflare remains a viable future option, but is not adopted in Phase 1 because:
+
+- it adds a second edge control plane while the accepted Phase 1 model is single-cloud
+- the current goal is operational simplicity for `staging + prod`, not front-door portability at any cost
+- Kubernetes, Terraform, and standard protocols already preserve the main portability requirement for applications and data paths
+
+Future trigger to reconsider Cloudflare or another external front door:
+
+- multi-cloud DR becomes an execution requirement
+- physical-server migration enters active planning
+- GCP edge capabilities no longer satisfy the product or operations needs
+
+## How to test
+
+1. DNS:
+   - confirm public hosts resolve to the active GCLB frontend
+2. TLS:
+   - confirm the certificate is active and attached to the intended target proxy
+3. Routing:
+   - confirm REST and WS routes reach the expected backend through GKE Ingress
+4. Health:
+   - confirm `GET /health` is the authoritative backend health-check endpoint
+5. CDN boundary:
+   - confirm API / WS routes are not cached
+6. Rollback:
+   - confirm a staging routing change can be reverted without DNS change in the normal case
+
+## ADR-001 compatibility checklist result
+
+Result: PASS / N.A. (no event schema change introduced by this ADR)
+
+- Additive-only schema rule: N.A.
+- Consumer impact: no runtime payload contract change
+- Monitoring and rollback readiness: covered by fixed traffic path and rollback baseline
+- Documentation scope: ADR, decisions summary, and edge runbook are updated together
+
+## Consequences
+
+- LIN-963 can proceed with one unambiguous DNS / TLS / LB baseline
+- LIN-973 can build WAF / edge protection policy on one fixed owner boundary
+- Phase 1 stays operationally simpler than the Cloudflare-front-door option
+- portability is preserved mainly through Kubernetes, Terraform, and protocol choices rather than a portable edge layer

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,3 +7,4 @@
 - `ADR-003-search-consistency-slo-reindex.md`: Search consistency baseline, lag SLO/SLI, reindex trigger conditions, and completion criteria.
 - `ADR-004-authz-fail-close-and-cache-strategy.md`: AuthZ fail-close baseline, REST/WS deny vs unavailable mapping, authorization cache TTL/invalidation strategy, and propagation SLO.
 - `ADR-005-dragonfly-ratelimit-failure-policy.md`: Dragonfly outage rate-limit hybrid policy, degraded enter/exit thresholds, and recovery warm-up/resynchronization baseline.
+- `ADR-006-phase1-edge-baseline-gcp-native-edge.md`: Phase 1 edge baseline, GCP native edge responsibility boundary, Cloudflare 不採用理由, and rollback order.

--- a/docs/agent_runs/LIN-961/Documentation.md
+++ b/docs/agent_runs/LIN-961/Documentation.md
@@ -1,0 +1,20 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now: ADR / infra summary / edge runbook の更新は完了し、PR 化前の整理に入っている。
+- Next: commit / push / PR 作成後に LIN-963 へ進む。
+
+## Decisions
+- 既存 local branch `codex/lin-961-edge-strategy-adr` は stale のため再利用しない。
+- 親 issue の strict order を優先し、LIN-963 より先に LIN-961 を main へ出す。
+- Phase 1 edge baseline は `Cloud DNS / Certificate Manager / GCLB / Cloud Armor / optional Cloud CDN` とする。
+- API / WebSocket は CDN cache 対象外とする。
+
+## How to run / demo
+- `make validate`
+- `git diff --check`
+- Result: `make validate` pass, `git diff --check` pass
+
+## Known issues / follow-ups
+- `docs/infra/00_discussion.md` は議論ログとして Cloudflare 案を含むが、SSOT は ADR-006 と `docs/infra/01_decisions.md` に移る。
+- runtime smoke は docs-only issue のため不要。

--- a/docs/agent_runs/LIN-961/Implement.md
+++ b/docs/agent_runs/LIN-961/Implement.md
@@ -1,0 +1,6 @@
+# Implement.md (Runbook)
+
+- Follow Plan.md as the single execution order. If order changes are needed, document the reason in Documentation.md and update it.
+- Keep diffs small and do not mix in out-of-scope improvements.
+- Run validation after each milestone and fix failures immediately before continuing.
+- Continuously update Documentation.md with decisions, progress, demo steps, and known issues.

--- a/docs/agent_runs/LIN-961/Plan.md
+++ b/docs/agent_runs/LIN-961/Plan.md
@@ -1,0 +1,27 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: if validation fails, repair it before moving to the next step.
+
+## Milestones
+### M1: 現行 docs の edge 前提を棚卸しする
+- Acceptance criteria:
+  - [ ] Cloudflare 前提の記述箇所を特定している。
+  - [ ] LIN-961 acceptance criteria と user decision を照合している。
+- Validation:
+  - `rg -n "Cloudflare|Cloud DNS|Certificate Manager|Cloud Armor|Cloud CDN|API Gateway" docs -S`
+
+### M2: ADR と infra summary を更新する
+- Acceptance criteria:
+  - [ ] ADR-006 を追加して GCP native edge baseline を文書化している。
+  - [ ] `docs/infra/01_decisions.md` の edge decision が ADR と一致している。
+- Validation:
+  - `make validate`
+
+### M3: Runbook を新 baseline に合わせる
+- Acceptance criteria:
+  - [ ] edge REST/WS runbook の routing path と責務分界が GCP native edge に更新されている。
+  - [ ] rollback / observability の記述が新 baseline に沿っている。
+- Validation:
+  - `make validate`
+  - `git diff --check`

--- a/docs/agent_runs/LIN-961/Prompt.md
+++ b/docs/agent_runs/LIN-961/Prompt.md
@@ -1,0 +1,25 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- Phase 1 の edge baseline を `GCP native edge` として ADR と関連 docs に固定する。
+- `Cloud DNS / Certificate Manager / GCLB / Cloud Armor / Cloud CDN(static only)` の責務分界を明文化する。
+- `API Gateway は main path では不要` をドキュメント上で明示する。
+
+## Non-goals
+- 実際の GCP edge リソースを Terraform で構築すること。
+- GKE / DB / 監視など edge 以外の基盤実装に踏み込むこと。
+
+## Deliverables
+- 新規 ADR 1本。
+- `docs/infra/01_decisions.md` の edge 方針更新。
+- `docs/runbooks/edge-rest-ws-routing-drain-runbook.md` の routing contract 更新。
+
+## Done when
+- [ ] CDN / DNS / TLS / WAF / DDoS の責務分担が ADR に明記されている。
+- [ ] staging / prod のトラフィック経路と切り戻し方針が記載されている。
+- [ ] 既存 docs の Cloudflare 前提が Phase 1 方針と矛盾しない。
+
+## Constraints
+- Perf: WebSocket 経路を壊さない責務分解にする。
+- Security: WAF / DDoS / cert expiry を監視対象として残す。
+- Compatibility: 後続の LIN-963 が Terraform に落としやすい責務境界にする。

--- a/docs/infra/01_decisions.md
+++ b/docs/infra/01_decisions.md
@@ -24,14 +24,10 @@
                         └──────┬──────┘
                                │
                     ┌──────────▼──────────┐
-                    │    Cloudflare        │
-                    │  DNS + CDN + WAF     │
-                    │  + DDoS 防御         │
-                    └──────────┬──────────┘
-                               │
-                    ┌──────────▼──────────┐
-                    │  GCP Global LB (L7)  │
-                    │  WebSocket 対応       │
+                    │   GCP Native Edge    │
+                    │ Cloud DNS + CertMgr  │
+                    │ GCLB + Cloud Armor   │
+                    │ + optional Cloud CDN │
                     └──────────┬──────────┘
                                │
               ┌────────────────┼────────────────┐
@@ -84,7 +80,7 @@
 |------|------|
 | 基盤 | **GKE Autopilot** |
 | 段階 | Autopilot → Standard → Self-hosted (成長に応じて) |
-| 環境 | **dev + staging + prod**（3環境、GCPプロジェクト分離） |
+| 環境 | **Phase 1 は staging + prod**（2環境、各環境 1 cluster）。`dev` は後続で追加検討 |
 
 ### 4. データストア
 
@@ -109,10 +105,11 @@
 
 | 項目 | 決定 |
 |------|------|
-| DNS + CDN | **Cloudflare** |
-| WAF + DDoS | **Cloudflare** |
-| ロードバランサー | **GCP Global HTTP(S) LB**（WebSocket 対応） |
-| TLS | Cloudflare（エッジ）+ GCP managed cert（オリジン） |
+| DNS | **Cloud DNS** |
+| CDN | **Cloud CDN（静的配信のみ。API / WS はキャッシュしない）** |
+| WAF + Edge 保護 | **Cloud Armor** |
+| ロードバランサー | **GCP External Application Load Balancer**（WebSocket 対応） |
+| TLS | **Certificate Manager + GCLB で終端** |
 | ドメイン | 取得済み（具体名は別途確認） |
 
 ### 7. CI/CD・デプロイ
@@ -159,7 +156,7 @@
 
 ### Phase 2: アプリケーションデプロイ
 - Rust API / Next.js / Python を K8s にデプロイ
-- Cloud Load Balancer + Cloudflare 接続
+- GCP native edge（Cloud DNS / Certificate Manager / GCLB / Cloud Armor）接続
 - External Secrets Operator セットアップ
 - DB マイグレーション自動化
 

--- a/docs/runbooks/edge-rest-ws-routing-drain-runbook.md
+++ b/docs/runbooks/edge-rest-ws-routing-drain-runbook.md
@@ -1,11 +1,12 @@
 # Edge REST/WS Routing and WS Drain Runbook (Draft)
 
 - Status: Draft
-- Last updated: 2026-02-26
+- Last updated: 2026-03-27
 - Owner scope: Edge routing and realtime connection continuity baseline for v0
 - References:
   - [ADR-002 Class A/B Event Classification and Delivery Boundary](../adr/ADR-002-class-ab-event-classification-and-delivery-boundary.md)
   - [ADR-005 Dragonfly Outage RateLimit Failure Policy (Hybrid)](../adr/ADR-005-dragonfly-ratelimit-failure-policy.md)
+  - [ADR-006 Phase 1 Edge Baseline on GCP Native Edge](../adr/ADR-006-phase1-edge-baseline-gcp-native-edge.md)
   - [LIN-585](https://linear.app/linklynx-ai/issue/LIN-585)
   - [LIN-586](https://linear.app/linklynx-ai/issue/LIN-586)
   - [LIN-587](https://linear.app/linklynx-ai/issue/LIN-587)
@@ -18,7 +19,7 @@ This runbook fixes one operational baseline for REST/WS edge routing and rolling
 
 In scope:
 
-- Cloudflare -> GCLB -> GKE Ingress -> API routing contract for REST and WS
+- Cloud DNS -> GCLB (+ Cloud Armor, optional Cloud CDN) -> GKE Ingress -> API routing contract for REST and WS
 - Health check contract and routing dependencies
 - WS drain behavior during rollout
 - Failure handling and rollback procedure for LB/Ingress path
@@ -37,9 +38,10 @@ Fill the placeholders below before each rollout.
 
 | key | staging placeholder | production placeholder |
 | --- | --- | --- |
-| Cloudflare zone | `<stg_cf_zone>` | `<prod_cf_zone>` |
+| Cloud DNS managed zone | `<stg_dns_zone>` | `<prod_dns_zone>` |
 | Public API host | `<stg_api_host>` | `<prod_api_host>` |
 | Public WS host | `<stg_ws_host>` | `<prod_ws_host>` |
+| Certificate Manager certificate | `<stg_cert_name>` | `<prod_cert_name>` |
 | GCLB backend service | `<stg_gclb_backend_service>` | `<prod_gclb_backend_service>` |
 | GCLB health check name | `<stg_gclb_health_check>` | `<prod_gclb_health_check>` |
 | Ingress namespace/name | `<stg_ingress_namespace>/<stg_ingress_name>` | `<prod_ingress_namespace>/<prod_ingress_name>` |
@@ -51,21 +53,25 @@ Fill the placeholders below before each rollout.
 
 | protocol | client scheme | edge path | app endpoint | expected behavior |
 | --- | --- | --- | --- | --- |
-| REST | `https://` | Cloudflare -> GCLB -> GKE Ingress | `GET /health` and API REST paths | Path remains available when at least one backend is healthy |
-| WebSocket | `wss://` | Cloudflare (WS passthrough) -> GCLB -> GKE Ingress | `GET /ws` | Upgrade succeeds when backend is healthy and not draining |
+| REST | `https://` | Cloud DNS -> GCLB (+ Cloud Armor, optional Cloud CDN) -> GKE Ingress | `GET /health` and API REST paths | Path remains available when at least one backend is healthy |
+| WebSocket | `wss://` | Cloud DNS -> GCLB (+ Cloud Armor) -> GKE Ingress | `GET /ws` | Upgrade succeeds when backend is healthy and not draining |
 
 ### 3.2 Responsibility boundary
 
-1. Cloudflare:
-- DNS and edge TLS entrypoint for REST/WS.
+1. Cloud DNS:
+- Authoritative public DNS for REST/WS hosts.
+2. Certificate Manager + GCLB:
+- Public TLS termination for REST/WS.
 - Pass WS upgrade traffic without protocol downgrade.
-2. GCLB:
+3. Cloud Armor:
+- WAF and request-filtering policy at the GCP edge.
+4. GCLB:
 - L7 backend health judgment.
 - New connection distribution only to healthy and ready backends.
-3. GKE Ingress:
+5. GKE Ingress:
 - Host/path routing to API service.
 - Remove draining pods from new request distribution via readiness gate.
-4. API:
+6. API:
 - `GET /health` returns health response for LB decision.
 - `GET /ws` handles connection lifecycle, heartbeat, and close semantics.
 
@@ -82,9 +88,11 @@ Fixed baseline:
 
 Operational checks before rollout:
 
-1. Confirm Cloudflare origin points to active GCLB frontend.
-2. Confirm GCLB health check targets Ingress/API `GET /health`.
-3. Confirm Ingress routes both REST and WS host/path to the same API service boundary.
+1. Confirm Cloud DNS host resolves to the active GCLB frontend.
+2. Confirm Certificate Manager certificate is active and attached to the intended target proxy.
+3. Confirm Cloud Armor policy is attached to the intended edge path.
+4. Confirm GCLB health check targets Ingress/API `GET /health`.
+5. Confirm Ingress routes both REST and WS host/path to the same API service boundary.
 
 ## 5. WS connection lifecycle baseline
 
@@ -180,13 +188,13 @@ If any threshold fails, treat rollout policy as non-compliant and open follow-up
 3. Route traffic only to stable backend revision.
 - Rollback decision: if WS upgrade success does not recover to baseline within 15 minutes, rollback deployment and Ingress changes together.
 
-### 8.3 Scenario C: Cloudflare edge/origin mismatch
+### 8.3 Scenario C: GCP edge config mismatch
 
-- Detection: edge-level origin errors while GCLB and Ingress appear healthy.
+- Detection: edge-level certificate, DNS, or policy errors while GCLB and Ingress appear healthy.
 - Temporary mitigation:
-1. Verify Cloudflare origin and DNS target against active GCLB endpoint.
-2. Reapply last validated Cloudflare route config.
-- Rollback decision: if mismatch persists, revert Cloudflare routing entry to previous verified config and stop further rollout.
+1. Verify Cloud DNS record, target proxy certificate attachment, and Cloud Armor policy against the active GCLB endpoint.
+2. Reapply the last validated GCP edge configuration.
+- Rollback decision: if mismatch persists, revert the last validated GCLB / certificate / DNS change set and stop further rollout.
 
 ## 9. Rollout procedure (routing-related changes)
 


### PR DESCRIPTION
## 概要
- ADR-006 を追加し、Phase 1 の edge baseline を GCP native edge に固定
- docs/infra/01_decisions.md の edge 決定事項を Cloud DNS / Certificate Manager / GCLB / Cloud Armor / optional Cloud CDN に更新
- docs/runbooks/edge-rest-ws-routing-drain-runbook.md を新 baseline に合わせて更新

## 変更理由
- LIN-963 以降の VPC / DNS / TLS / Ingress 実装に入る前に、edge の責務境界を 1 つに固定する必要があるため
- 現在の運用方針は single cloud / GCP 優先であり、Cloudflare front door より GCP native edge の方が Phase 1 に適しているため

## Acceptance Criteria 対応
- CDN / DNS / TLS / WAF / DDoS の責務分担を ADR で確定: ADR-006 で対応
- staging / prod のトラフィック図と障害時の切り戻し方針を記載: ADR-006 と runbook で対応
- LIN-960 の edge Open question を縮小: decisions summary と runbook を同時更新して対応

## テスト
- make validate ✅
- git diff --check ✅

## 補足
- docs-only issue のため runtime smoke は不要
- PR base は main のため human review 前提

## Linear
- LIN-961
- https://linear.app/linklynx-ai/issue/LIN-961/01-edge-戦略-adr-を確定する