### PR TITLE
infra: LIN-1014 月1万円向け prod-only GKE 基盤を追加する

### DIFF
--- a/docs/agent_runs/LIN-1014/Documentation.md
+++ b/docs/agent_runs/LIN-1014/Documentation.md
@@ -1,0 +1,27 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now: low-budget prod-only GKE module と docs 実装、validation 完了。
+- Next: self-review を通して commit / PR を作成する。
+
+## Decisions
+- `LIN-1014` は `prod only` を採用し、staging 常設 cluster は作らない。
+- low-budget path では fixed request を baseline にし、VPA は recommendation-only に留める。
+- custom node service account を作り、Autopilot cluster の `auto_provisioning_defaults.service_account` に割り当てる。
+- initial workload baseline は `CPU 500m / Memory 512Mi / Ephemeral 1Gi` を Rust API 向けの起点とする。
+
+## How to run / demo
+- `terraform fmt -check -recursive infra`
+- `make infra-validate`
+- `make validate`
+
+## Known issues / follow-ups
+- この branch は `LIN-963` 上の stacked branch。
+- 実運用の `kubectl` / `terraform plan` は backend と GCP credentials が必要。
+- `terraform plan` は backend 未初期化の local workspace では未実施。
+
+## Validation log
+- Passed: `terraform fmt -check -recursive infra`
+- Passed: `make infra-validate` with `PATH=/tmp/terraform_1.6.6:$PATH`
+- Passed: `make validate`
+- Skipped: real `terraform plan` / `kubectl` checks because backend.hcl と GCP credentials が local workspace にない

--- a/docs/agent_runs/LIN-1014/Implement.md
+++ b/docs/agent_runs/LIN-1014/Implement.md
@@ -1,0 +1,6 @@
+# Implement.md (Runbook)
+
+- Follow `Plan.md` in order.
+- Keep the scope limited to `LIN-1014`.
+- Reuse `LIN-963` outputs instead of duplicating network resources.
+- Prefer docs that explain why the low-budget path differs from the standard `LIN-964` plan.

--- a/docs/agent_runs/LIN-1014/Plan.md
+++ b/docs/agent_runs/LIN-1014/Plan.md
@@ -1,0 +1,32 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: validation fails are fixed before moving on.
+
+## Milestones
+### M1: Low-budget GKE 前提と module 設計を固める
+- Acceptance criteria:
+  - [ ] prod only / staging no-cluster の責務を明文化する
+  - [ ] cluster resource, node service account, outputs を決める
+  - [ ] resource request baseline と upgrade 条件を決める
+- Validation:
+  - relevant docs review
+  - official GKE / Terraform docs check
+
+### M2: Terraform と docs を実装する
+- Acceptance criteria:
+  - [ ] prod root に minimal Autopilot cluster を追加する
+  - [ ] staging no-cluster を docs と code で明示する
+  - [ ] infra docs に low-budget path を追記する
+- Validation:
+  - `terraform fmt -check -recursive infra`
+  - `make infra-validate`
+
+### M3: Repo validation と PR 準備を完了する
+- Acceptance criteria:
+  - [ ] `make validate` が通る
+  - [ ] review gate を通す
+  - [ ] PR に cost assumptions と skipped checks を整理する
+- Validation:
+  - `make validate`
+  - review gate evidence

--- a/docs/agent_runs/LIN-1014/Prompt.md
+++ b/docs/agent_runs/LIN-1014/Prompt.md
@@ -1,0 +1,28 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- `LIN-1014` として、月額 `1万円` 前後の初期予算に合わせた `prod only` GKE Autopilot 最小基盤を Terraform 化する。
+- `LIN-963` の network foundation を利用して、prod project のみ常設 cluster を持つ low-budget path を作る。
+- `staging 常設クラスタなし` と `fixed request / VPA recommendation-only` の初期運用方針を code/docs に明示する。
+
+## Non-goals
+- `staging + prod` の 2 クラスタ構成にはしない。
+- Next.js / Python / Dragonfly まで同居前提にはしない。
+- HPA 自動化や本番負荷試験までは進めない。
+
+## Deliverables
+- `infra/modules/gke_autopilot_minimal`
+- `infra/environments/prod` からの prod-only module wiring
+- low-budget GKE baseline を説明する README 更新
+- `docs/agent_runs/LIN-1014/` の実行メモ
+
+## Done when
+- [ ] prod only の GKE Autopilot cluster が Terraform で再現可能
+- [ ] low-budget 前提の namespace / naming / resource request baseline が docs にある
+- [ ] `staging 常設クラスタなし` が code/docs で明示されている
+- [ ] `LIN-964` 標準構成へ拡張する条件が記載されている
+
+## Constraints
+- Perf: validation は `terraform fmt -check`, `make infra-validate`, `make validate` を通す
+- Security: low-budget path でも custom node service account を使い、main path を汚さない
+- Compatibility: `LIN-963` PR 上に積む stacked branch として差分を閉じる

--- a/infra/README.md
+++ b/infra/README.md
@@ -13,6 +13,7 @@ LIN-962 で GCP bootstrap と Terraform remote state の最小土台を追加し
 ```text
 infra/
 ├── modules/
+│   ├── gke_autopilot_minimal/
 │   ├── project_baseline/
 │   ├── network_foundation/
 │   └── state_backend/
@@ -112,3 +113,33 @@ domain が未確定でも code は先に用意し、environment ごとの `terra
 - DNS authorization record
 - Google-managed certificate
 - certificate map / entry
+
+## LIN-1014 low-budget GKE path
+
+月額 `1万円` 前後の初期予算では、まず `prod only` の Autopilot cluster 1つに寄せる。
+
+### Why prod only
+
+- GKE cluster management fee は `1 cluster あたり $0.10/hour` だが、Autopilot / zonal cluster には billing account ごとに `月 $74.40` の free tier credit がある
+- そのため、**常設 1 cluster** なら management fee はほぼ吸収できるが、`staging + prod` 常設は edge / DNS / traffic と合わせて初期予算に対して重くなりやすい
+- low-budget path では `Rust API` を先に成立させ、常設 staging は後から足す
+
+### Baseline
+
+- prod: Autopilot cluster 1つ
+- staging: 常設 cluster なし
+- initial workload: Rust API のみ
+- fixed request baseline:
+  - CPU: `500m`
+  - Memory: `512Mi`
+  - Ephemeral storage: `1Gi`
+- VPA: recommendation-only
+- HPA: 未導入
+
+### Upgrade path
+
+次の条件を満たしたら標準 path の `LIN-964` へ移る。
+
+- staging 常設環境がないと deploy safety を維持できない
+- Next.js / Python が常時 production workload になった
+- autoscaling を固定 request では吸収しきれない

--- a/infra/environments/prod/README.md
+++ b/infra/environments/prod/README.md
@@ -24,6 +24,22 @@ terraform plan
 - GKE Ingress resource 自体はこの issue では作らず、後続 cluster / workload issue で attach する
 - main path に `API Gateway` は置かない
 
+## LIN-1014 low-budget path
+
+- `enable_minimal_gke_cluster = true` で **prod only** の GKE Autopilot cluster を作る
+- `staging` 常設 cluster は作らず、local / preview / 必要時の一時環境で代替する
+- 初期の workload baseline は Rust API 1本に絞る
+  - CPU request: `500m`
+  - Memory request: `512Mi`
+  - Ephemeral storage request: `1Gi`
+- VPA は recommendation-only 前提とし、自動 apply は後続 issue に回す
+
+### 低予算 path から標準 path へ拡張する条件
+
+- staging 常設環境がないと release safety を維持できなくなったとき
+- Next.js / Python が常時稼働前提になり、prod only 1 cluster では運用しづらくなったとき
+- HPA を入れたいだけの観測データが揃ったとき
+
 ## tfvars で埋める値
 
 - `public_dns_zone_name`

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -12,6 +12,20 @@ module "network_foundation" {
   public_hostnames     = var.public_hostnames
 }
 
+module "gke_autopilot_minimal" {
+  count = var.enable_minimal_gke_cluster ? 1 : 0
+
+  source = "../../modules/gke_autopilot_minimal"
+
+  environment                   = local.environment
+  network_self_link             = module.network_foundation.network_self_link
+  pods_secondary_range_name     = module.network_foundation.gke_pods_secondary_range_name
+  project_id                    = var.project_id
+  region                        = var.region
+  services_secondary_range_name = module.network_foundation.gke_services_secondary_range_name
+  subnetwork_self_link          = module.network_foundation.gke_nodes_subnet_self_link
+}
+
 output "environment" {
   value = local.environment
 }
@@ -22,4 +36,8 @@ output "project_id" {
 
 output "network_foundation" {
   value = module.network_foundation
+}
+
+output "gke_autopilot_minimal" {
+  value = var.enable_minimal_gke_cluster ? module.gke_autopilot_minimal[0] : null
 }

--- a/infra/environments/prod/terraform.tfvars.example
+++ b/infra/environments/prod/terraform.tfvars.example
@@ -3,6 +3,7 @@ region     = "us-east1"
 
 # Optional: set when using service account impersonation.
 terraform_admin_service_account_email = "terraform-admin@linklynx-bootstrap.iam.gserviceaccount.com"
+enable_minimal_gke_cluster            = true
 
 # Fill these with the real production domain before plan/apply.
 public_dns_zone_name = "linklynx-prod-public"

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -33,3 +33,9 @@ variable "public_hostnames" {
   type        = set(string)
   default     = []
 }
+
+variable "enable_minimal_gke_cluster" {
+  description = "Whether to create the low-budget prod-only GKE Autopilot cluster baseline."
+  type        = bool
+  default     = true
+}

--- a/infra/environments/staging/README.md
+++ b/infra/environments/staging/README.md
@@ -24,6 +24,15 @@ terraform plan
 - GKE Ingress resource 自体はこの issue では作らず、後続 cluster / smoke deploy issue で attach する
 - main path に `API Gateway` は置かない
 
+## LIN-1014 low-budget path
+
+- 月 `1万円` 前後の初期予算 path では、staging 常設 cluster は作らない
+- staging は次で代替する
+  - local 開発
+  - preview 環境
+  - 必要時のみの一時 cluster
+- 常設 staging cluster が必要になったら、標準 path の `LIN-964` 相当へ拡張する
+
 ## tfvars で埋める値
 
 - `public_dns_zone_name`

--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -23,3 +23,10 @@ output "project_id" {
 output "network_foundation" {
   value = module.network_foundation
 }
+
+output "gke_low_budget_strategy" {
+  value = {
+    cluster_enabled = false
+    reason          = "LIN-1014 keeps staging on local / preview / temporary environments to stay within the initial 10k JPY budget."
+  }
+}

--- a/infra/modules/gke_autopilot_minimal/main.tf
+++ b/infra/modules/gke_autopilot_minimal/main.tf
@@ -1,0 +1,63 @@
+locals {
+  base_name                         = "linklynx-${var.environment}"
+  cluster_name                      = var.cluster_name != "" ? var.cluster_name : "${local.base_name}-autopilot"
+  node_service_account_display_name = "GKE Autopilot node service account (${var.environment})"
+
+  labels = merge(
+    {
+      cost_profile = "low-budget"
+      environment  = var.environment
+      issue        = "lin-1014"
+      managed_by   = "terraform"
+    },
+    var.labels,
+  )
+}
+
+resource "google_service_account" "node" {
+  account_id   = var.node_service_account_account_id
+  display_name = local.node_service_account_display_name
+}
+
+resource "google_project_iam_member" "node_default" {
+  project = var.project_id
+  role    = "roles/container.defaultNodeServiceAccount"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+resource "google_project_iam_member" "node_artifact_registry_reader" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.node.email}"
+}
+
+resource "google_container_cluster" "this" {
+  name     = local.cluster_name
+  location = var.region
+
+  enable_autopilot    = true
+  deletion_protection = var.deletion_protection
+  network             = var.network_self_link
+  subnetwork          = var.subnetwork_self_link
+  resource_labels     = local.labels
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = var.pods_secondary_range_name
+    services_secondary_range_name = var.services_secondary_range_name
+  }
+
+  cluster_autoscaling {
+    auto_provisioning_defaults {
+      service_account = google_service_account.node.email
+    }
+  }
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+  depends_on = [
+    google_project_iam_member.node_default,
+    google_project_iam_member.node_artifact_registry_reader,
+  ]
+}

--- a/infra/modules/gke_autopilot_minimal/outputs.tf
+++ b/infra/modules/gke_autopilot_minimal/outputs.tf
@@ -1,0 +1,39 @@
+output "cluster_name" {
+  value = google_container_cluster.this.name
+}
+
+output "cluster_location" {
+  value = google_container_cluster.this.location
+}
+
+output "cluster_endpoint" {
+  value = google_container_cluster.this.endpoint
+}
+
+output "node_service_account_email" {
+  value = google_service_account.node.email
+}
+
+output "workload_identity_pool" {
+  value = "${var.project_id}.svc.id.goog"
+}
+
+output "recommended_namespaces" {
+  value = var.recommended_namespaces
+}
+
+output "low_budget_request_baseline" {
+  value = {
+    cpu               = var.fixed_request_cpu
+    ephemeral_storage = var.fixed_request_ephemeral_storage
+    memory            = var.fixed_request_memory
+  }
+}
+
+output "upgrade_conditions" {
+  value = {
+    add_staging_cluster_when = "Preview or staging validation can no longer be covered by local and temporary environments."
+    move_to_standard_lin964  = "Next.js or Python become always-on production workloads, or team needs separate staging/prod release cadence."
+    switch_to_hpa_when       = "Measured CPU, memory, or concurrency patterns show stable autoscaling signals."
+  }
+}

--- a/infra/modules/gke_autopilot_minimal/variables.tf
+++ b/infra/modules/gke_autopilot_minimal/variables.tf
@@ -1,0 +1,93 @@
+variable "project_id" {
+  description = "Project ID that owns the cluster."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name used in resource naming."
+  type        = string
+}
+
+variable "region" {
+  description = "Regional location for the Autopilot cluster."
+  type        = string
+}
+
+variable "network_self_link" {
+  description = "VPC self link used by the cluster."
+  type        = string
+}
+
+variable "subnetwork_self_link" {
+  description = "Subnetwork self link used by the cluster."
+  type        = string
+}
+
+variable "pods_secondary_range_name" {
+  description = "Secondary range name used for pod IP allocation."
+  type        = string
+}
+
+variable "services_secondary_range_name" {
+  description = "Secondary range name used for service IP allocation."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Optional cluster name override."
+  type        = string
+  default     = ""
+}
+
+variable "release_channel" {
+  description = "GKE release channel."
+  type        = string
+  default     = "REGULAR"
+
+  validation {
+    condition     = contains(["RAPID", "REGULAR", "STABLE", "UNSPECIFIED"], var.release_channel)
+    error_message = "release_channel must be RAPID, REGULAR, STABLE, or UNSPECIFIED."
+  }
+}
+
+variable "deletion_protection" {
+  description = "Whether Terraform should protect the cluster from deletion."
+  type        = bool
+  default     = false
+}
+
+variable "node_service_account_account_id" {
+  description = "Account ID for the custom Autopilot node service account."
+  type        = string
+  default     = "gke-autopilot-node"
+}
+
+variable "fixed_request_cpu" {
+  description = "Documented initial CPU request baseline for the first Rust API deployment."
+  type        = string
+  default     = "500m"
+}
+
+variable "fixed_request_memory" {
+  description = "Documented initial memory request baseline for the first Rust API deployment."
+  type        = string
+  default     = "512Mi"
+}
+
+variable "fixed_request_ephemeral_storage" {
+  description = "Documented initial ephemeral storage request baseline for the first Rust API deployment."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "recommended_namespaces" {
+  description = "Recommended namespace baseline for the low-budget prod-only cluster."
+  type        = list(string)
+  default     = ["app", "ops"]
+}
+
+variable "labels" {
+  description = "Additional labels applied to supported resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## 概要
- 月額 `1万円` 前後の low-budget path として、`prod only` の GKE Autopilot cluster baseline を追加しました
- `staging` 常設 cluster は作らず、local / preview / 一時環境で代替する方針を docs と code に明記しました
- 初期の Rust API 向け fixed request baseline と、標準 path (`LIN-964`) へ拡張する条件を整理しました

## 変更内容
- `infra/modules/gke_autopilot_minimal` を追加
  - custom node service account
  - `roles/container.defaultNodeServiceAccount`
  - `roles/artifactregistry.reader`
  - prod only の GKE Autopilot cluster
- `infra/environments/prod` から minimal cluster module を呼ぶように変更
- `infra/environments/staging` に low-budget path では cluster を作らないことを output / docs で明示
- `infra/README.md` と environment README に low-budget path の説明を追加
- `docs/agent_runs/LIN-1014/` に実行メモを追加

## Acceptance Criteria 対応
- [x] prod only の GKE Autopilot cluster が Terraform で再現可能
- [x] 月1万円前後の初期予算に合わせた namespace / resource request baseline が文書化されている
- [x] `staging 常設クラスタなし` がコードとドキュメントで明示されている
- [x] `LIN-964` の標準構成へ拡張する条件が記載されている

## テスト
- [x] `terraform fmt -check -recursive infra`
- [x] `make infra-validate` (`PATH=/tmp/terraform_1.6.6:$PATH`)
- [x] `make validate`
- [ ] `terraform plan`
  - `backend.hcl` と実際の GCP credentials が local workspace にないため未実施です
- [ ] `kubectl get ns`, `kubectl get pods -A`
  - cluster 未作成のため未実施です

## コスト前提
- GKE の cluster management fee は `1 cluster あたり $0.10/hour` ですが、Autopilot / zonal cluster には billing account ごとに `月 $74.40` の free tier credit があります
- そのため low-budget path では **prod only の 1 cluster** に絞り、edge と workload request を小さく保つ前提にしました
- 初期 workload baseline は Rust API のみを想定し、`500m CPU / 512Mi memory / 1Gi ephemeral-storage` を起点にしています

## stacked PR について
- この PR は `LIN-963` branch (`codex/lin-963-network-foundation`) の上に積んでいます
- `LIN-963` が merge されたら base を `main` に切り替える想定です

## 補足
- UI 変更はありません
- event contract / ADR-001 checklist は対象外です
- VPA は recommendation-only 前提で、自動 apply はこの PR に含めていません

Linear: https://linear.app/linklynx-ai/issue/LIN-1014/04a-月1万yen向け-prod-only-gke-autopilot-最小基盤を整備する
