### PR TITLE
docs: LIN-1020 prod-only path の ops baseline を整備

### DIFF
--- a/docs/agent_runs/LIN-1020/Documentation.md
+++ b/docs/agent_runs/LIN-1020/Documentation.md
@@ -1,0 +1,16 @@
+# Documentation.md (Status / audit log)
+
+## Current status
+- Now: low-budget ops baseline 実装と検証が完了し、PR 化の最終整理段階
+- Next: commit / push / PR 作成と Linear 更新
+
+## Decisions
+- 標準 `LIN-974` とは別に、low-budget sibling として `LIN-1020` を起票した
+- low-budget path では incident flow / postmortem / capacity assumption を docs で先に固定する
+
+## Validation log
+- `make validate`
+- `git diff --check`
+- manual self-review:
+  - docs-only change であることを確認
+  - UI change なしのため UI review は不要

--- a/docs/agent_runs/LIN-1020/Implement.md
+++ b/docs/agent_runs/LIN-1020/Implement.md
@@ -1,0 +1,11 @@
+# Implement.md
+
+## Scope
+- incident flow runbook を追加する
+- postmortem template を追加する
+- low-budget ops baseline を infra docs に反映する
+
+## Non-goals
+- PagerDuty / Opsgenie integration
+- standard path の full operating model
+- 実 traffic を前提にした精密 capacity modeling

--- a/docs/agent_runs/LIN-1020/Plan.md
+++ b/docs/agent_runs/LIN-1020/Plan.md
@@ -1,0 +1,23 @@
+# Plan.md (Milestones + validations)
+
+## Rules
+- Stop-and-fix: validation が落ちたら次へ進む前に直す。
+
+## Milestones
+### M1: low-budget incident / capacity baseline を runbook 化する
+- Acceptance criteria:
+  - [x] incident flow が runbook として書かれている
+  - [x] capacity assumptions と scale trigger が明文化されている
+  - [x] chaos readiness 条件が固定日ではなく条件ベースで定義されている
+- Validation:
+  - `make validate`
+  - `git diff --check`
+
+### M2: postmortem template と docs 差分を整える
+- Acceptance criteria:
+  - [x] postmortem template がある
+  - [x] low-budget path と標準 path の運用差分が docs に記載される
+  - [x] validation log が残る
+- Validation:
+  - `make validate`
+  - `git diff --check`

--- a/docs/agent_runs/LIN-1020/Prompt.md
+++ b/docs/agent_runs/LIN-1020/Prompt.md
@@ -1,0 +1,13 @@
+# Prompt.md
+
+## User request
+- 次のインフラ issue を順番に実装する
+- 現在の low-budget `prod-only` path を維持する
+
+## Target issue
+- `LIN-1020` `[14a] prod-only path の incident / postmortem / capacity baseline を整備する`
+
+## Constraints
+- `1 issue = 1 PR`
+- docs / runbook 中心で閉じる
+- PagerDuty など新しい外部通知基盤の導入までは広げない

--- a/docs/infra/01_decisions.md
+++ b/docs/infra/01_decisions.md
@@ -147,6 +147,15 @@
 | 標準 path 拡張 | **External Secrets Operator** を後続で検討 |
 | 方針 | Git にシークレットは入れない。初期は長期静的キーを排除し、secret-level IAM と audit log を優先する |
 
+### 10. 運用 baseline
+
+| 項目 | 決定 |
+|------|------|
+| low-budget incident flow | **Discord thread + `hirwatan` / `sabe` / `miwasa` mention** |
+| postmortem | **軽量 template を使って毎回残す** |
+| capacity trigger | **登録者数ではなく observed traffic / latency / DB pressure を優先** |
+| Chaos Engineering | **固定日ではなく readiness 条件が揃ってから開始** |
+
 ---
 
 ## フェーズ計画（概要）

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -21,3 +21,5 @@
 - `cloud-sql-postgres-migration-operations-runbook.md`: Cloud SQL-backed PostgreSQL forward-only migration gate, manual approval boundary, and failure-handling baseline for the low-budget prod-only path.
 - `cloud-monitoring-low-budget-operations-runbook.md`: Cloud Monitoring + Cloud Logging baseline, optional notification channel routing, and low-budget prod-only alert triage flow.
 - `cloud-armor-low-budget-operations-runbook.md`: Cloud Armor backend attachment, baseline WAF rules, and low-budget prod-only security verify/rollback flow.
+- `incident-low-budget-operations-runbook.md`: low-budget prod-only incident flow, Discord mention baseline, capacity assumptions, and chaos readiness checklist.
+- `postmortem-low-budget-template.md`: reusable low-budget postmortem template for incident close-out and follow-up actions.

--- a/docs/runbooks/incident-low-budget-operations-runbook.md
+++ b/docs/runbooks/incident-low-budget-operations-runbook.md
@@ -1,0 +1,147 @@
+# Incident Low-Budget Operations Runbook
+
+- Status: Draft
+- Last updated: 2026-03-29
+- Owner scope: low-budget `prod-only` incident / capacity baseline
+- References:
+  - `docs/runbooks/cloud-monitoring-low-budget-operations-runbook.md`
+  - `docs/runbooks/cloud-armor-low-budget-operations-runbook.md`
+  - `docs/runbooks/postgres-pitr-runbook.md`
+  - `LIN-1020`
+
+## 1. Purpose and scope
+
+This runbook defines the initial operating flow for the low-budget `prod-only` path.
+
+In scope:
+
+- first-response incident flow
+- Discord mention and ownership handoff
+- initial capacity assumptions and scale triggers
+- Chaos Engineering readiness conditions
+
+Out of scope:
+
+- PagerDuty / Opsgenie / dedicated on-call tooling
+- multi-region / multi-cloud DR execution
+- standard-path full operating model
+
+## 2. Contact baseline
+
+Initial incident mentions go to:
+
+- `hirwatan`
+- `sabe`
+- `miwasa`
+
+Communication baseline:
+
+1. Open an incident thread in Discord.
+2. Mention the three baseline contacts above.
+3. Record:
+   - start time
+   - affected surface (`/health`, `/ws`, DB, WAF, login, etc.)
+   - user-visible impact
+   - current mitigation owner
+
+## 3. Severity guide
+
+- `SEV-1`
+  - `/health` unavailable from public edge
+  - WebSocket connect path broadly unavailable
+  - data-loss or restore decision candidate
+- `SEV-2`
+  - sustained Cloud SQL CPU pressure
+  - repeated Rust API restart burst
+  - Cloud Armor false positive that blocks legitimate core traffic
+- `SEV-3`
+  - partial degradation
+  - noisy alert without broad user impact
+  - capacity warning without current outage
+
+## 4. First 15 minutes
+
+1. Confirm whether the issue is edge, workload, database, or security-policy related.
+2. Check Cloud Monitoring dashboard and the active alert policy first.
+3. Follow the linked specialist runbook:
+   - Rust restart / Cloud SQL pressure: `cloud-monitoring-low-budget-operations-runbook.md`
+   - WAF false positive / security attach: `cloud-armor-low-budget-operations-runbook.md`
+   - restore decision: `postgres-pitr-runbook.md`
+4. Decide one of:
+   - mitigate in place
+   - roll back recent Terraform / image change
+   - enter database incident handling
+5. Record the decision and owner in the Discord incident thread.
+
+## 5. Capacity assumptions
+
+This baseline is intentionally conservative because the low-budget path uses:
+
+- single region: `us-east1`
+- `prod-only` cluster
+- one initial runtime path centered on Rust API
+- low-budget Cloud SQL baseline
+
+Planning envelope:
+
+- registered users: `10,000 - 100,000`
+- active users may eventually reach the same order of magnitude, but scaling decisions must use observed traffic rather than account count alone
+
+Initial operating envelope for the low-budget path:
+
+- peak concurrent WebSocket connections: `500 - 2,000`
+- sustained message ingress: `50 - 200 msg/s`
+- REST API latency target: `P95 <= 300ms`, `P99 <= 800ms`
+- WebSocket reconnect target during incidents/rollouts: `P95 <= 10s`
+
+These are operating assumptions, not product guarantees.
+
+## 6. Scale triggers
+
+Open a capacity review issue and consider moving toward the standard path when any of the following becomes sustained:
+
+1. peak concurrent WebSocket connections exceed `2,000`
+2. message ingress exceeds `200 msg/s` for 15 minutes
+3. Cloud SQL CPU alert repeats for 3 consecutive windows after query / rollout checks
+4. Rust API restart burst repeats outside rollout windows
+5. REST `P95` exceeds `300ms` or `P99` exceeds `800ms` for 3 consecutive 5-minute windows
+6. monthly cost forecast no longer fits the low-budget target
+
+Priority order:
+
+1. optimize obvious regressions
+2. tighten rollout or WAF configuration if the issue is policy-related
+3. scale up instance / cluster profile
+4. if scaling alone is no longer enough, move to the standard path (`staging`, broader observability, fuller operating model)
+
+## 7. Postmortem requirement
+
+Create a postmortem when:
+
+- any `SEV-1` incident occurs
+- a `SEV-2` incident lasts more than 30 minutes
+- rollback or PITR is executed
+- user-visible degradation repeats for the same root cause
+
+Use `docs/runbooks/postmortem-low-budget-template.md`.
+
+## 8. Chaos readiness conditions
+
+Do not start Chaos Engineering just because of a date.
+
+The low-budget path is ready only when all are true:
+
+1. Cloud Monitoring and Cloud Armor baselines are active.
+2. rollback paths for image, Terraform, and DB restore have been tabletop-reviewed.
+3. the incident flow has been exercised at least once as a tabletop.
+4. there is a disposable rehearsal environment or the team has moved to a standard path with safer pre-prod validation.
+5. no unresolved recent `SEV-1` incident is still open.
+
+For the current single-cluster `prod-only` path, prefer tabletop and game-day drills before fault injection.
+
+## 9. Tabletop checklist
+
+1. simulate a Rust API restart burst
+2. simulate a Cloud SQL CPU alert
+3. simulate a Cloud Armor false positive
+4. verify that Discord mention, owner assignment, mitigation choice, and postmortem follow-up can all be recorded without ambiguity

--- a/docs/runbooks/postmortem-low-budget-template.md
+++ b/docs/runbooks/postmortem-low-budget-template.md
@@ -1,0 +1,49 @@
+# Postmortem Low-Budget Template
+
+## 1. Summary
+
+- What happened:
+- Environment:
+- Started at:
+- Resolved at:
+- Severity:
+
+## 2. User impact
+
+- Who was affected:
+- Visible symptoms:
+- Estimated affected requests / sessions / users:
+
+## 3. Root cause
+
+- Immediate cause:
+- Why it was possible:
+- Detection gap:
+
+## 4. Timeline
+
+| Time | Event |
+| --- | --- |
+| `HH:MM` | Detection / user report / alert fired |
+| `HH:MM` | Incident owner assigned |
+| `HH:MM` | Mitigation started |
+| `HH:MM` | Recovery confirmed |
+| `HH:MM` | Postmortem opened |
+
+## 5. What worked / what did not
+
+- Worked:
+- Did not work:
+
+## 6. Follow-up actions
+
+| Action | Owner | Due date |
+| --- | --- | --- |
+| | | |
+
+## 7. Links
+
+- Incident thread:
+- PR / rollback:
+- Related runbook:
+- Related Linear issue:

--- a/infra/README.md
+++ b/infra/README.md
@@ -355,3 +355,29 @@ low-budget path の security は、まず `Cloud Armor + Trivy + Secret Manager 
 
 - DAST / bot management / VPC-SC / IAP
 - 標準 path の full security program
+
+## LIN-1020 prod-only ops baseline
+
+low-budget path の運用は、まず「人が迷わず反応できる」ことを優先する。
+
+### Baseline
+
+- incident routing: Discord thread + `hirwatan` / `sabe` / `miwasa`
+- primary signals:
+  - Cloud Monitoring alert
+  - Cloud Armor false positive / block
+  - DB restore decision
+- postmortem: lightweight template を必須化
+- capacity planning: account count ではなく observed traffic と SLO regression を基準に見直す
+
+### Initial assumptions
+
+- registered users: `10,000 - 100,000`
+- peak concurrent WebSocket connections: `500 - 2,000`
+- sustained message ingress: `50 - 200 msg/s`
+- REST latency target: `P95 <= 300ms`, `P99 <= 800ms`
+
+### Chaos readiness
+
+- 固定日ではなく readiness 条件で開始する
+- single-cluster `prod-only` の間は、fault injection より tabletop を優先する

--- a/infra/environments/prod/README.md
+++ b/infra/environments/prod/README.md
@@ -172,6 +172,21 @@ default では `enable_minimal_security_baseline = false` にしている。
 - secret access の audit 確認は `docs/runbooks/workload-identity-secret-manager-operations-runbook.md` を使う
 - Cloud Armor の verify / rollback は `docs/runbooks/cloud-armor-low-budget-operations-runbook.md` を使う
 
+## LIN-1020 prod-only ops baseline
+
+`LIN-1020` は low-budget path 向けに、初期 incident flow / postmortem / capacity assumption を整理する。
+
+### 追加される docs
+
+- `docs/runbooks/incident-low-budget-operations-runbook.md`
+- `docs/runbooks/postmortem-low-budget-template.md`
+
+### 運用メモ
+
+- 初期 incident のメンション先は `hirwatan` / `sabe` / `miwasa`
+- low-budget path では observed traffic と latency regression を基準に scale trigger を判断する
+- Chaos Engineering は固定日ではなく readiness 条件が揃ってから開始する
+
 ## tfvars で埋める値
 
 - `public_dns_zone_name`


### PR DESCRIPTION
## 概要
- low-budget `prod-only` path 向けに incident flow runbook を追加
- postmortem template を追加し、capacity assumption / scale trigger / chaos readiness を文書化
- infra docs に low-budget path の運用 baseline を反映

## テスト
- `make validate`
- `git diff --check`
- manual self-review
  - docs-only change であることを確認
  - UI change なしのため UI review は不要

## ADR-001 チェック
- Event schema / API contract の変更: なし
- 互換性判断: docs / runbook / template 追加のみで、既存 event contract / runtime contract への破壊的変更はありません

## 補足
- `codex/lin-1019-low-budget-security-baseline` 上に積んだ stacked PR です
- 標準 path の full operating model は `LIN-974` に残しています