### PR TITLE
infra: LIN-1015 prod-only の Rust API smoke deploy を Terraform で整備

### DIFF
--- a/docs/agent_runs/LIN-1015/Documentation.md
+++ b/docs/agent_runs/LIN-1015/Documentation.md
@@ -1,0 +1,30 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now: LIN-1015 の実装と validation は完了。PR 化の最終整理中
+- Next: self-review を反映して commit / push / PR を作る
+
+## Decisions
+- low-budget path の次 issue として `LIN-1015` を新規起票し、`LIN-1013` の staging 前提とは切り分ける
+- edge は `GCP native edge` 方針に沿い、prod public host と Gateway route を Terraform 管理に置く
+- digest が未指定のときは smoke workload を作らず、prod apply の明示操作を必須にする
+- `enable_rust_api_smoke_deploy = true` なのに digest / hostname / edge prerequisites が不足している場合は Terraform `check` で fail-fast させる
+- cluster create と workload deploy は同一 root だが、初回は `LIN-1014` apply 後に `LIN-1015` を有効化する 2 段階運用を前提にする
+
+## How to run / demo
+- `LIN-1014` と `LIN-966` が apply / 実行済みの前提で prod tfvars に image digest を入れて apply する
+- apply 後に `curl https://<prod_api_host>/health` と `wscat` で `/ws` を確認する
+- rollback は `rust_api_image_digest` を直前 digest に戻して再 apply する
+
+## Validation log
+- `terraform fmt -check -recursive infra`
+- `PATH=/tmp/terraform_1.6.6:$PATH make infra-validate`
+- `make validate`
+- `git diff --check`
+
+## Local plan note
+- `terraform -chdir=infra/environments/prod plan ...` は、この workspace に backend 用 `backend.hcl` がなく、root に `backend "gcs" {}` があるため、そのままでは local plan を安定再現できなかった
+- `TF_DATA_DIR` を分けた試行でも `Backend initialization required` に戻るため、issue では `validate` までをローカル gate とし、実 plan/apply は bootstrap 後の実環境で確認する前提にした
+
+## Known issues / follow-ups
+- 実 cluster / 実ドメインがない local workspace では actual apply はできない

--- a/docs/agent_runs/LIN-1015/Implement.md
+++ b/docs/agent_runs/LIN-1015/Implement.md
@@ -1,0 +1,6 @@
+# Implement.md (Runbook)
+
+- Follow Plan.md as the single execution order. If order changes are needed, document the reason in Documentation.md and update it.
+- Keep diffs small and do not mix in out-of-scope improvements.
+- Run validation after each milestone and fix failures immediately before continuing.
+- Continuously update Documentation.md with decisions, progress, demo steps, and known issues.

--- a/docs/agent_runs/LIN-1015/Plan.md
+++ b/docs/agent_runs/LIN-1015/Plan.md
@@ -1,0 +1,23 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: if validation fails, repair it before moving to the next step.
+
+## Milestones
+### M1: prod root に smoke workload の Terraform wiring を追加する
+- Acceptance criteria:
+  - [x] Kubernetes provider が prod cluster output を使って構成される
+  - [x] Rust API smoke workload module が namespace / service account / deployment / service / edge route を持つ
+  - [x] image digest と public host を変数で差し替えられる
+- Validation:
+  - `terraform fmt -check -recursive infra`
+  - `PATH=/tmp/terraform_1.6.6:$PATH make infra-validate`
+
+### M2: docs と example 設定を更新する
+- Acceptance criteria:
+  - [x] prod apply / rollback / verify 手順が docs にある
+  - [x] low-budget path における staging との差分が説明されている
+  - [x] local で回せる validation と skip 理由が記録されている
+- Validation:
+  - `make validate`
+  - `PATH=/tmp/terraform_1.6.6:$PATH terraform -chdir=infra/environments/prod init -backend=false -reconfigure >/dev/null && PATH=/tmp/terraform_1.6.6:$PATH terraform -chdir=infra/environments/prod plan -refresh=false -var-file=terraform.tfvars.example`

--- a/docs/agent_runs/LIN-1015/Prompt.md
+++ b/docs/agent_runs/LIN-1015/Prompt.md
@@ -1,0 +1,28 @@
+# Prompt.md (Spec / Source of truth)
+
+## Goals
+- low-budget path に合わせて `prod` GKE Autopilot 上へ Rust API smoke workload を Terraform だけで出せるようにする
+- image は Artifact Registry digest 参照に固定する
+- `GET /health` と `GET /ws` を prod public host から通せる最小経路を用意する
+
+## Non-goals
+- staging cluster の追加
+- Argo CD / Argo Rollouts の導入
+- Cloud SQL や外部データストアとの本接続
+- Secret Manager / External Secrets の本格導入
+
+## Deliverables
+- prod environment で使う Kubernetes provider wiring
+- Rust API smoke workload module
+- apply / rollback / verify 手順の documentation
+
+## Done when
+- [ ] prod root から Terraform だけで smoke workload を定義できる
+- [ ] image digest の更新で roll-forward / rollback できる
+- [ ] `/health` / `/ws` の確認手順が残る
+- [ ] `make validate` と issue-specific Terraform checks が通る
+
+## Constraints
+- Perf: 低予算 baseline の `500m CPU / 512Mi memory / 1Gi ephemeral storage` を崩さない
+- Security: mutable tag に依存しない。長期静的 key は増やさない
+- Compatibility: `LIN-1014` の prod-only cluster baseline と `LIN-966` の publish flow に沿う

--- a/infra/README.md
+++ b/infra/README.md
@@ -217,3 +217,36 @@ low-budget path でも image publish 自体は `staging` / `prod` の両 project
 4. `prod` publish は protected branch merge または manual approval 付き workflow dispatch で行う
 
 この issue では image copy / promotion の完全自動化までは持たない。
+
+## LIN-1015 prod-only Rust API smoke deploy baseline
+
+low-budget path の最初の workload deploy は `prod` の Rust API 1本に絞る。
+
+### Why default-off
+
+`infra/environments/prod` では smoke workload resource を持つが、default は `enable_rust_api_smoke_deploy = false` にする。
+
+- cluster 作成 (`LIN-1014`) と workload deploy (`LIN-1015`) を分離したい
+- image digest と public host が埋まってから明示的に有効化したい
+- local validation では cluster 未作成状態でも `terraform validate` / `plan` を通したい
+
+`enable_rust_api_smoke_deploy = true` にした状態で digest / host / edge prerequisites が足りないときは、Terraform `check` で fail-fast する。
+
+### Required inputs
+
+- `enable_rust_api_smoke_deploy = true`
+- `rust_api_image_digest = us-east1-docker.pkg.dev/.../rust@sha256:...`
+- `rust_api_public_hostname = api.<domain>`
+
+### What gets created
+
+- Kubernetes namespace / service account / deployment / service
+- GKE Gateway API resource (`Gateway`, `HTTPRoute`)
+- `HealthCheckPolicy` with `/health`
+
+Route baseline は次の通り。
+
+- `https://<rust_api_public_hostname>/health`
+- `wss://<rust_api_public_hostname>/ws`
+
+deploy 後の rollback は `rust_api_image_digest` を直前 digest に戻して再 apply する。

--- a/infra/environments/prod/README.md
+++ b/infra/environments/prod/README.md
@@ -41,6 +41,36 @@ terraform plan
 - Next.js / Python が常時稼働前提になり、prod only 1 cluster では運用しづらくなったとき
 - HPA を入れたいだけの観測データが揃ったとき
 
+## LIN-1015 prod-only Rust API smoke deploy
+
+`LIN-1015` は `LIN-1014` の cluster を使って、最初の Rust API workload を Terraform で出す。
+
+### 使う変数
+
+- `enable_rust_api_smoke_deploy`
+- `rust_api_image_digest`
+- `rust_api_public_hostname`
+
+default では `enable_rust_api_smoke_deploy = false` にしている。
+cluster 作成後に digest と hostname が揃ってから明示的に `true` へ切り替える。
+`true` のまま前提値が足りない場合は Terraform `check` で apply を止める。
+
+### 作られるもの
+
+- namespace: `rust-api-smoke`
+- Kubernetes ServiceAccount / Deployment / Service
+- Gateway API:
+  - `Gateway`
+  - `HTTPRoute`
+  - `HealthCheckPolicy`
+
+### 運用メモ
+
+- Gateway は `LIN-963` で確保した named static IP と certificate map を使う
+- 最初の有効化は `LIN-1014` cluster apply 後の 2 段階目 apply として実施する
+- image は tag ではなく Artifact Registry digest を使う
+- rollback は `rust_api_image_digest` を直前 digest に戻して `terraform apply` する
+
 ## tfvars で埋める値
 
 - `public_dns_zone_name`

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -1,5 +1,27 @@
 locals {
-  environment = "prod"
+  environment                   = "prod"
+  normalized_public_hostnames   = [for hostname in var.public_hostnames : trimsuffix(hostname, ".")]
+  rust_api_public_hostname      = var.rust_api_public_hostname != "" ? trimsuffix(var.rust_api_public_hostname, ".") : (length(local.normalized_public_hostnames) > 0 ? local.normalized_public_hostnames[0] : "")
+  enable_rust_api_smoke         = var.enable_rust_api_smoke_deploy && var.enable_minimal_gke_cluster
+  rust_api_smoke_inputs_are_set = var.rust_api_image_digest != "" && local.rust_api_public_hostname != ""
+  rust_api_smoke_edge_is_ready  = module.network_foundation.public_certificate_map_name != null && module.network_foundation.public_lb_ipv4_name != ""
+}
+
+check "rust_api_smoke_prerequisites" {
+  assert {
+    condition     = !var.enable_rust_api_smoke_deploy || var.enable_minimal_gke_cluster
+    error_message = "enable_rust_api_smoke_deploy requires enable_minimal_gke_cluster = true."
+  }
+
+  assert {
+    condition     = !var.enable_rust_api_smoke_deploy || local.rust_api_smoke_inputs_are_set
+    error_message = "enable_rust_api_smoke_deploy requires rust_api_image_digest and a public hostname."
+  }
+
+  assert {
+    condition     = !var.enable_rust_api_smoke_deploy || local.rust_api_smoke_edge_is_ready
+    error_message = "enable_rust_api_smoke_deploy requires LIN-963 edge resources (certificate map and named public IPv4) to be enabled."
+  }
 }
 
 module "network_foundation" {
@@ -35,6 +57,30 @@ module "gke_autopilot_minimal" {
   subnetwork_self_link          = module.network_foundation.gke_nodes_subnet_self_link
 }
 
+module "rust_api_smoke_deploy" {
+  count = local.enable_rust_api_smoke ? 1 : 0
+
+  source = "../../modules/rust_api_smoke_deploy"
+
+  certificate_map_name     = basename(module.network_foundation.public_certificate_map_name)
+  deployment_name          = "rust-api-smoke"
+  gateway_name             = "rust-api-gateway"
+  gateway_static_ip_name   = module.network_foundation.public_lb_ipv4_name
+  health_check_policy_name = "rust-api-healthcheck"
+  image                    = var.rust_api_image_digest
+  labels = {
+    environment = local.environment
+    issue       = "lin-1015"
+  }
+  namespace            = "rust-api-smoke"
+  public_hostname      = local.rust_api_public_hostname
+  route_name           = "rust-api-route"
+  service_account_name = "rust-api-smoke"
+  service_name         = "rust-api-smoke"
+
+  depends_on = [module.gke_autopilot_minimal]
+}
+
 output "environment" {
   value = local.environment
 }
@@ -53,4 +99,8 @@ output "artifact_registry_repository" {
 
 output "gke_autopilot_minimal" {
   value = var.enable_minimal_gke_cluster ? module.gke_autopilot_minimal[0] : null
+}
+
+output "rust_api_smoke_deploy" {
+  value = local.enable_rust_api_smoke ? module.rust_api_smoke_deploy[0] : null
 }

--- a/infra/environments/prod/providers.tf
+++ b/infra/environments/prod/providers.tf
@@ -3,3 +3,11 @@ provider "google" {
   region                      = var.region
   impersonate_service_account = var.terraform_admin_service_account_email != "" ? var.terraform_admin_service_account_email : null
 }
+
+data "google_client_config" "current" {}
+
+provider "kubernetes" {
+  host                   = var.enable_minimal_gke_cluster ? "https://${module.gke_autopilot_minimal[0].cluster_endpoint}" : null
+  token                  = data.google_client_config.current.access_token
+  cluster_ca_certificate = var.enable_minimal_gke_cluster ? base64decode(module.gke_autopilot_minimal[0].cluster_ca_certificate) : null
+}

--- a/infra/environments/prod/terraform.tfvars.example
+++ b/infra/environments/prod/terraform.tfvars.example
@@ -5,6 +5,9 @@ artifact_registry_repository_id = "application-images"
 # Optional: set when using service account impersonation.
 terraform_admin_service_account_email = "terraform-admin@linklynx-bootstrap.iam.gserviceaccount.com"
 enable_minimal_gke_cluster            = true
+enable_rust_api_smoke_deploy          = false
+rust_api_image_digest                 = "us-east1-docker.pkg.dev/linklynx-prod/application-images/rust@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+rust_api_public_hostname              = "api.example.com"
 
 # Fill these with the real production domain before plan/apply.
 public_dns_zone_name = "linklynx-prod-public"

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -45,3 +45,26 @@ variable "enable_minimal_gke_cluster" {
   type        = bool
   default     = true
 }
+
+variable "enable_rust_api_smoke_deploy" {
+  description = "Whether to create the prod Rust API smoke workload on the minimal cluster."
+  type        = bool
+  default     = false
+}
+
+variable "rust_api_public_hostname" {
+  description = "Public hostname without a trailing dot for the Rust API smoke route. Defaults to the first public hostname when empty."
+  type        = string
+  default     = ""
+}
+
+variable "rust_api_image_digest" {
+  description = "Artifact Registry image digest reference for the Rust API smoke workload."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.rust_api_image_digest == "" || can(regex("^.+@sha256:[a-f0-9]{64}$", var.rust_api_image_digest))
+    error_message = "rust_api_image_digest must be empty or a full image reference ending with @sha256:<64 lowercase hex>."
+  }
+}

--- a/infra/environments/prod/versions.tf
+++ b/infra/environments/prod/versions.tf
@@ -8,5 +8,9 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.32"
+    }
   }
 }

--- a/infra/modules/gke_autopilot_minimal/outputs.tf
+++ b/infra/modules/gke_autopilot_minimal/outputs.tf
@@ -10,6 +10,10 @@ output "cluster_endpoint" {
   value = google_container_cluster.this.endpoint
 }
 
+output "cluster_ca_certificate" {
+  value = google_container_cluster.this.master_auth[0].cluster_ca_certificate
+}
+
 output "node_service_account_email" {
   value = google_service_account.node.email
 }

--- a/infra/modules/network_foundation/outputs.tf
+++ b/infra/modules/network_foundation/outputs.tf
@@ -58,6 +58,10 @@ output "public_lb_ipv4_address" {
   value = google_compute_global_address.public_lb_ipv4.address
 }
 
+output "public_lb_ipv4_name" {
+  value = google_compute_global_address.public_lb_ipv4.name
+}
+
 output "public_dns_zone_name" {
   value = local.public_dns_enabled ? google_dns_managed_zone.public[0].name : null
 }

--- a/infra/modules/rust_api_smoke_deploy/main.tf
+++ b/infra/modules/rust_api_smoke_deploy/main.tf
@@ -1,0 +1,247 @@
+locals {
+  app_labels = merge(
+    {
+      app        = var.deployment_name
+      component  = "rust-api-smoke"
+      managed_by = "terraform"
+    },
+    var.labels,
+  )
+}
+
+resource "kubernetes_namespace_v1" "this" {
+  metadata {
+    name   = var.namespace
+    labels = local.app_labels
+  }
+}
+
+resource "kubernetes_service_account_v1" "this" {
+  metadata {
+    name      = var.service_account_name
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = local.app_labels
+  }
+
+  automount_service_account_token = false
+}
+
+resource "kubernetes_deployment_v1" "this" {
+  metadata {
+    name      = var.deployment_name
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = local.app_labels
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = local.app_labels
+    }
+
+    template {
+      metadata {
+        labels = local.app_labels
+      }
+
+      spec {
+        service_account_name             = kubernetes_service_account_v1.this.metadata[0].name
+        automount_service_account_token  = false
+        termination_grace_period_seconds = 120
+
+        container {
+          name              = "rust-api"
+          image             = var.image
+          image_pull_policy = "IfNotPresent"
+
+          port {
+            container_port = 8080
+            name           = "http"
+          }
+
+          env {
+            name  = "RUST_LOG"
+            value = "info"
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/health"
+              port = "http"
+            }
+
+            initial_delay_seconds = 5
+            period_seconds        = 10
+            timeout_seconds       = 2
+            failure_threshold     = 3
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/health"
+              port = "http"
+            }
+
+            initial_delay_seconds = 15
+            period_seconds        = 30
+            timeout_seconds       = 2
+            failure_threshold     = 3
+          }
+
+          resources {
+            requests = {
+              cpu               = var.cpu_request
+              memory            = var.memory_request
+              ephemeral-storage = var.ephemeral_storage_request
+            }
+            limits = {
+              cpu               = var.cpu_request
+              memory            = var.memory_request
+              ephemeral-storage = var.ephemeral_storage_request
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "this" {
+  metadata {
+    name      = var.service_name
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = local.app_labels
+  }
+
+  spec {
+    selector = local.app_labels
+
+    port {
+      name         = "http"
+      port         = 8080
+      target_port  = "http"
+      app_protocol = "HTTP"
+    }
+
+    type = "ClusterIP"
+  }
+}
+
+resource "kubernetes_manifest" "gateway" {
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name      = var.gateway_name
+      namespace = kubernetes_namespace_v1.this.metadata[0].name
+      annotations = {
+        "networking.gke.io/certmap" = var.certificate_map_name
+      }
+      labels = local.app_labels
+    }
+    spec = {
+      gatewayClassName = "gke-l7-global-external-managed"
+      addresses = [
+        {
+          type  = "NamedAddress"
+          value = var.gateway_static_ip_name
+        }
+      ]
+      listeners = [
+        {
+          name     = "https"
+          protocol = "HTTPS"
+          port     = 443
+          hostname = var.public_hostname
+          allowedRoutes = {
+            namespaces = {
+              from = "Same"
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  depends_on = [kubernetes_service_v1.this]
+}
+
+resource "kubernetes_manifest" "route" {
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "HTTPRoute"
+    metadata = {
+      name      = var.route_name
+      namespace = kubernetes_namespace_v1.this.metadata[0].name
+      labels    = local.app_labels
+    }
+    spec = {
+      parentRefs = [
+        {
+          name        = var.gateway_name
+          sectionName = "https"
+        }
+      ]
+      hostnames = [var.public_hostname]
+      rules = [
+        {
+          matches = [
+            {
+              path = {
+                type  = "PathPrefix"
+                value = "/"
+              }
+            }
+          ]
+          backendRefs = [
+            {
+              name = kubernetes_service_v1.this.metadata[0].name
+              port = 8080
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  depends_on = [kubernetes_manifest.gateway]
+}
+
+resource "kubernetes_manifest" "health_check_policy" {
+  manifest = {
+    apiVersion = "networking.gke.io/v1"
+    kind       = "HealthCheckPolicy"
+    metadata = {
+      name      = var.health_check_policy_name
+      namespace = kubernetes_namespace_v1.this.metadata[0].name
+      labels    = local.app_labels
+    }
+    spec = {
+      targetRef = {
+        group = ""
+        kind  = "Service"
+        name  = kubernetes_service_v1.this.metadata[0].name
+      }
+      default = {
+        checkIntervalSec   = 15
+        timeoutSec         = 5
+        healthyThreshold   = 1
+        unhealthyThreshold = 2
+        logConfig = {
+          enabled = true
+        }
+        config = {
+          type = "HTTP"
+          httpHealthCheck = {
+            portSpecification = "USE_FIXED_PORT"
+            port              = 8080
+            requestPath       = "/health"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_manifest.route]
+}

--- a/infra/modules/rust_api_smoke_deploy/outputs.tf
+++ b/infra/modules/rust_api_smoke_deploy/outputs.tf
@@ -1,0 +1,15 @@
+output "namespace" {
+  value = kubernetes_namespace_v1.this.metadata[0].name
+}
+
+output "service_name" {
+  value = kubernetes_service_v1.this.metadata[0].name
+}
+
+output "gateway_name" {
+  value = var.gateway_name
+}
+
+output "public_hostname" {
+  value = var.public_hostname
+}

--- a/infra/modules/rust_api_smoke_deploy/variables.tf
+++ b/infra/modules/rust_api_smoke_deploy/variables.tf
@@ -1,0 +1,84 @@
+variable "namespace" {
+  description = "Namespace for the smoke workload."
+  type        = string
+}
+
+variable "service_account_name" {
+  description = "Kubernetes service account name for the smoke workload."
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "Deployment name."
+  type        = string
+}
+
+variable "service_name" {
+  description = "Service name."
+  type        = string
+}
+
+variable "gateway_name" {
+  description = "Gateway name."
+  type        = string
+}
+
+variable "route_name" {
+  description = "HTTPRoute name."
+  type        = string
+}
+
+variable "health_check_policy_name" {
+  description = "HealthCheckPolicy name."
+  type        = string
+}
+
+variable "public_hostname" {
+  description = "Public hostname without a trailing dot."
+  type        = string
+}
+
+variable "gateway_static_ip_name" {
+  description = "Name of the reserved global static IP resource."
+  type        = string
+}
+
+variable "certificate_map_name" {
+  description = "Short certificate map name used by the Gateway annotation."
+  type        = string
+}
+
+variable "image" {
+  description = "Container image including immutable digest."
+  type        = string
+}
+
+variable "cpu_request" {
+  description = "CPU request baseline."
+  type        = string
+  default     = "500m"
+}
+
+variable "memory_request" {
+  description = "Memory request baseline."
+  type        = string
+  default     = "512Mi"
+}
+
+variable "ephemeral_storage_request" {
+  description = "Ephemeral storage request baseline."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "replicas" {
+  description = "Replica count for the smoke workload."
+  type        = number
+  default     = 1
+}
+
+variable "labels" {
+  description = "Additional labels."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## 概要
- prod-only の low-budget path 向けに Rust API smoke workload を Terraform 管理へ追加
- GCP native edge の named static IP / certificate map を使う最小公開経路を追加
- apply・rollback・確認手順と前提条件を docs に追記

## 変更内容
- prod root に Kubernetes provider と smoke deploy 用の module wiring を追加
- namespace / service account / deployment / service / Gateway / HTTPRoute / HealthCheckPolicy を Terraform 定義
- image digest と public hostname を変数化し、前提不足時は Terraform check で fail-fast するように変更
- low-budget path の運用メモと rollback 手順を infra docs に追加

## 動作確認
- `terraform fmt -check -recursive infra`
- `PATH=/tmp/terraform_1.6.6:$PATH make infra-validate`
- `make validate`

## 補足
- `terraform plan` はこの workspace に backend 用 `backend.hcl` がなく、`backend "gcs" {}` を含む root を local で安定再現できないため、実環境での確認前提です

## ADR-001 チェック
- [x] 関連 docs / runbook を確認し、今回の変更は `docs/runbooks/edge-rest-ws-routing-drain-runbook.md` と整合しています
- [x] event schema / DB contract の変更はありません
- [x] 互換性を壊す変更はありません