### PR TITLE
infra: LIN-1017 prod-only path の Cloud SQL baseline を整備

### DIFF
--- a/docs/agent_runs/LIN-1017/Documentation.md
+++ b/docs/agent_runs/LIN-1017/Documentation.md
@@ -1,0 +1,21 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now: Cloud SQL baseline module と runbook の実装、validation は完了
+- Next: self-review をまとめて commit / PR 化する
+
+## Decisions
+- 標準 `LIN-968` とは別に、low-budget sibling として `LIN-1017` を起票した
+- low-budget path では `prod-only` / single instance / no HA / no read replica を baseline にする
+- app 接続や migration executor の具体接続方式は後続 issue に分離する
+- Cloud SQL baseline では password / `DATABASE_URL` の実値を Terraform 管理せず、instance と運用境界だけ先に固定する
+- local `terraform plan` は一時 workspace で backend stanza を外せば module 解決までは進むが、最終的には ADC 不在で停止する
+
+## Validation log
+- `terraform fmt -check -recursive infra`
+- `PATH=/tmp/terraform_1.6.6:$PATH make infra-validate`
+- `make validate`
+- `git diff --check`
+- `terraform plan`
+  - 一時 workspace で backend stanza を外した検証では module 解決まで成功
+  - 最終的には `google` provider の ADC 不在で停止 (`could not find default credentials`)

--- a/docs/agent_runs/LIN-1017/Implement.md
+++ b/docs/agent_runs/LIN-1017/Implement.md
@@ -1,0 +1,11 @@
+# Implement.md
+
+## Scope
+- `prod-only` Cloud SQL module を追加する
+- prod environment に wiring する
+- Cloud SQL 前提の migration / PITR docs を追加・更新する
+
+## Non-goals
+- application runtime の Cloud SQL 接続切替
+- Cloud SQL Auth Proxy 導入
+- HA / read replica / staging instance

--- a/docs/agent_runs/LIN-1017/Plan.md
+++ b/docs/agent_runs/LIN-1017/Plan.md
@@ -1,0 +1,23 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: validation が落ちたら次へ進む前に直す。
+
+## Milestones
+### M1: prod-only Cloud SQL baseline module を Terraform 化する
+- Acceptance criteria:
+  - [x] Cloud SQL instance / database baseline module がある
+  - [x] prod root に low-budget path の toggle と output がある
+  - [x] private IP / backup / PITR / maintenance / deletion protection を定義する
+- Validation:
+  - `terraform fmt -check -recursive infra`
+  - `PATH=/tmp/terraform_1.6.6:$PATH make infra-validate`
+
+### M2: docs / runbook を Cloud SQL 前提へ寄せる
+- Acceptance criteria:
+  - [x] low-budget profile と standard profile の差分が説明される
+  - [x] PITR runbook と migration runbook が Cloud SQL 前提で揃う
+  - [x] `make validate` と validation log が残る
+- Validation:
+  - `make validate`
+  - `git diff --check`

--- a/docs/agent_runs/LIN-1017/Prompt.md
+++ b/docs/agent_runs/LIN-1017/Prompt.md
@@ -1,0 +1,13 @@
+# Prompt.md
+
+## User request
+- 次のインフラ issue を順番に実装する
+- 現在の low-budget `prod-only` path を維持する
+
+## Target issue
+- `LIN-1017` `[08a] prod-only path の Cloud SQL baseline と PITR / migration runbook を整備する`
+
+## Constraints
+- `1 issue = 1 PR`
+- Terraform で baseline を再現可能にする
+- app 接続実装や Auth Proxy 導入までは広げない

--- a/docs/infra/01_decisions.md
+++ b/docs/infra/01_decisions.md
@@ -90,7 +90,7 @@
 
 | DB | ホスティング | 理由 |
 |----|------------|------|
-| **PostgreSQL** | Cloud SQL（マネージド） | PITR/HA/バックアップ自動。運用負荷最小 |
+| **PostgreSQL** | Cloud SQL（マネージド） | PITR/バックアップ自動。標準 path は HA を検討、low-budget path は `prod-only` 単一 instance から開始 |
 | **ScyllaDB** | ScyllaDB Cloud or GCE 専用 | K8s 外。Autopilot の制限回避 |
 | **Dragonfly** | K8s 上 StatefulSet | 軽量。Redis 互換 |
 | **Redpanda** | K8s 上 Helm chart | 公式 Operator あり |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -18,3 +18,4 @@
 - `profile-media-gcs-operations-runbook.md`: Profile avatar/banner signed URL issuance, same-bucket upload/download verification, and runtime credential triage baseline.
 - `redpanda-topic-retention-replay-runbook.md`: Redpanda topic naming/retention change controls, replay execution, outage recovery, and rollback baseline for v1 event stream operations.
 - `workload-identity-secret-manager-operations-runbook.md`: Workload Identity, secret-level IAM, audit-log verification, and secret rotation/rollback baseline for the low-budget prod-only path.
+- `cloud-sql-postgres-migration-operations-runbook.md`: Cloud SQL-backed PostgreSQL forward-only migration gate, manual approval boundary, and failure-handling baseline for the low-budget prod-only path.

--- a/docs/runbooks/cloud-sql-postgres-migration-operations-runbook.md
+++ b/docs/runbooks/cloud-sql-postgres-migration-operations-runbook.md
@@ -1,0 +1,91 @@
+# Cloud SQL Postgres Migration Operations Runbook
+
+- Status: Draft
+- Last updated: 2026-03-29
+- Owner scope: Cloud SQL / PostgreSQL schema operations
+- References:
+  - `database/contracts/lin588_postgres_operations_baseline.md`
+  - `docs/DATABASE.md`
+  - `docs/runbooks/postgres-pitr-runbook.md`
+  - `LIN-1017`
+
+## 1. Purpose and scope
+
+This runbook defines the forward-only migration baseline for the Cloud SQL-backed PostgreSQL production path.
+
+In scope:
+
+- Pre-check gates before applying production migrations
+- Operator approval and execution flow
+- Post-check and rollback boundaries
+
+Out of scope:
+
+- Application-side database client changes
+- Cloud SQL Auth Proxy rollout details
+- Backward-incompatible schema changes
+
+## 2. Principles
+
+- The source of truth remains `database/postgres/migrations`.
+- Migrations are append-only. Editing existing migration files is prohibited.
+- Production rollback is **application rollback + corrective forward migration** only.
+- Restore or PITR is reserved for data-loss or consistency incidents, not normal schema rollback.
+
+## 3. Environment policy
+
+| Environment | Validation / apply rule |
+| --- | --- |
+| local | `docker compose` + `make db-migrate` for fast feedback |
+| staging | Not provisioned in the low-budget path. Use local or temporary validation environment. |
+| prod | Manual approval required before execution |
+
+## 4. Pre-checks before prod migration
+
+All of the following must be true:
+
+1. Migration diff is reviewed and consistent with forward-only policy.
+2. A recent automated backup exists.
+3. PITR is enabled and the restore window covers the expected rollback decision point.
+4. The operator running the migration has private reachability and approved credentials for Cloud SQL.
+5. The deploy plan identifies application rollout order and failure owner.
+
+## 5. Standard execution flow
+
+1. Validate the migration locally against the repo baseline.
+2. Confirm the target migration list and expected DDL impact.
+3. Freeze unrelated deploys.
+4. Take note of:
+   - current application revision
+   - Cloud SQL instance name
+   - latest successful backup time
+   - earliest / latest restore time
+5. Obtain explicit manual approval for prod execution.
+6. Execute the migration from an approved runner with Cloud SQL private reachability.
+7. Run post-checks immediately after apply.
+
+## 6. Post-checks
+
+After apply, confirm:
+
+1. Migration state is consistent (`sqlx migrate info` or equivalent).
+2. Core metadata reads succeed.
+3. Connection pressure stays within the LIN-588 thresholds.
+4. Error rate and latency do not regress during the first observation window.
+
+## 7. Failure handling
+
+If migration apply fails:
+
+1. Stop further rollout.
+2. Roll back application traffic if needed.
+3. Decide between:
+   - corrective forward migration, or
+   - PITR / restore procedure via `docs/runbooks/postgres-pitr-runbook.md`
+4. Record failure reason, data impact, and next action in the incident log.
+
+## 8. Low-budget path notes
+
+- `LIN-1017` uses a single prod Cloud SQL instance and does not include HA or read replicas.
+- Shared-core / small-instance profiles are bootstrap-only choices and should be upgraded before meaningful production traffic.
+- A standard production profile should move to dedicated-core and revisit HA before release risk becomes material.

--- a/docs/runbooks/postgres-pitr-runbook.md
+++ b/docs/runbooks/postgres-pitr-runbook.md
@@ -1,13 +1,15 @@
-# PostgreSQL PITR Runbook (Draft)
+# PostgreSQL PITR Runbook
 
 - Status: Draft
-- Last updated: 2026-02-26
-- Owner scope: Postgres operations (v0 baseline)
+- Last updated: 2026-03-29
+- Owner scope: Postgres / Cloud SQL operations (v0 baseline)
 - References:
   - `database/contracts/lin588_postgres_operations_baseline.md`
   - `docs/DATABASE.md`
+  - `docs/runbooks/cloud-sql-postgres-migration-operations-runbook.md`
   - `LIN-588`
   - `LIN-597`
+  - `LIN-1017`
 
 ## 1. Purpose and scope
 
@@ -17,12 +19,12 @@ In scope:
 
 - PITR start decision
 - Target recovery timestamp decision
+- Cloud SQL restore / clone-from-earlier-point procedure baseline
 - Standard restore, validation, and resume procedure
 - Tabletop drill checklist and record template
 
 Out of scope:
 
-- Vendor-specific operation details
 - Production auto-recovery implementation
 - v1 advanced DR operations
 
@@ -66,24 +68,32 @@ After the decision, record start time, expected recovery time, and target timest
 2. Select the point that preserves consistency with minimum loss.
 3. Confirm the selected point is within the RPO target (15 minutes).
 
-### 5.2 Execute restore
+### 5.2 Prepare Cloud SQL restore
 
 1. Stop write paths or switch to maintenance mode.
-2. Prepare restore target instance.
-3. Restore to target timestamp from validated backups/logs.
-4. Run baseline health checks on restored instance.
+2. Record the source instance name, latest successful backup, and earliest / latest restore time.
+3. Prepare a **new restore target instance**. Do not overwrite the source instance in-place.
+4. Choose the target timestamp and instance naming convention before execution.
 
-### 5.3 Validate data and contract consistency
+### 5.3 Execute restore
+
+1. Create a restored clone from the selected point in time.
+2. Wait for restore completion and baseline instance health.
+3. Run validation against the restored instance before any traffic cutover.
+
+### 5.4 Validate data and contract consistency
 
 1. Verify migration applied-state consistency (no divergence).
 2. Validate core table reads.
 3. Validate connectivity for required critical queries.
+4. Confirm the restored instance exposes the expected earliest / latest restore window after recovery.
 
-### 5.4 Resume service
+### 5.5 Resume service
 
 1. Resume read paths first.
 2. Resume write paths gradually after read-path stability.
 3. Keep enhanced monitoring and judge full recovery against RTO.
+4. Keep the source instance isolated until the incident close decision is recorded.
 
 ## 6. Close decision
 
@@ -111,7 +121,13 @@ Escalate immediately when any of the following is true:
 4. Verify close conditions can be judged objectively.
 5. Record follow-up improvements in a format reusable by LIN-597.
 
-## 9. Drill record template
+## 9. Cloud SQL-specific notes
+
+- `LIN-1017` low-budget baseline assumes a single prod instance with backup + PITR enabled and no HA.
+- PITR should restore into a separate instance, then cut over after validation.
+- Schema rollback still follows the forward-only rule. PITR is reserved for data-loss or consistency incidents that corrective forward migration cannot address in time.
+
+## 10. Drill record template
 
 ```markdown
 ### Postgres PITR Drill Record

--- a/infra/README.md
+++ b/infra/README.md
@@ -273,3 +273,38 @@ low-budget path では `External Secrets Operator` をまだ入れず、`Workloa
 - secret の実値投入
 - External Secrets Operator
 - GitOps 連携
+
+## LIN-1017 prod-only Cloud SQL baseline
+
+low-budget path では `LIN-968` の `staging + prod / 4 vCPU + 16 GB` baseline をそのまま採らず、`prod-only` の単一 Cloud SQL instance から始める。
+
+### Why a sibling issue
+
+- `Cloud SQL` は low-budget path の中でもコスト影響が大きい
+- `LIN-1014` 以降の prod-only path と、標準 path の `staging + prod` baseline を混ぜたくない
+- まず `private IP + backup + PITR + deletion protection` を code 化して、app connectivity や HA は後続へ分離したい
+
+### Baseline
+
+- environment: `prod` only
+- instance count: 1
+- availability: `ZONAL`
+- read replica: none
+- private IP only
+- backup: enabled
+- PITR: enabled
+- maintenance window: fixed
+- deletion protection: enabled
+
+### Cost profile note
+
+- default tier は `db-g1-small` を bootstrap profile として置く
+- これは long-term production size ではなく、初期構築と最小運用線のための profile
+- traffic / migration risk / SLO が立ち上がったら、標準 path に寄せて dedicated-core + HA を検討する
+
+### What stays out of scope
+
+- DB password や runtime `DATABASE_URL` の実値管理
+- Cloud SQL Auth Proxy 導入
+- app runtime 側の TLS / connection change
+- staging 常設 instance

--- a/infra/environments/prod/README.md
+++ b/infra/environments/prod/README.md
@@ -96,11 +96,39 @@ default では `linklynx-prod-rust-api-smoke-runtime` という placeholder secr
 - secret value の rotation と audit log の見方は `docs/runbooks/workload-identity-secret-manager-operations-runbook.md` を使う
 - low-budget path では ESO を入れず、runtime が ADC で Secret Manager API を読む前提に寄せる
 
+## LIN-1017 prod-only Cloud SQL baseline
+
+`LIN-1017` は low-budget path 向けに、`prod` だけの Cloud SQL for PostgreSQL baseline を追加する。
+
+### 使う変数
+
+- `enable_minimal_cloud_sql_baseline`
+- `minimal_cloud_sql_tier`
+- `minimal_cloud_sql_database_name`
+- `minimal_cloud_sql_disk_size_gb`
+
+default では `enable_minimal_cloud_sql_baseline = false` にしている。
+Cloud SQL は low-budget path の中でも費用インパクトが大きいため、明示的に有効化したときだけ作る。
+
+### 作られるもの
+
+- Cloud SQL for PostgreSQL instance
+- application database (`linklynx`)
+- private IP / backup / PITR / maintenance / deletion protection baseline
+
+### 運用メモ
+
+- low-budget profile は `db-g1-small` を baseline にするが、これは bootstrap 用の暫定 profile として扱う
+- HA / read replica は含めない
+- DB password や runtime 接続方式はこの issue では作らず、後続で Secret Manager / app connectivity 側に分離する
+- migration 手順は `docs/runbooks/cloud-sql-postgres-migration-operations-runbook.md`、PITR は `docs/runbooks/postgres-pitr-runbook.md` を使う
+
 ## tfvars で埋める値
 
 - `public_dns_zone_name`
 - `public_dns_name`
 - `public_hostnames`
 - `artifact_registry_repository_id` (default `application-images`)
+- `enable_minimal_cloud_sql_baseline` とその profile 値
 
 prod は `api.<domain>` を起点にし、後続 issue で必要な host を追加する。

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -5,6 +5,7 @@ locals {
   enable_rust_api_smoke         = var.enable_rust_api_smoke_deploy && var.enable_minimal_gke_cluster
   rust_api_smoke_inputs_are_set = var.rust_api_image_digest != "" && local.rust_api_public_hostname != ""
   rust_api_smoke_edge_is_ready  = module.network_foundation.public_certificate_map_name != null && module.network_foundation.public_lb_ipv4_name != ""
+  enable_minimal_cloud_sql      = var.enable_minimal_cloud_sql_baseline
 }
 
 check "rust_api_smoke_prerequisites" {
@@ -119,6 +120,27 @@ module "rust_api_smoke_deploy" {
   ]
 }
 
+module "cloud_sql_postgres_minimal" {
+  count = local.enable_minimal_cloud_sql ? 1 : 0
+
+  source = "../../modules/cloud_sql_postgres_minimal"
+
+  allocated_ip_range_name = module.network_foundation.private_service_access_range_name
+  database_name           = var.minimal_cloud_sql_database_name
+  disk_size_gb            = var.minimal_cloud_sql_disk_size_gb
+  environment             = local.environment
+  labels = {
+    environment = local.environment
+    issue       = "lin-1017"
+  }
+  network_self_link = module.network_foundation.network_self_link
+  project_id        = var.project_id
+  region            = var.region
+  tier              = var.minimal_cloud_sql_tier
+
+  depends_on = [module.network_foundation]
+}
+
 output "environment" {
   value = local.environment
 }
@@ -145,4 +167,8 @@ output "rust_api_runtime_identity" {
 
 output "rust_api_smoke_deploy" {
   value = local.enable_rust_api_smoke ? module.rust_api_smoke_deploy[0] : null
+}
+
+output "cloud_sql_postgres_minimal" {
+  value = local.enable_minimal_cloud_sql ? module.cloud_sql_postgres_minimal[0] : null
 }

--- a/infra/environments/prod/terraform.tfvars.example
+++ b/infra/environments/prod/terraform.tfvars.example
@@ -6,8 +6,11 @@ artifact_registry_repository_id = "application-images"
 terraform_admin_service_account_email = "terraform-admin@linklynx-bootstrap.iam.gserviceaccount.com"
 enable_minimal_gke_cluster            = true
 enable_rust_api_smoke_deploy          = false
+enable_minimal_cloud_sql_baseline     = false
 rust_api_image_digest                 = "us-east1-docker.pkg.dev/linklynx-prod/application-images/rust@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 rust_api_public_hostname              = "api.example.com"
+minimal_cloud_sql_tier                = "db-g1-small"
+minimal_cloud_sql_database_name       = "linklynx"
 
 # Fill these with the real production domain before plan/apply.
 public_dns_zone_name = "linklynx-prod-public"

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -74,3 +74,27 @@ variable "rust_api_runtime_secret_ids" {
   type        = set(string)
   default     = ["linklynx-prod-rust-api-smoke-runtime"]
 }
+
+variable "enable_minimal_cloud_sql_baseline" {
+  description = "Whether to create the low-budget prod-only Cloud SQL baseline."
+  type        = bool
+  default     = false
+}
+
+variable "minimal_cloud_sql_database_name" {
+  description = "Application database name for the low-budget Cloud SQL baseline."
+  type        = string
+  default     = "linklynx"
+}
+
+variable "minimal_cloud_sql_tier" {
+  description = "Cloud SQL machine tier for the low-budget prod-only baseline."
+  type        = string
+  default     = "db-g1-small"
+}
+
+variable "minimal_cloud_sql_disk_size_gb" {
+  description = "Initial storage size for the low-budget Cloud SQL baseline."
+  type        = number
+  default     = 20
+}

--- a/infra/modules/cloud_sql_postgres_minimal/main.tf
+++ b/infra/modules/cloud_sql_postgres_minimal/main.tf
@@ -1,0 +1,63 @@
+locals {
+  instance_name = var.instance_name != "" ? var.instance_name : "linklynx-${var.environment}-postgres"
+  labels = merge(
+    {
+      component    = "cloud-sql"
+      cost_profile = "low-budget"
+      environment  = var.environment
+      issue        = "lin-1017"
+      managed_by   = "terraform"
+    },
+    var.labels,
+  )
+}
+
+resource "google_sql_database_instance" "this" {
+  project          = var.project_id
+  name             = local.instance_name
+  region           = var.region
+  database_version = var.database_version
+
+  deletion_protection = var.deletion_protection
+
+  settings {
+    tier                        = var.tier
+    availability_type           = var.availability_type
+    disk_type                   = var.disk_type
+    disk_size                   = var.disk_size_gb
+    disk_autoresize             = var.disk_autoresize
+    deletion_protection_enabled = var.deletion_protection
+    user_labels                 = local.labels
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = var.point_in_time_recovery_enabled
+      start_time                     = var.backup_start_time
+      transaction_log_retention_days = var.transaction_log_retention_days
+
+      backup_retention_settings {
+        retained_backups = var.retained_backups
+        retention_unit   = "COUNT"
+      }
+    }
+
+    ip_configuration {
+      ipv4_enabled       = false
+      private_network    = var.network_self_link
+      allocated_ip_range = var.allocated_ip_range_name
+      ssl_mode           = "ENCRYPTED_ONLY"
+    }
+
+    maintenance_window {
+      day          = var.maintenance_day
+      hour         = var.maintenance_hour
+      update_track = var.maintenance_update_track
+    }
+  }
+}
+
+resource "google_sql_database" "application" {
+  project  = var.project_id
+  instance = google_sql_database_instance.this.name
+  name     = var.database_name
+}

--- a/infra/modules/cloud_sql_postgres_minimal/outputs.tf
+++ b/infra/modules/cloud_sql_postgres_minimal/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_name" {
+  value = google_sql_database_instance.this.name
+}
+
+output "connection_name" {
+  value = google_sql_database_instance.this.connection_name
+}
+
+output "private_ip_address" {
+  value = google_sql_database_instance.this.private_ip_address
+}
+
+output "database_name" {
+  value = google_sql_database.application.name
+}
+
+output "self_link" {
+  value = google_sql_database_instance.this.self_link
+}

--- a/infra/modules/cloud_sql_postgres_minimal/variables.tf
+++ b/infra/modules/cloud_sql_postgres_minimal/variables.tf
@@ -1,0 +1,126 @@
+variable "environment" {
+  description = "Environment name."
+  type        = string
+}
+
+variable "project_id" {
+  description = "Target GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "Primary region for the Cloud SQL instance."
+  type        = string
+}
+
+variable "network_self_link" {
+  description = "Self link of the VPC used for private IP connectivity."
+  type        = string
+}
+
+variable "allocated_ip_range_name" {
+  description = "Private services access range name reserved for Google-managed producer services."
+  type        = string
+}
+
+variable "instance_name" {
+  description = "Optional override for the Cloud SQL instance name."
+  type        = string
+  default     = ""
+}
+
+variable "database_name" {
+  description = "Application database name to create."
+  type        = string
+  default     = "linklynx"
+}
+
+variable "database_version" {
+  description = "Cloud SQL PostgreSQL version."
+  type        = string
+  default     = "POSTGRES_16"
+}
+
+variable "tier" {
+  description = "Cloud SQL machine tier."
+  type        = string
+  default     = "db-g1-small"
+}
+
+variable "availability_type" {
+  description = "Cloud SQL availability type."
+  type        = string
+  default     = "ZONAL"
+}
+
+variable "disk_type" {
+  description = "Storage type."
+  type        = string
+  default     = "PD_SSD"
+}
+
+variable "disk_size_gb" {
+  description = "Initial storage size in GB."
+  type        = number
+  default     = 20
+}
+
+variable "disk_autoresize" {
+  description = "Whether Cloud SQL can increase storage automatically."
+  type        = bool
+  default     = true
+}
+
+variable "deletion_protection" {
+  description = "Protect the Cloud SQL instance from deletion in Terraform and GCP."
+  type        = bool
+  default     = true
+}
+
+variable "backup_start_time" {
+  description = "Daily backup start time in UTC, HH:MM."
+  type        = string
+  default     = "03:00"
+}
+
+variable "retained_backups" {
+  description = "Number of retained automated backups."
+  type        = number
+  default     = 7
+}
+
+variable "transaction_log_retention_days" {
+  description = "PITR transaction log retention period in days."
+  type        = number
+  default     = 7
+}
+
+variable "point_in_time_recovery_enabled" {
+  description = "Whether PITR is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "maintenance_day" {
+  description = "Maintenance window day (1-7)."
+  type        = number
+  default     = 7
+}
+
+variable "maintenance_hour" {
+  description = "Maintenance window hour in UTC (0-23)."
+  type        = number
+  default     = 4
+}
+
+variable "maintenance_update_track" {
+  description = "Maintenance update track."
+  type        = string
+  default     = "stable"
+}
+
+variable "labels" {
+  description = "Additional resource labels."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## 概要
- low-budget prod-only path 向けの Cloud SQL for PostgreSQL baseline module を追加
- prod root に Cloud SQL toggle / variables / outputs を配線
- Cloud SQL 前提の migration runbook と PITR runbook を整備

## 変更内容
- infra/modules/cloud_sql_postgres_minimal を追加し、private IP / backup / PITR / maintenance / deletion protection baseline を定義
- infra/environments/prod に enable_minimal_cloud_sql_baseline と Cloud SQL profile 変数を追加
- docs/runbooks/cloud-sql-postgres-migration-operations-runbook.md を追加
- docs/runbooks/postgres-pitr-runbook.md を Cloud SQL 前提の restore / cutover 手順へ更新
- infra/README.md と infra/environments/prod/README.md に low-budget Cloud SQL path と標準 path の差分を追記

## ADR-001 checklist
- [x] docs / contracts / runbook の参照先を確認した
- [x] 互換性を壊すイベント / API 変更は含まない
- [x] out-of-scope な app runtime 変更は含めない

## テスト
- terraform fmt -check -recursive infra
- PATH=/tmp/terraform_1.6.6:$PATH make infra-validate
- make validate
- git diff --check

## 補足
- terraform plan は一時 workspace で backend stanza を外した検証を行い、module 解決までは成功しました
- 最終的には google provider の ADC 不在により停止したため、実環境での plan/apply は別途確認が必要です
- 本 PR は codex/lin-1016-prod-iam-secret-manager の上に積んだ stacked PR です
